### PR TITLE
Allow duplicate wasm hash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/btcsuite/btcd v0.0.0-20190807005414-4063feeff79a // indirect
-	github.com/confio/go-cosmwasm v0.7.0
+	github.com/confio/go-cosmwasm v0.7.1
 	github.com/cosmos/cosmos-sdk v0.38.1
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/confio/go-cosmwasm v0.6.3 h1:TcZ8k0RsGissZ83JcRMvOu93FpDu2S9XGzCd79xw
 github.com/confio/go-cosmwasm v0.6.3/go.mod h1:pHipRby+f3cv97QPLELkzOAlNs/s87uDyhc+SnMn7L4=
 github.com/confio/go-cosmwasm v0.7.0 h1:15IkIEmAPU22bLYStig/kHw6FoGOxmaaF/kh0hFMGfE=
 github.com/confio/go-cosmwasm v0.7.0/go.mod h1:pHipRby+f3cv97QPLELkzOAlNs/s87uDyhc+SnMn7L4=
+github.com/confio/go-cosmwasm v0.7.1 h1:lTAruzPuBv7Txjd0sEM40Wx2tC0jg58Ot7/KWtdNGiU=
+github.com/confio/go-cosmwasm v0.7.1/go.mod h1:pHipRby+f3cv97QPLELkzOAlNs/s87uDyhc+SnMn7L4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -67,17 +67,10 @@ func (k Keeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte,
 	if err != nil {
 		return 0, sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
 	}
-	var codeHash []byte
-	if isSimulationMode(ctx) {
-		// https://github.com/cosmwasm/wasmd/issues/42
-		// any sha256 hash is good enough
-		codeHash = make([]byte, 32)
-	} else {
-		codeHash, err = k.wasmer.Create(wasmCode)
-		if err != nil {
-			// return 0, sdkerrors.Wrap(err, "cosmwasm create")
-			return 0, sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
-		}
+	codeHash, err := k.wasmer.Create(wasmCode)
+	if err != nil {
+		// return 0, sdkerrors.Wrap(err, "cosmwasm create")
+		return 0, sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
 	}
 	store := ctx.KVStore(k.storeKey)
 	codeID = k.autoIncrementID(ctx, types.KeyLastCodeID)

--- a/x/wasm/internal/keeper/keeper_test.go
+++ b/x/wasm/internal/keeper/keeper_test.go
@@ -93,12 +93,21 @@ func TestCreateWithSimulation(t *testing.T) {
 	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
 	require.NoError(t, err)
 
-	contractID, err := keeper.Create(ctx, creator, wasmCode, "https://github.com/cosmwasm/wasmd/blob/master/x/wasm/testdata/escrow.wasm", "cosmwasm-opt:0.5.2")
+	// create this once in simulation mode
+	contractID, err := keeper.Create(ctx, creator, wasmCode, "https://github.com/cosmwasm/wasmd/blob/master/x/wasm/testdata/escrow.wasm", "confio/cosmwasm-opt:0.57.2")
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), contractID)
+
+	// then try to create it in non-simulation mode (should not fail)
+	ctx, accKeeper, keeper = CreateTestInput(t, false, tempDir)
+	contractID, err = keeper.Create(ctx, creator, wasmCode, "https://github.com/cosmwasm/wasmd/blob/master/x/wasm/testdata/escrow.wasm", "confio/cosmwasm-opt:0.7.2")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), contractID)
+
 	// and verify content
-	_, err = keeper.GetByteCode(ctx, contractID)
-	require.Error(t, err, os.ErrNotExist)
+	code, err := keeper.GetByteCode(ctx, contractID)
+	require.NoError(t, err)
+	require.Equal(t, code, wasmCode)
 }
 
 func TestIsSimulationMode(t *testing.T) {

--- a/x/wasm/internal/keeper/keeper_test.go
+++ b/x/wasm/internal/keeper/keeper_test.go
@@ -48,6 +48,37 @@ func TestCreate(t *testing.T) {
 	require.Equal(t, wasmCode, storedCode)
 }
 
+func TestCreateDuplicate(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	ctx, accKeeper, keeper := CreateTestInput(t, false, tempDir)
+
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit)
+
+	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
+	require.NoError(t, err)
+
+	// create one copy
+	contractID, err := keeper.Create(ctx, creator, wasmCode, "https://github.com/cosmwasm/wasmd/blob/master/x/wasm/testdata/escrow.wasm", "cosmwasm-opt:0.5.2")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), contractID)
+
+	// create second copy
+	duplicateID, err := keeper.Create(ctx, creator, wasmCode, "https://github.com/cosmwasm/wasmd/blob/master/x/wasm/testdata/escrow.wasm", "cosmwasm-opt:0.5.2")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), duplicateID)
+
+	// and verify both content is proper
+	storedCode, err := keeper.GetByteCode(ctx, contractID)
+	require.NoError(t, err)
+	require.Equal(t, wasmCode, storedCode)
+	storedCode, err = keeper.GetByteCode(ctx, duplicateID)
+	require.NoError(t, err)
+	require.Equal(t, wasmCode, storedCode)
+}
+
 func TestCreateWithSimulation(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "wasm")
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes #99 

Uses (go-)cosmwasm `v0.7.1` to allow multiple codeIDs with the same wasm hash. Simplify some handling of simulation logic with the update.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))