### PR TITLE
Non zero query height

### DIFF
--- a/x/wasm/client/rest/query.go
+++ b/x/wasm/client/rest/query.go
@@ -41,7 +41,7 @@ func listCodesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 		cliCtx = cliCtx.WithHeight(height)
-		rest.PostProcessResponse(w, cliCtx, string(res))
+		rest.PostProcessResponse(w, cliCtx, json.RawMessage(res))
 	}
 }
 
@@ -106,7 +106,7 @@ func listContractsByCodeHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		cliCtx = cliCtx.WithHeight(height)
-		rest.PostProcessResponse(w, cliCtx, string(res))
+		rest.PostProcessResponse(w, cliCtx, json.RawMessage(res))
 	}
 }
 
@@ -130,7 +130,7 @@ func queryContractHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		cliCtx = cliCtx.WithHeight(height)
-		rest.PostProcessResponse(w, cliCtx, string(res))
+		rest.PostProcessResponse(w, cliCtx, json.RawMessage(res))
 	}
 }
 

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -65,11 +65,14 @@ func queryContractInfo(ctx sdk.Context, bech string, req abci.RequestQuery, keep
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())
 	}
 	info := keeper.GetContractInfo(ctx, addr)
+	if info == nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownAddress, bech)
+	}
+
 	infoWithAddress := ContractInfoWithAddress{
 		Address:      addr,
 		ContractInfo: info,
 	}
-
 	bz, err := json.MarshalIndent(infoWithAddress, "", "  ")
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())

--- a/x/wasm/internal/types/msg.go
+++ b/x/wasm/internal/types/msg.go
@@ -93,7 +93,7 @@ type MsgInstantiateContract struct {
 	Sender    sdk.AccAddress  `json:"sender" yaml:"sender"`
 	Code      uint64          `json:"code_id" yaml:"code_id"`
 	Label     string          `json:"label" yaml:"label"`
-	InitMsg   json.RawMessage `json:"init_msg" yaml:"init_msg"`
+	InitMsg   json.RawMessage `json:"init_msg,omitempty" yaml:"init_msg"`
 	InitFunds sdk.Coins       `json:"init_funds" yaml:"init_funds"`
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes #76 

Properly handles height in queries (both accepting user input as well as returning value in output)

This also modfies all `x/wasm` queries to return proper json, not strings (breaking, but nice). The only string response is the SmartQuery, which returns a string as Base64 endoded result (as we want to support `[]byte`)

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))