### PR TITLE
Convert -tags argument to comma separated list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,6 @@ RUN apk add libusb-dev linux-headers
 WORKDIR /code
 COPY . /code
 
-# try this one out
-RUN BUILD_TAGS=muslc make view
-
-RUN false
-
 # download all deps
 RUN go mod download
 # TODO: how to use this instead of hardcoding GO_COSMWASM

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# docker build . -t cosmwasm/wasm:latest
-# docker run --rm -it cosmwasm/wasm:latest /bin/sh
+# docker build . -t cosmwasm/wasmd:latest
+# docker run --rm -it cosmwasm/wasmd:latest /bin/sh
 FROM cosmwasm/go-ext-builder:0.8.2-alpine AS builder
 
 RUN apk add git
@@ -9,6 +9,11 @@ RUN apk add libusb-dev linux-headers
 # copy all code into /code
 WORKDIR /code
 COPY . /code
+
+# try this one out
+RUN BUILD_TAGS=muslc make view
+
+RUN false
 
 # download all deps
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ endif
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
-empty:=
-space:= $(empty) $(empty)
+empty :=
+space := $(empty) $(empty)
 comma := ,
 build_tags_comma_sep := $(subst $(space),$(comma),$(build_tags))
 
@@ -60,7 +60,7 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
-BUILD_FLAGS := -tags "$(build_tags_comma_sep)" -ldflags '$(ldflags)' -trimpath
+BUILD_FLAGS := -tags $(build_tags_comma_sep) -ldflags '$(ldflags)' -trimpath
 
 # The below include contains the tools target.
 include contrib/devtools/Makefile

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
-BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)' -trimpath
+BUILD_FLAGS := -tags $(build_tags_comma_sep) -ldflags '$(ldflags)' -trimpath
 
 # The below include contains the tools target.
 include contrib/devtools/Makefile

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ endif
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
-whitespace :=
-whitespace += $(whitespace)
+empty:=
+space:= $(empty) $(empty)
 comma := ,
-build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
+build_tags_comma_sep := $(subst $(space),$(comma),$(build_tags))
 
 # process linker flags
 
@@ -60,7 +60,7 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
-BUILD_FLAGS := -tags $(build_tags_comma_sep) -ldflags '$(ldflags)' -trimpath
+BUILD_FLAGS := -tags "$(build_tags_comma_sep)" -ldflags '$(ldflags)' -trimpath
 
 # The below include contains the tools target.
 include contrib/devtools/Makefile


### PR DESCRIPTION
See `go help build`:

```
-tags tag,list
  a comma-separated list of build tags to consider satisfied during the
  build. For more information about build tags, see the description of
  build constraints in the documentation for the go/build package.
  (Earlier versions of Go used a space-separated list, and that form
  is deprecated but still recognized.)
```



Maybe that helps fixing the broken `application_version.build_tags`: "netgo ledger muslc,". I don't know.