### PR TITLE
Improve wasm contract queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Features
-
+* (wasmd)[\#2](https://github.com/cosmwasm/wasmd/pull/22)  Improve wasm contract queries (all, raw, smart)
 * (wasmd) [\#119](https://github.com/cosmwasm/wasmd/pull/119) Add support for the `--inter-block-cache` CLI
 flag and configuration.
 * (wasmcli) [\#132](https://github.com/cosmwasm/wasmd/pull/132) Add `tx decode` command to decode

--- a/docs/deploy-testnet.md
+++ b/docs/deploy-testnet.md
@@ -95,7 +95,7 @@ sleep 3
 wasmcli query wasm list-contracts
 CONTRACT=cosmos18vd8fpwxzck93qlwghaj6arh4p7c5n89uzcee5
 wasmcli query wasm contract $CONTRACT
-wasmcli query wasm contract-state $CONTRACT
+wasmcli query wasm contract-state all $CONTRACT
 wasmcli query account $CONTRACT
 
 # execute fails if wrong person

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/snikch/goodman v0.0.0-20171125024755-10e37e294daa
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/testify v1.4.0
 	github.com/tendermint/go-amino v0.15.1

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/spf13/cobra"
 
@@ -176,7 +180,7 @@ func GetCmdGetContractStateAll(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, keeper.QueryGetContractState, addr.String())
+			route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QueryGetContractState, addr.String(), keeper.QueryMethodContractStateAll)
 			res, _, err := cliCtx.Query(route)
 			if err != nil {
 				return err
@@ -188,24 +192,24 @@ func GetCmdGetContractStateAll(cdc *codec.Codec) *cobra.Command {
 }
 
 func GetCmdGetContractStateRaw(cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
+	decoder := newArgDecoder(hex.DecodeString)
+	cmd := &cobra.Command{
 		Use:   "raw [bech32_address] [key]",
 		Short: "Prints out internal state for key of a contract given its address",
 		Long:  "Prints out internal state for of a contract given its address",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			addr, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {
 				return err
 			}
-			key := args[1]
-			if key == "" {
-				return errors.New("key must not be empty")
+			queryData, err := decoder.DecodeString(args[1])
+			if err != nil {
+				return err
 			}
 			route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QueryGetContractState, addr.String(), keeper.QueryMethodContractStateRaw)
-			queryData := []byte(key) // todo: open question: encode into json???
 			res, _, err := cliCtx.QueryWithData(route, queryData)
 			if err != nil {
 				return err
@@ -214,15 +218,19 @@ func GetCmdGetContractStateRaw(cdc *codec.Codec) *cobra.Command {
 			return nil
 		},
 	}
+	decoder.RegisterFlags(cmd.PersistentFlags(), "key argument")
+	return cmd
 }
 
 func GetCmdGetContractStateSmart(cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
+	decoder := newArgDecoder(asciiDecodeString)
+
+	cmd := &cobra.Command{
 		Use:   "smart [bech32_address] [query]",
 		Short: "Calls contract with given address  with query data and prints the returned result",
 		Long:  "Calls contract with given address  with query data and prints the returned result",
 		Args:  cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			addr, err := sdk.AccAddressFromBech32(args[0])
@@ -234,14 +242,62 @@ func GetCmdGetContractStateSmart(cdc *codec.Codec) *cobra.Command {
 				return errors.New("key must not be empty")
 			}
 			route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QueryGetContractState, addr.String(), keeper.QueryMethodContractStateSmart)
-			var queryData []byte
+
+			queryData, err := decoder.DecodeString(args[1])
+			if err != nil {
+				return fmt.Errorf("decode query: %s", err)
+			}
 			res, _, err := cliCtx.QueryWithData(route, queryData)
 			if err != nil {
 				return err
 			}
-			// todo: decode response
 			fmt.Println(string(res))
 			return nil
 		},
 	}
+	decoder.RegisterFlags(cmd.PersistentFlags(), "query argument")
+	return cmd
+}
+
+type argumentDecoder struct {
+	// dec is the default decoder
+	dec                func(string) ([]byte, error)
+	asciiF, hexF, b64F bool
+}
+
+func newArgDecoder(def func(string) ([]byte, error)) *argumentDecoder {
+	return &argumentDecoder{dec: def}
+}
+
+func (a *argumentDecoder) RegisterFlags(f *flag.FlagSet, argName string) {
+	f.BoolVar(&a.asciiF, "ascii", false, "ascii encoded "+argName)
+	f.BoolVar(&a.hexF, "hex", false, "hex encoded  "+argName)
+	f.BoolVar(&a.b64F, "b64", false, "base64 encoded "+argName)
+}
+
+func (a *argumentDecoder) DecodeString(s string) ([]byte, error) {
+	found := -1
+	for i, v := range []*bool{&a.asciiF, &a.hexF, &a.b64F} {
+		if !*v {
+			continue
+		}
+		if found != -1 {
+			return nil, errors.New("multiple decoding flags used")
+		}
+		found = i
+	}
+	switch found {
+	case 0:
+		return asciiDecodeString(s)
+	case 1:
+		return hex.DecodeString(s)
+	case 2:
+		return base64.StdEncoding.DecodeString(s)
+	default:
+		return a.dec(s)
+	}
+}
+
+func asciiDecodeString(s string) ([]byte, error) {
+	return []byte(s), nil
 }

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -190,10 +190,13 @@ func (k Keeper) QueryRaw(ctx sdk.Context, contractAddress sdk.AccAddress, key []
 	}
 	prefixStoreKey := types.GetContractStorePrefixKey(contractAddress)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
-	return []types.Model{{
-		Key:   string(key),
-		Value: string(prefixStore.Get(key)),
-	}}
+	if val := prefixStore.Get(key); val != nil {
+		return []types.Model{{
+			Key:   string(key),
+			Value: string(val),
+		}}
+	}
+	return []types.Model{}
 }
 
 func (k Keeper) contractInstance(ctx sdk.Context, contractAddress sdk.AccAddress) (types.CodeInfo, prefix.Store, sdk.Error) {

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -183,20 +183,22 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 	return models, nil
 }
 
-// QueryRaw returns the contract's state for give key. For a `nil` key a `nil` result is returned.
+// QueryRaw returns the contract's state for give key. For a `nil` key a empty slice` result is returned.
 func (k Keeper) QueryRaw(ctx sdk.Context, contractAddress sdk.AccAddress, key []byte) []types.Model {
+	result := make([]types.Model, 0)
 	if key == nil {
-		return nil
+		return result
 	}
 	prefixStoreKey := types.GetContractStorePrefixKey(contractAddress)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
+
 	if val := prefixStore.Get(key); val != nil {
-		return []types.Model{{
+		return append(result, types.Model{
 			Key:   string(key),
 			Value: string(val),
-		}}
+		})
 	}
-	return []types.Model{}
+	return result
 }
 
 func (k Keeper) contractInstance(ctx sdk.Context, contractAddress sdk.AccAddress) (types.CodeInfo, prefix.Store, sdk.Error) {

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -91,6 +91,9 @@ func queryContractState(ctx sdk.Context, bech, queryMethod string, req abci.Requ
 				Value: string(iter.Value()),
 			})
 		}
