### PR TITLE
Properly encode contract query results

### DIFF
--- a/x/wasm/client/rest/query.go
+++ b/x/wasm/client/rest/query.go
@@ -138,6 +138,15 @@ func queryContractStateAllHandlerFn(cliCtx context.CLIContext) http.HandlerFunc 
 			return
 		}
 		rest.PostProcessResponse(w, cliCtx, string(res))
+
+		// parse res
+		var resultData []types.Model
+		err = json.Unmarshal(res, &resultData)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		rest.PostProcessResponse(w, cliCtx, resultData)
 	}
 }
 
@@ -156,12 +165,20 @@ func queryContractStateRawHandlerFn(cliCtx context.CLIContext) http.HandlerFunc 
 			return
 		}
 		route := fmt.Sprintf("custom/%s/%s/%s/%s", types.QuerierRoute, keeper.QueryGetContractState, addr.String(), keeper.QueryMethodContractStateRaw)
+
 		res, _, err := cliCtx.QueryWithData(route, queryData)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		rest.PostProcessResponse(w, cliCtx, string(res))
+		// parse res
+		var resultData []types.Model
+		err = json.Unmarshal(res, &resultData)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		rest.PostProcessResponse(w, cliCtx, resultData)
 	}
 }
 
@@ -188,7 +205,8 @@ func queryContractStateSmartHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		rest.PostProcessResponse(w, cliCtx, string(res))
+		// return as raw bytes (to be base64-encoded)
+		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
 

--- a/x/wasm/client/rest/query.go
+++ b/x/wasm/client/rest/query.go
@@ -137,7 +137,6 @@ func queryContractStateAllHandlerFn(cliCtx context.CLIContext) http.HandlerFunc 
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-		rest.PostProcessResponse(w, cliCtx, string(res))
 
 		// parse res
 		var resultData []types.Model
@@ -182,6 +181,10 @@ func queryContractStateRawHandlerFn(cliCtx context.CLIContext) http.HandlerFunc 
 	}
 }
 
+type smartResponse struct {
+	Smart []byte `json:"smart"`
+}
+
 func queryContractStateSmartHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := newArgDecoder(hex.DecodeString)
@@ -206,7 +209,8 @@ func queryContractStateSmartHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 			return
 		}
 		// return as raw bytes (to be base64-encoded)
-		rest.PostProcessResponse(w, cliCtx, res)
+		responseData := smartResponse{Smart: res}
+		rest.PostProcessResponse(w, cliCtx, responseData)
 	}
 }
 

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -113,6 +113,7 @@ func queryContractState(ctx sdk.Context, bech, queryMethod string, req abci.Requ
 	var resultData []types.Model
 	switch queryMethod {
 	case QueryMethodContractStateAll:
+		// this returns a serialized json object (which internally encoded binary fields properly)
 		for iter := keeper.GetContractState(ctx, contractAddr); iter.Valid(); iter.Next() {
 			resultData = append(resultData, types.Model{
 				Key:   iter.Key(),
@@ -123,8 +124,10 @@ func queryContractState(ctx sdk.Context, bech, queryMethod string, req abci.Requ
 			resultData = make([]types.Model, 0)
 		}
 	case QueryMethodContractStateRaw:
+		// this returns a serialized json object
 		resultData = keeper.QueryRaw(ctx, contractAddr, req.Data)
 	case QueryMethodContractStateSmart:
+		// this returns raw bytes (must be base64-encoded)
 		return keeper.QuerySmart(ctx, contractAddr, req.Data)
 	default:
 		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, queryMethod)

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+
 	tmBytes "github.com/tendermint/tendermint/libs/bytes"
 
 	wasmTypes "github.com/confio/go-cosmwasm/types"
@@ -14,8 +15,10 @@ const defaultQueryGasLimit = uint64(3000000)
 
 // Model is a struct that holds a KV pair
 type Model struct {
-	Key   tmBytes.HexBytes `json:"key"`
-	Value json.RawMessage  `json:"val"`
+	// hex-encode key to read it better (this is often ascii)
+	Key tmBytes.HexBytes `json:"key"`
+	// base64-encode raw value
+	Value []byte `json:"val"`
 }
 
 // CodeInfo is data for the uploaded contract WASM code

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -411,7 +411,7 @@ func assertContractState(t *testing.T, q sdk.Querier, ctx sdk.Context, addr sdk.
 
 	expectedBz, err := json.Marshal(expected)
 	require.NoError(t, err)
-	assert.Equal(t, json.RawMessage(expectedBz), res[0].Value)
+	assert.Equal(t, expectedBz, res[0].Value)
 }
 
 func assertContractInfo(t *testing.T, q sdk.Querier, ctx sdk.Context, addr sdk.AccAddress, codeID uint64, creator sdk.AccAddress) {


### PR DESCRIPTION
Closes #69 

`querySmart` base64-encodes the result from the contract, making no assumptions on the content
    
`queryRaw` and `queryAllState` return json arrays. Each element looks like:

```go
type Model struct {
	// hex-encode key to read it better (this is often ascii)
	Key tmBytes.HexBytes `json:"key"`
	// base64-encode raw value
	Value []byte `json:"val"`
}
```

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))