### PR TITLE
Validate genesis model

### DIFF
--- a/x/wasm/internal/keeper/genesis.go
+++ b/x/wasm/internal/keeper/genesis.go
@@ -25,12 +25,11 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 	}
 
 	for _, contract := range data.Contracts {
-		keeper.setContractInfo(ctx, contract.ContractAddress, &contract.ContractInfo)
-		keeper.setContractState(ctx, contract.ContractAddress, contract.ContractState)
+		keeper.importContract(ctx, contract.ContractAddress, &contract.ContractInfo, contract.ContractState)
 	}
 
 	for _, seq := range data.Sequences {
-		keeper.setAutoIncrementID(ctx, seq.IDKey, seq.Value)
+		keeper.importAutoIncrementID(ctx, seq.IDKey, seq.Value)
 	}
 }
 

--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -101,7 +101,7 @@ func TestFailFastImport(t *testing.T) {
 			}},
 			Contracts: nil,
 		}},
-		"happy path: code info and contract do match": {
+		"happy path: code id in info and contract do match": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
 					CodeInfo: wasmTypes.CodeInfo{
@@ -112,13 +112,8 @@ func TestFailFastImport(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: addrFromUint64(1<<32 + 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractAddress: contractAddress(1, 1),
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					},
 				},
 			},
@@ -135,21 +130,11 @@ func TestFailFastImport(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: addrFromUint64(1<<32 + 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractAddress: contractAddress(1, 1),
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					}, {
-						ContractAddress: addrFromUint64(2<<32 + 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractAddress: contractAddress(2, 1),
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					},
 				},
 			},
@@ -160,17 +145,12 @@ func TestFailFastImport(t *testing.T) {
 				Contracts: []types.Contract{
 					{
 						ContractAddress: contractAddress(1, 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					},
 				},
 			},
 		},
-		"prevent duplicate contracts": {
+		"prevent duplicate contract address": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
 					CodeInfo: wasmTypes.CodeInfo{
@@ -182,25 +162,15 @@ func TestFailFastImport(t *testing.T) {
 				Contracts: []types.Contract{
 					{
 						ContractAddress: contractAddress(1, 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					}, {
 						ContractAddress: contractAddress(1, 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 					},
 				},
 			},
 		},
-		"prevent duplicate contract model": {
+		"prevent duplicate contract model keys": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
 					CodeInfo: wasmTypes.CodeInfo{
@@ -211,13 +181,8 @@ func TestFailFastImport(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: addrFromUint64(1<<32 + 1),
-						ContractInfo: wasmTypes.ContractInfo{
-							CodeID:  1,
-							Creator: anyAddress,
-							Label:   "any",
-							Created: &types.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
-						},
+						ContractAddress: contractAddress(1, 1),
+						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }),
 						ContractState: []types.Model{
 							{
 								Key:   []byte{0x1},

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -48,7 +48,7 @@ func TestQueryContractState(t *testing.T) {
 		{Key: []byte("foo"), Value: []byte(`"bar"`)},
 		{Key: []byte{0x0, 0x1}, Value: []byte(`{"count":8}`)},
 	}
-	keeper.setContractState(ctx, addr, contractModel)
+	keeper.importContractState(ctx, addr, contractModel)
 
 	// this gets us full error, not redacted sdk.Error
 	q := NewQuerier(keeper)

--- a/x/wasm/internal/types/errors.go
+++ b/x/wasm/internal/types/errors.go
@@ -46,4 +46,7 @@ var (
 
 	// ErrInvalid error for content that is invalid in this context
 	ErrInvalid = sdkErrors.Register(DefaultCodespace, 13, "invalid")
+
+	// ErrDuplicate error for content that exsists
+	ErrDuplicate = sdkErrors.Register(DefaultCodespace, 14, "duplicate")
 )

--- a/x/wasm/internal/types/errors.go
+++ b/x/wasm/internal/types/errors.go
@@ -37,4 +37,13 @@ var (
 
 	// ErrMigrationFailed error for rust execution contract failure
 	ErrMigrationFailed = sdkErrors.Register(DefaultCodespace, 10, "migrate wasm contract failed")
+
+	// ErrEmpty error for empty content
+	ErrEmpty = sdkErrors.Register(DefaultCodespace, 11, "empty")
+
+	// ErrLimit error for content that exceeds a limit
+	ErrLimit = sdkErrors.Register(DefaultCodespace, 12, "exceeds limit")
+
+	// ErrInvalid error for content that is invalid in this context
+	ErrInvalid = sdkErrors.Register(DefaultCodespace, 13, "invalid")
 )

--- a/x/wasm/internal/types/genesis.go
+++ b/x/wasm/internal/types/genesis.go
@@ -1,10 +1,20 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
 
 type Sequence struct {
 	IDKey []byte `json:"id_key"`
 	Value uint64 `json:"value"`
+}
+
+func (s Sequence) ValidateBasic() error {
+	if len(s.IDKey) == 0 {
+		return sdkerrors.Wrap(ErrEmpty, "id key")
+	}
+	return nil
 }
 
 // GenesisState is the struct representation of the export genesis
@@ -14,10 +24,39 @@ type GenesisState struct {
 	Sequences []Sequence `json:"sequences"`
 }
 
+func (s GenesisState) ValidateBasic() error {
+	for i := range s.Codes {
+		if err := s.Codes[i].ValidateBasic(); err != nil {
+			return sdkerrors.Wrapf(err, "code: %d", i)
+		}
+	}
+	for i := range s.Contracts {
+		if err := s.Contracts[i].ValidateBasic(); err != nil {
+			return sdkerrors.Wrapf(err, "contract: %d", i)
+		}
+	}
+	for i := range s.Sequences {
+		if err := s.Sequences[i].ValidateBasic(); err != nil {
+			return sdkerrors.Wrapf(err, "sequence: %d", i)
+		}
+	}
+	return nil
+}
+
 // Code struct encompasses CodeInfo and CodeBytes
 type Code struct {
 	CodeInfo   CodeInfo `json:"code_info"`
 	CodesBytes []byte   `json:"code_bytes"`
+}
+
+func (c Code) ValidateBasic() error {
+	if err := c.CodeInfo.ValidateBasic(); err != nil {
+		return sdkerrors.Wrap(err, "code info")
+	}
+	if err := validateWasmCode(c.CodesBytes); err != nil {
+		return sdkerrors.Wrap(err, "code bytes")
+	}
+	return nil
 }
 
 // Contract struct encompasses ContractAddress, ContractInfo, and ContractState
@@ -27,8 +66,23 @@ type Contract struct {
 	ContractState   []Model        `json:"contract_state"`
 }
 
+func (c Contract) ValidateBasic() error {
+	if err := sdk.VerifyAddressFormat(c.ContractAddress); err != nil {
+		return sdkerrors.Wrap(err, "contract address")
+	}
+	if err := c.ContractInfo.ValidateBasic(); err != nil {
+		return sdkerrors.Wrap(err, "contract info")
+	}
+	for i := range c.ContractState {
+		if err := c.ContractState[i].ValidateBasic(); err != nil {
+			return sdkerrors.Wrapf(err, "contract state %d", i)
+		}
+	}
+	return nil
+}
+
 // ValidateGenesis performs basic validation of supply genesis data returning an
 // error for any failed validation criteria.
 func ValidateGenesis(data GenesisState) error {
-	return nil
+	return data.ValidateBasic()
 }

--- a/x/wasm/internal/types/genesis_test.go
+++ b/x/wasm/internal/types/genesis_test.go
@@ -1,0 +1,107 @@
+package types
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/rand"
+)
+
+func TestValidateGenesisState(t *testing.T) {
+	specs := map[string]struct {
+		srcMutator func(state GenesisState)
+		expError   bool
+	}{
+		"all good": {
+			srcMutator: func(s GenesisState) {},
+		},
+		"codeinfo invalid": {
+			srcMutator: func(s GenesisState) {
+				s.Codes[0].CodeInfo.CodeHash = nil
+			},
+			expError: true,
+		},
+		"contract invalid": {
+			srcMutator: func(s GenesisState) {
+				s.Contracts[0].ContractAddress = nil
+			},
+			expError: true,
+		},
+		"sequence invalid": {
+			srcMutator: func(s GenesisState) {
+				s.Sequences[0].IDKey = nil
+			},
+			expError: true,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			state := genesisFixture(spec.srcMutator)
+			got := state.ValidateBasic()
+			if spec.expError {
+				require.Error(t, got)
+				return
+			}
+			require.NoError(t, got)
+		})
+	}
+
+}
+
+func genesisFixture(mutators ...func(state GenesisState)) GenesisState {
+	const (
+		numCodes     = 2
+		numContracts = 2
+		numSequences = 2
+	)
+
+	fixture := GenesisState{
+		Codes:     make([]Code, numCodes),
+		Contracts: make([]Contract, numContracts),
+		Sequences: make([]Sequence, numSequences),
+	}
+	for i := 0; i < numCodes; i++ {
+		fixture.Codes[i] = codeFixture()
+	}
+	for i := 0; i < numContracts; i++ {
+		fixture.Contracts[i] = contractFixture()
+	}
+	for i := 0; i < numSequences; i++ {
+		fixture.Sequences[i] = Sequence{
+			IDKey: rand.Bytes(5),
+			Value: uint64(i),
+		}
+	}
+	for _, m := range mutators {
+		m(fixture)
+	}
+	return fixture
+}
+
+func codeFixture() Code {
+	wasmCode := rand.Bytes(100)
+	codeHash := sha256.Sum256(wasmCode)
+	anyAddress := make([]byte, 20)
+
+	return Code{
+		CodeInfo: CodeInfo{
+			CodeHash: codeHash[:],
+			Creator:  anyAddress,
+		},
+		CodesBytes: wasmCode,
+	}
+}
+
+func contractFixture() Contract {
+	anyAddress := make([]byte, 20)
+	return Contract{
+		ContractAddress: anyAddress,
+		ContractInfo: ContractInfo{
+			CodeID:  1,
+			Creator: anyAddress,
+			Label:   "any",
+			Created: &AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
+		},
+	}
+}

--- a/x/wasm/internal/types/test_fixtures.go
+++ b/x/wasm/internal/types/test_fixtures.go
@@ -1,0 +1,102 @@
+package types
+
+import (
+	"bytes"
+	"crypto/sha256"
+
+	"github.com/tendermint/tendermint/libs/rand"
+)
+
+func GenesisFixture(mutators ...func(*GenesisState)) GenesisState {
+	const (
+		numCodes     = 2
+		numContracts = 2
+		numSequences = 2
+	)
+
+	fixture := GenesisState{
+		Codes:     make([]Code, numCodes),
+		Contracts: make([]Contract, numContracts),
+		Sequences: make([]Sequence, numSequences),
+	}
+	for i := 0; i < numCodes; i++ {
+		fixture.Codes[i] = CodeFixture()
+	}
+	for i := 0; i < numContracts; i++ {
+		fixture.Contracts[i] = ContractFixture()
+	}
+	for i := 0; i < numSequences; i++ {
+		fixture.Sequences[i] = Sequence{
+			IDKey: rand.Bytes(5),
+			Value: uint64(i),
+		}
+	}
+	for _, m := range mutators {
+		m(&fixture)
+	}
+	return fixture
+}
+
+func CodeFixture(mutators ...func(*Code)) Code {
+	wasmCode := rand.Bytes(100)
+	codeHash := sha256.Sum256(wasmCode)
+	anyAddress := make([]byte, 20)
+
+	fixture := Code{
+		CodeInfo: CodeInfo{
+			CodeHash: codeHash[:],
+			Creator:  anyAddress,
+		},
+		CodesBytes: wasmCode,
+	}
+
+	for _, m := range mutators {
+		m(&fixture)
+	}
+	return fixture
+}
+
+func CodeInfoFixture(mutators ...func(*CodeInfo)) CodeInfo {
+	wasmCode := bytes.Repeat([]byte{0x1}, 10)
+	codeHash := sha256.Sum256(wasmCode)
+	anyAddress := make([]byte, 20)
+	fixture := CodeInfo{
+		CodeHash: codeHash[:],
+		Creator:  anyAddress,
+		Source:   "https://example.com",
+		Builder:  "my/builder:tag",
+	}
+	for _, m := range mutators {
+		m(&fixture)
+	}
+	return fixture
+}
+
+func ContractFixture(mutators ...func(*Contract)) Contract {
+	anyAddress := make([]byte, 20)
+	fixture := Contract{
+		ContractAddress: anyAddress,
+		ContractInfo:    ContractInfoFixture(),
+		ContractState:   []Model{{Key: []byte("anyKey"), Value: []byte("anyValue")}},
+	}
+
+	for _, m := range mutators {
+		m(&fixture)
+	}
+	return fixture
+}
+
+func ContractInfoFixture(mutators ...func(*ContractInfo)) ContractInfo {
+	anyAddress := make([]byte, 20)
+	fixture := ContractInfo{
+		CodeID:  1,
+		Creator: anyAddress,
+		Label:   "any",
+		Created: &AbsoluteTxPosition{BlockHeight: 1, TxIndex: 1},
+	}
+
+	for _, m := range mutators {
+		m(&fixture)
+	}
+	return fixture
+}

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -97,6 +97,9 @@ func (c *ContractInfo) ValidateBasic() error {
 	if err := validateLabel(c.Label); err != nil {
 		return sdkerrors.Wrap(err, "label")
 	}
+	if c.Created == nil {
+		return sdkerrors.Wrap(ErrEmpty, "created")
+	}
 	if err := c.Created.ValidateBasic(); err != nil {
 		return sdkerrors.Wrap(err, "created")
 	}

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -97,6 +97,12 @@ func (c *ContractInfo) ValidateBasic() error {
 	if err := validateLabel(c.Label); err != nil {
 		return sdkerrors.Wrap(err, "label")
 	}
+	if err := c.Created.ValidateBasic(); err != nil {
+		return sdkerrors.Wrap(err, "created")
+	}
+	if err := c.LastUpdated.ValidateBasic(); err != nil {
+		return sdkerrors.Wrap(err, "last updated")
+	}
 	return nil
 }
 
@@ -117,6 +123,16 @@ func (a *AbsoluteTxPosition) LessThan(b *AbsoluteTxPosition) bool {
 		return false
 	}
 	return a.BlockHeight < b.BlockHeight || (a.BlockHeight == b.BlockHeight && a.TxIndex < b.TxIndex)
+}
+
+func (a *AbsoluteTxPosition) ValidateBasic() error {
+	if a == nil {
+		return nil
+	}
+	if a.BlockHeight < 0 {
+		return sdkerrors.Wrap(ErrInvalid, "height")
+	}
+	return nil
 }
 
 // NewCreatedAt gets a timestamp from the context

--- a/x/wasm/internal/types/types_test.go
+++ b/x/wasm/internal/types/types_test.go
@@ -1,0 +1,133 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContractInfoValidateBasic(t *testing.T) {
+	specs := map[string]struct {
+		srcMutator func(*ContractInfo)
+		expError   bool
+	}{
+		"all good": {srcMutator: func(_ *ContractInfo) {}},
+		"code id empty": {
+			srcMutator: func(c *ContractInfo) { c.CodeID = 0 },
+			expError:   true,
+		},
+		"creator empty": {
+			srcMutator: func(c *ContractInfo) { c.Creator = nil },
+			expError:   true,
+		},
+		"creator not an address": {
+			srcMutator: func(c *ContractInfo) { c.Creator = make([]byte, sdk.AddrLen-1) },
+			expError:   true,
+		},
+		"admin empty": {
+			srcMutator: func(c *ContractInfo) { c.Admin = nil },
+			expError:   false,
+		},
+		"admin not an address": {
+			srcMutator: func(c *ContractInfo) { c.Admin = make([]byte, sdk.AddrLen-1) },
+			expError:   true,
+		},
+		"label empty": {
+			srcMutator: func(c *ContractInfo) { c.Label = "" },
+			expError:   true,
+		},
+		"label exceeds limit": {
+			srcMutator: func(c *ContractInfo) { c.Label = strings.Repeat("a", MaxLabelSize+1) },
+			expError:   true,
+		},
+		"init msg empty": {
+			srcMutator: func(c *ContractInfo) { c.InitMsg = nil },
+		},
+		"created nil": {
+			srcMutator: func(c *ContractInfo) { c.Created = nil },
+			expError:   true,
+		},
+		"created invalid": {
+			srcMutator: func(c *ContractInfo) { c.Created = &AbsoluteTxPosition{BlockHeight: -1} },
+			expError:   true,
+		},
+		"last updated nil": {
+			srcMutator: func(c *ContractInfo) { c.LastUpdated = nil },
+		},
+		"previous code id empty": {
+			srcMutator: func(c *ContractInfo) { c.PreviousCodeID = 0 },
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			state := ContractInfoFixture(spec.srcMutator)
+			got := state.ValidateBasic()
+			if spec.expError {
+				require.Error(t, got)
+				return
+			}
+			require.NoError(t, got)
+		})
+	}
+}
+
+func TestCodeInfoValidateBasic(t *testing.T) {
+	specs := map[string]struct {
+		srcMutator func(*CodeInfo)
+		expError   bool
+	}{
+		"all good": {srcMutator: func(_ *CodeInfo) {}},
+		"code hash empty": {
+			srcMutator: func(c *CodeInfo) { c.CodeHash = []byte{} },
+			expError:   true,
+		},
+		"code hash nil": {
+			srcMutator: func(c *CodeInfo) { c.CodeHash = nil },
+			expError:   true,
+		},
+		"creator empty": {
+			srcMutator: func(c *CodeInfo) { c.Creator = nil },
+			expError:   true,
+		},
+		"creator not an address": {
+			srcMutator: func(c *CodeInfo) { c.Creator = make([]byte, sdk.AddrLen-1) },
+			expError:   true,
+		},
+		"source empty": {
+			srcMutator: func(c *CodeInfo) { c.Source = "" },
+		},
+		"source not an url": {
+			srcMutator: func(c *CodeInfo) { c.Source = "invalid" },
+			expError:   true,
+		},
+		"source not an absolute url": {
+			srcMutator: func(c *CodeInfo) { c.Source = "../bar.txt" },
+			expError:   true,
+		},
+		"source not https schema url": {
+			srcMutator: func(c *CodeInfo) { c.Source = "http://example.com" },
+			expError:   true,
+		},
+		"builder tag exceeds limit": {
+			srcMutator: func(c *CodeInfo) { c.Builder = strings.Repeat("a", MaxBuildTagSize+1) },
+			expError:   true,
+		},
+		"builder tag does not match pattern": {
+			srcMutator: func(c *CodeInfo) { c.Builder = "invalid" },
+			expError:   true,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			state := CodeInfoFixture(spec.srcMutator)
+			got := state.ValidateBasic()
+			if spec.expError {
+				require.Error(t, got)
+				return
+			}
+			require.NoError(t, got)
+		})
+	}
+}

--- a/x/wasm/internal/types/validation.go
+++ b/x/wasm/internal/types/validation.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"net/url"
+	"regexp"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const (
+	MaxWasmSize = 500 * 1024
+
+	// MaxLabelSize is the longest label that can be used when Instantiating a contract
+	MaxLabelSize = 128
+
+	// BuildTagRegexp is a docker image regexp.
+	// We only support max 128 characters, with at least one organization name (subset of all legal names).
+	//
+	// Details from https://docs.docker.com/engine/reference/commandline/tag/#extended-description :
+	//
+	// An image name is made up of slash-separated name components (optionally prefixed by a registry hostname).
+	// Name components may contain lowercase characters, digits and separators.
+	// A separator is defined as a period, one or two underscores, or one or more dashes. A name component may not start or end with a separator.
+	//
+	// A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
+	// A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+	BuildTagRegexp = "^[a-z0-9][a-z0-9._-]*[a-z0-9](/[a-z0-9][a-z0-9._-]*[a-z0-9])+:[a-zA-Z0-9_][a-zA-Z0-9_.-]*$"
+
+	MaxBuildTagSize = 128
+)
+
+func validateSourceURL(source string) error {
+	if source != "" {
+		u, err := url.Parse(source)
+		if err != nil {
+			return sdkerrors.Wrap(ErrInvalid, "not an url")
+		}
+		if !u.IsAbs() {
+			return sdkerrors.Wrap(ErrInvalid, "not an absolute url")
+		}
+		if u.Scheme != "https" {
+			return sdkerrors.Wrap(ErrInvalid, "must use https")
+		}
+	}
+	return nil
+}
+
+func validateBuilder(buildTag string) error {
+	if len(buildTag) > MaxBuildTagSize {
+		return sdkerrors.Wrap(ErrLimit, "longer than 128 characters")
+	}
+
+	if buildTag != "" {
+		ok, err := regexp.MatchString(BuildTagRegexp, buildTag)
+		if err != nil || !ok {
+			return ErrInvalid
+		}
+	}
+	return nil
+}
+
+func validateWasmCode(s []byte) error {
+	if len(s) == 0 {
+		return sdkerrors.Wrap(ErrEmpty, "is required")
+	}
+	if len(s) > MaxWasmSize {
+		return sdkerrors.Wrapf(ErrLimit, "cannot be longer than %d bytes", MaxWasmSize)
+	}
+	return nil
+}
+
+func validateLabel(label string) error {
+	if label == "" {
+		return sdkerrors.Wrap(ErrEmpty, "is required")
+	}
+	if len(label) > MaxLabelSize {
+		return sdkerrors.Wrap(ErrLimit, "cannot be longer than 128 characters")
+	}
+	return nil
+}

--- a/x/wasm/module.go
+++ b/x/wasm/module.go
@@ -114,7 +114,9 @@ func (am AppModule) NewQuerierHandler() sdk.Querier {
 func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
 	var genesisState GenesisState
 	ModuleCdc.MustUnmarshalJSON(data, &genesisState)
-	InitGenesis(ctx, am.keeper, genesisState)
+	if err := InitGenesis(ctx, am.keeper, genesisState); err != nil {
+		panic(err)
+	}
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
A data import via genesis file allows currently to bypass all validation checks of the models so that the internal state could end up in an inconsistent or broken state.

With this PR some syntax checks on the model were added as well as a sanity check on the DB import to prevent overwrites by duplicate data. Orphan contracts without a persistent codeInfo are prevented, now.

* Not covered:
The position of a `code_info` within the `code` block matters for the codeID generation during import. Switching two elements can therefore lead to different codeIDs and may cause contracts to point to the wrong one.
 See https://github.com/CosmWasm/wasmd/issues/166
______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))