+		if resultData == nil {
+			resultData = make([]types.Model, 0)
+		}
 	case QueryMethodContractStateRaw:
 		resultData = keeper.QueryRaw(ctx, contractAddr, req.Data)
 	case QueryMethodContractStateSmart:

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -88,10 +88,9 @@ func TestQueryContractState(t *testing.T) {
 			//expModelContains: []model{}, // stopping here as contract internals are not stable
 		},
 		"query unknown raw key": {
-			srcPath:          []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
-			srcReq:           abci.RequestQuery{Data: []byte("unknown")},
-			expModelLen:      1,
-			expModelContains: []model{{Key: "unknown", Value: ""}},
+			srcPath:     []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
+			srcReq:      abci.RequestQuery{Data: []byte("unknown")},
+			expModelLen: 0,
 		},
 		"query empty raw key": {
 			srcPath:     []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -1,0 +1,131 @@
+package keeper
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmwasm/wasmd/x/wasm/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestQueryContractState(t *testing.T) {
+	type model struct {
+		Key   string `json:"key"`
+		Value string `json:"val"`
+	}
+
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	ctx, accKeeper, keeper := CreateTestInput(t, false, tempDir)
+
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	topUp := sdk.NewCoins(sdk.NewInt64Coin("denom", 5000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit.Add(deposit))
+	anyAddr := createFakeFundedAccount(ctx, accKeeper, topUp)
+
+	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
+	require.NoError(t, err)
+
+	contractID, err := keeper.Create(ctx, creator, wasmCode)
+	require.NoError(t, err)
+
+	_, _, bob := keyPubAddr()
+	initMsg := InitMsg{
+		Verifier:    anyAddr.String(),
+		Beneficiary: bob.String(),
+	}
+	initMsgBz, err := json.Marshal(initMsg)
+	require.NoError(t, err)
+
+	addr, err := keeper.Instantiate(ctx, creator, contractID, initMsgBz, deposit)
+	require.NoError(t, err)
+	require.Equal(t, "cosmos18vd8fpwxzck93qlwghaj6arh4p7c5n89uzcee5", addr.String())
+
+	contractModel := []types.Model{
+		{Key: "foo", Value: "bar"},
+		{Key: string([]byte{0x0, 0x1}), Value: string([]byte{0x2, 0x3})},
+	}
+	keeper.setContractState(ctx, addr, contractModel)
+
+	q := NewQuerier(keeper)
+	specs := map[string]struct {
+		srcPath          []string
+		srcReq           abci.RequestQuery
+		expModelLen      int
+		expModelContains []model
+		expErr           sdk.Error
+	}{
+		"query all": {
+			srcPath:     []string{QueryGetContractState, addr.String(), QueryMethodContractStateAll},
+			expModelLen: 3,
+			expModelContains: []model{
+				{Key: "foo", Value: "bar"},
+				{Key: string([]byte{0x0, 0x1}), Value: string([]byte{0x2, 0x3})},
+			},
+		},
+		"query raw key": {
+			srcPath:          []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
+			srcReq:           abci.RequestQuery{Data: []byte("foo")},
+			expModelLen:      1,
+			expModelContains: []model{{Key: "foo", Value: "bar"}},
+		},
+		"query raw binary key": {
+			srcPath:          []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
+			srcReq:           abci.RequestQuery{Data: []byte{0x0, 0x1}},
+			expModelLen:      1,
+			expModelContains: []model{{Key: string([]byte{0x0, 0x1}), Value: string([]byte{0x2, 0x3})}},
+		},
+		"query smart": {
+			srcPath:     []string{QueryGetContractState, addr.String(), QueryMethodContractStateSmart},
+			srcReq:      abci.RequestQuery{Data: []byte(`{"raw":{"key":"config"}}`)},
+			expModelLen: 1,
+			//expModelContains: []model{}, // stopping here as contract internals are not stable
+		},
+		"query unknown raw key": {
+			srcPath:          []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
+			srcReq:           abci.RequestQuery{Data: []byte("unknown")},
+			expModelLen:      1,
+			expModelContains: []model{{Key: "unknown", Value: ""}},
+		},
+		"query empty raw key": {
+			srcPath:     []string{QueryGetContractState, addr.String(), QueryMethodContractStateRaw},
+			expModelLen: 0,
+		},
+		"query raw with unknown address": {
+			srcPath:     []string{QueryGetContractState, anyAddr.String(), QueryMethodContractStateRaw},
+			expModelLen: 0,
+		},
+		"query all with unknown address": {
+			srcPath:     []string{QueryGetContractState, anyAddr.String(), QueryMethodContractStateAll},
+			expModelLen: 0,
+		},
+		"query smart with unknown address": {
+			srcPath:     []string{QueryGetContractState, anyAddr.String(), QueryMethodContractStateSmart},
+			expModelLen: 0,
+			expErr:      types.ErrNotFound("contract"),
+		},
+	}
+
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			binResult, err := q(ctx, spec.srcPath, spec.srcReq)
+			require.Equal(t, spec.expErr, err)
+			// then
+			var r []model
+			if spec.expErr == nil {
+				require.NoError(t, json.Unmarshal(binResult, &r))
+			}
+			require.Len(t, r, spec.expModelLen)
+			// and in result set
+			for _, v := range spec.expModelContains {
+				assert.Contains(t, r, v)
+			}
+		})
+	}
+}

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -119,6 +119,7 @@ func TestQueryContractState(t *testing.T) {
 			var r []model
 			if spec.expErr == nil {
 				require.NoError(t, json.Unmarshal(binResult, &r))
+				require.NotNil(t, r)
 			}
 			require.Len(t, r, spec.expModelLen)
 			// and in result set

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -9,7 +9,7 @@ import (
 // Model is a struct that holds a KV pair
 type Model struct {
 	Key   string `json:"key"`
-	Value string `json:"value"`
+	Value string `json:"val"`
 }
 
 // CodeInfo is data for the uploaded contract WASM code

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -394,7 +394,7 @@ func assertContractList(t *testing.T, q sdk.Querier, ctx sdk.Context, addrs []st
 
 type model struct {
 	Key   string `json:"key"`
-	Value string `json:"value"`
+	Value string `json:"val"`
 }
 
 func assertContractState(t *testing.T, q sdk.Querier, ctx sdk.Context, addr sdk.AccAddress, expected state) {

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cosmwasm/wasmd/x/wasm/internal/keeper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -397,7 +398,7 @@ type model struct {
 }
 
 func assertContractState(t *testing.T, q sdk.Querier, ctx sdk.Context, addr sdk.AccAddress, expected state) {
-	path := []string{QueryGetContractState, addr.String()}
+	path := []string{QueryGetContractState, addr.String(), keeper.QueryMethodContractStateAll}
 	bz, sdkerr := q(ctx, path, abci.RequestQuery{})
 	require.NoError(t, sdkerr)
 


### PR DESCRIPTION
Resolves #12

In this PR are the 3 different query types implemented as defined in #12. This includes server side and cli code.

Example:
```sh
wasmcli query wasm contract-state all "${CONTRACT}"
wasmcli query wasm contract-state raw  "${CONTRACT}" config --ascii
wasmcli query wasm contract-state smart "${CONTRACT}" '{"raw":{"key":"config"}}' --ascii
```
They all return:
```json
[
  {
    "key": "config",
    "val": "{\"arbiter\":\"cosmos1s5k2p7nct27jzjrzvqgwy785wug0js9vdmdr5s\",\"recipient\":\"cosmos1p35xmxjl8ysxdp699ff4kmca8duwcve2jupxe3\",\"source\":\"cosmos1laapuw0u4vx3jjyq8vtf3pmzj24h3eqdfunyuk\",\"end_height\":0,\"end_time\":0}"
  }
]
```
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
