### PR TITLE
Genesis code import not position agnostic

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"encoding/binary"
 	"path/filepath"
 
@@ -95,6 +96,29 @@ func (k Keeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte,
 	store.Set(types.GetCodeKey(codeID), k.cdc.MustMarshalBinaryBare(codeInfo))
 
 	return codeID, nil
+}
+
+func (k Keeper) importCode(ctx sdk.Context, codeID uint64, codeInfo types.CodeInfo, wasmCode []byte) error {
+	wasmCode, err := uncompress(wasmCode)
+	if err != nil {
+		return sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
+	}
+	newCodeHash, err := k.wasmer.Create(wasmCode)
+	if err != nil {
+		return sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
+	}
+	if !bytes.Equal(codeInfo.CodeHash, newCodeHash) {
+		return sdkerrors.Wrap(types.ErrInvalid, "code hashes not same")
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	key := types.GetCodeKey(codeID)
+	if store.Has(key) {
+		return sdkerrors.Wrapf(types.ErrDuplicate, "duplicate code: %d", codeID)
+	}
+	// 0x01 | codeID (uint64) -> ContractInfo
+	store.Set(key, k.cdc.MustMarshalBinaryBare(codeInfo))
+	return nil
 }
 
 // Instantiate creates an instance of a WASM contract

--- a/x/wasm/internal/types/genesis.go
+++ b/x/wasm/internal/types/genesis.go
@@ -1,5 +1,6 @@
 package types
 
+import "C"
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -45,11 +46,15 @@ func (s GenesisState) ValidateBasic() error {
 
 // Code struct encompasses CodeInfo and CodeBytes
 type Code struct {
+	CodeID     uint64   `json:"code_id"`
 	CodeInfo   CodeInfo `json:"code_info"`
 	CodesBytes []byte   `json:"code_bytes"`
 }
 
 func (c Code) ValidateBasic() error {
+	if c.CodeID == 0 {
+		return sdkerrors.Wrap(ErrEmpty, "code id")
+	}
 	if err := c.CodeInfo.ValidateBasic(); err != nil {
 		return sdkerrors.Wrap(err, "code info")
 	}

--- a/x/wasm/internal/types/genesis_test.go
+++ b/x/wasm/internal/types/genesis_test.go
@@ -53,6 +53,12 @@ func TestCodeValidateBasic(t *testing.T) {
 		expError   bool
 	}{
 		"all good": {srcMutator: func(_ *Code) {}},
+		"code id invalid": {
+			srcMutator: func(c *Code) {
+				c.CodeID = 0
+			},
+			expError: true,
+		},
 		"codeinfo invalid": {
 			srcMutator: func(c *Code) {
 				c.CodeInfo.CodeHash = nil

--- a/x/wasm/internal/types/keys.go
+++ b/x/wasm/internal/types/keys.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"encoding/binary"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -32,9 +34,13 @@ var (
 )
 
 // GetCodeKey constructs the key for retreiving the ID for the WASM code
-func GetCodeKey(contractID uint64) []byte {
-	contractIDBz := sdk.Uint64ToBigEndian(contractID)
+func GetCodeKey(codeID uint64) []byte {
+	contractIDBz := sdk.Uint64ToBigEndian(codeID)
 	return append(CodeKeyPrefix, contractIDBz...)
+}
+
+func decodeCodeKey(src []byte) uint64 {
+	return binary.BigEndian.Uint64(src[len(CodeKeyPrefix):])
 }
 
 // GetContractAddressKey returns the key for the WASM contract instance

--- a/x/wasm/internal/types/test_fixtures.go
+++ b/x/wasm/internal/types/test_fixtures.go
@@ -43,6 +43,7 @@ func CodeFixture(mutators ...func(*Code)) Code {
 	anyAddress := make([]byte, 20)
 
 	fixture := Code{
+		CodeID: 1,
 		CodeInfo: CodeInfo{
 			CodeHash: codeHash[:],
 			Creator:  anyAddress,


### PR DESCRIPTION
Resolves #166 

The codeID is stored within the genesis data so that the order in the file does not matter anymore.

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))