### PR TITLE
Return null not error when query missing contract

### DIFF
--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -67,7 +67,7 @@ func queryContractInfo(ctx sdk.Context, bech string, req abci.RequestQuery, keep
 	}
 	info := keeper.GetContractInfo(ctx, addr)
 	if info == nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownAddress, bech)
+		return []byte("null"), nil
 	}
 	// redact the Created field (just used for sorting, not part of public API)
 	info.Created = nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

We return an error on `wasmd` and later parse the error to return null in `cosmwasm-js`.

Let's just properly return null

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))