### PR TITLE
Fix CI release build command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build Docker artifact - demo
-          command: docker build --pull -t "cosmwasm/wasmd-demo:${CIRCLE_TAG}" . .
+          command: docker build --pull -t "cosmwasm/wasmd-demo:${CIRCLE_TAG}" .
       - run:
           name: Push application Docker image to docker hub
           command: |


### PR DESCRIPTION
The release artifact build step contains a typo. This patch removed a trailing `.` that broke the v0.0.1 build.

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))