### PR TITLE
Install libgo_cosmwasm.so to shared location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ COPY . .
 RUN make tools
 RUN make install
 
+# Install libgo_cosmwasm.so to a shared directory where it is readable by all users
+# See https://github.com/CosmWasm/wasmd/issues/43#issuecomment-608366314
+RUN cp /go/pkg/mod/github.com/confio/go-cosmwasm@v*/api/libgo_cosmwasm.so /lib/x86_64-linux-gnu
+
 COPY docker/* /opt/
 RUN chmod +x /opt/*.sh
 


### PR DESCRIPTION
Closes #43

Turns out libgo_cosmwasm.so can be available in any of the configured lib locations. So there is no need to manipulate Go's preferred file structure and permissions.

With this diff, I get

```
$ docker exec --user="0" wasmd ldd /go/bin/wasmcli
        linux-vdso.so.1 (0x00007fff14dbb000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007ffb48478000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ffb48457000)
        libgo_cosmwasm.so => /go/pkg/mod/github.com/confio/go-cosmwasm@v0.7.1/api/libgo_cosmwasm.so (0x00007ffb481c3000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ffb48002000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ffb48488000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ffb47ffd000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ffb47fe1000)
```

and

```
$ docker exec --user="$UID" wasmd ldd /go/bin/wasmcli
        linux-vdso.so.1 (0x00007fff70c64000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f783948c000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f783946b000)
        libgo_cosmwasm.so => /lib/x86_64-linux-gnu/libgo_cosmwasm.so (0x00007f78391d7000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7839016000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f783949c000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f7839011000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f7838ff5000)
```

, i.e. `/go/pkg/mod/...` is prioritized over `/lib/x86_64-linux-gnu` but both locations work fine.