### PR TITLE
Full history of contract code migrations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Features
+* (wasmd) [\#130](https://github.com/CosmWasm/wasmd/issues/130) Full history of contract code migrations
 * (wasmd) [\#187](https://github.com/CosmWasm/wasmd/issues/187) Introduce wasmgovd binary
 * (wasmd) [\#178](https://github.com/CosmWasm/wasmd/issues/178) Add cli support for wasm gov proposals
 * (wasmd) [\#163](https://github.com/CosmWasm/wasmd/issues/163) Control who can instantiate code

--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -43,7 +43,7 @@ var (
 	GetContractAddressKey     = types.GetContractAddressKey
 	GetContractStorePrefixKey = types.GetContractStorePrefixKey
 	NewCodeInfo               = types.NewCodeInfo
-	NewCreatedAt              = types.NewCreatedAt
+	NewCreatedAt              = types.NewAbsoluteTxPosition
 	NewContractInfo           = types.NewContractInfo
 	NewEnv                    = types.NewEnv
 	NewWasmCoins              = types.NewWasmCoins

--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -43,7 +43,7 @@ var (
 	GetContractAddressKey     = types.GetContractAddressKey
 	GetContractStorePrefixKey = types.GetContractStorePrefixKey
 	NewCodeInfo               = types.NewCodeInfo
-	NewCreatedAt              = types.NewAbsoluteTxPosition
+	NewAbsoluteTxPosition     = types.NewAbsoluteTxPosition
 	NewContractInfo           = types.NewContractInfo
 	NewEnv                    = types.NewEnv
 	NewWasmCoins              = types.NewWasmCoins

--- a/x/wasm/internal/keeper/genesis.go
+++ b/x/wasm/internal/keeper/genesis.go
@@ -83,6 +83,9 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 			}
 			state = append(state, m)
 		}
+		// redact contract info
+		contract.Created = nil
+		contract.ContractCodeHistory = nil
 
 		genState.Contracts = append(genState.Contracts, types.Contract{
 			ContractAddress: addr,

--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -104,9 +104,8 @@ func TestGenesisExportImport(t *testing.T) {
 func TestFailFastImport(t *testing.T) {
 	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
 	require.NoError(t, err)
-	codeHash := sha256.Sum256(wasmCode)
-	anyAddress := make([]byte, 20)
 
+	myCodeInfo := wasmTypes.CodeInfoFixture(wasmTypes.WithSHA256CodeHash(wasmCode))
 	specs := map[string]struct {
 		src        types.GenesisState
 		expSuccess bool
@@ -114,11 +113,8 @@ func TestFailFastImport(t *testing.T) {
 		"happy path: code info correct": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Sequences: []types.Sequence{
@@ -132,18 +128,12 @@ func TestFailFastImport(t *testing.T) {
 		"happy path: code ids can contain gaps": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}, {
-					CodeID: 3,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     3,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Sequences: []types.Sequence{
@@ -157,18 +147,12 @@ func TestFailFastImport(t *testing.T) {
 		"happy path: code order does not matter": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 2,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     2,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}, {
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: nil,
@@ -182,11 +166,8 @@ func TestFailFastImport(t *testing.T) {
 		},
 		"prevent code hash mismatch": {src: types.GenesisState{
 			Codes: []types.Code{{
-				CodeID: 1,
-				CodeInfo: wasmTypes.CodeInfo{
-					CodeHash: make([]byte, len(codeHash)),
-					Creator:  anyAddress,
-				},
+				CodeID:     1,
+				CodeInfo:   wasmTypes.CodeInfoFixture(func(i *wasmTypes.CodeInfo) { i.CodeHash = make([]byte, sha256.Size) }),
 				CodesBytes: wasmCode,
 			}},
 			Params: types.DefaultParams(),
@@ -194,19 +175,13 @@ func TestFailFastImport(t *testing.T) {
 		"prevent duplicate codeIDs": {src: types.GenesisState{
 			Codes: []types.Code{
 				{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				},
 				{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				},
 			},
@@ -215,11 +190,8 @@ func TestFailFastImport(t *testing.T) {
 		"happy path: code id in info and contract do match": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: []types.Contract{
@@ -239,11 +211,8 @@ func TestFailFastImport(t *testing.T) {
 		"happy path: code info with two contracts": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: []types.Contract{
@@ -277,11 +246,8 @@ func TestFailFastImport(t *testing.T) {
 		"prevent duplicate contract address": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: []types.Contract{
@@ -299,11 +265,8 @@ func TestFailFastImport(t *testing.T) {
 		"prevent duplicate contract model keys": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: []types.Contract{
@@ -337,11 +300,8 @@ func TestFailFastImport(t *testing.T) {
 		"prevent code id seq init value == max codeID used": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 2,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     2,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Sequences: []types.Sequence{
@@ -353,11 +313,8 @@ func TestFailFastImport(t *testing.T) {
 		"prevent contract id seq init value == count contracts": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
-					CodeID: 1,
-					CodeInfo: wasmTypes.CodeInfo{
-						CodeHash: codeHash[:],
-						Creator:  anyAddress,
-					},
+					CodeID:     1,
+					CodeInfo:   myCodeInfo,
 					CodesBytes: wasmCode,
 				}},
 				Contracts: []types.Contract{
@@ -456,8 +413,8 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
         "source": "https://example.com",
         "builder": "foo/bar:tag",
         "instantiate_config": {
-          "type": 1,
-          "address": ""
+          "permission": "OnlyAddress",
+          "address": "cosmos1qtu5n0cnhfkjj6l2rq97hmky9fd89gwca9yarx"
         }
       },
       "code_bytes": %q

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -606,6 +606,8 @@ func (k Keeper) importContract(ctx sdk.Context, address sdk.AccAddress, c *types
 	if k.containsContractInfo(ctx, address) {
 		return errors.Wrapf(types.ErrDuplicate, "contract: %s", address)
 	}
+
+	c.ResetFromGenesis(ctx)
 	k.setContractInfo(ctx, address, c)
 	return k.importContractState(ctx, address, state)
 }

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -169,6 +169,7 @@ func (k Keeper) importCode(ctx sdk.Context, codeID uint64, codeInfo types.CodeIn
 func (k Keeper) Instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.AccAddress, initMsg []byte, label string, deposit sdk.Coins) (sdk.AccAddress, error) {
 	return k.instantiate(ctx, codeID, creator, admin, initMsg, label, deposit, k.authZPolicy)
 }
+
 func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.AccAddress, initMsg []byte, label string, deposit sdk.Coins, authZ AuthorizationPolicy) (sdk.AccAddress, error) {
 	ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: init")
 

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -240,7 +240,7 @@ func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 	}
 
 	// persist instance
-	createdAt := types.NewCreatedAt(ctx)
+	createdAt := types.NewAbsoluteTxPosition(ctx)
 	instance := types.NewContractInfo(codeID, creator, admin, initMsg, label, createdAt)
 	store.Set(types.GetContractAddressKey(contractAddress), k.cdc.MustMarshalBinaryBare(instance))
 
@@ -340,7 +340,7 @@ func (k Keeper) migrate(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	events := types.ParseEvents(res.Log, contractAddress)
 	ctx.EventManager().EmitEvents(events)
 
-	contractInfo.UpdateCodeID(ctx, newCodeID)
+	contractInfo.AddMigration(ctx, newCodeID, msg)
 	k.setContractInfo(ctx, contractAddress, contractInfo)
 
 	if err := k.dispatchMessages(ctx, contractAddress, res.Messages); err != nil {

--- a/x/wasm/internal/keeper/keeper_test.go
+++ b/x/wasm/internal/keeper/keeper_test.go
@@ -306,7 +306,7 @@ func TestInstantiate(t *testing.T) {
 	require.Equal(t, "cosmos18vd8fpwxzck93qlwghaj6arh4p7c5n89uzcee5", addr.String())
 
 	gasAfter := ctx.GasMeter().GasConsumed()
-	require.Equal(t, uint64(0x11740), gasAfter-gasBefore)
+	require.Equal(t, uint64(0x1175b), gasAfter-gasBefore)
 
 	// ensure it is stored properly
 	info := keeper.GetContractInfo(ctx, addr)
@@ -535,7 +535,7 @@ func TestExecute(t *testing.T) {
 
 	// make sure gas is properly deducted from ctx
 	gasAfter := ctx.GasMeter().GasConsumed()
-	require.Equal(t, uint64(0x11c2e), gasAfter-gasBefore)
+	require.Equal(t, uint64(0x11c49), gasAfter-gasBefore)
 
 	// ensure bob now exists and got both payments released
 	bobAcct = accKeeper.GetAccount(ctx, bob)

--- a/x/wasm/internal/keeper/proposal_integration_test.go
+++ b/x/wasm/internal/keeper/proposal_integration_test.go
@@ -179,11 +179,10 @@ func TestMigrateProposal(t *testing.T) {
 	assert.Equal(t, anyAddress, cInfo.Admin)
 	assert.Equal(t, "testing", cInfo.Label)
 	expHistory := []types.ContractCodeHistoryEntry{{
-		//	Operation: types.InitContractCodeHistoryType,
-		//	CodeID:    1,
-		//	Updated:   types.NewAbsoluteTxPosition(ctx),
-		//	Msg:       initMsgBz,
-		//}, {
+		Operation: types.GenesisContractCodeHistoryType,
+		CodeID:    1,
+		Updated:   types.NewAbsoluteTxPosition(ctx),
+	}, {
 		Operation: types.MigrateContractCodeHistoryType,
 		CodeID:    src.Code,
 		Updated:   types.NewAbsoluteTxPosition(ctx),

--- a/x/wasm/internal/keeper/proposal_integration_test.go
+++ b/x/wasm/internal/keeper/proposal_integration_test.go
@@ -104,7 +104,14 @@ func TestInstantiateProposal(t *testing.T) {
 	assert.Equal(t, oneAddress, cInfo.Creator)
 	assert.Equal(t, otherAddress, cInfo.Admin)
 	assert.Equal(t, "testing", cInfo.Label)
-	assert.Equal(t, src.InitMsg, cInfo.InitMsg)
+	expHistory := []types.ContractCodeHistoryEntry{{
+		Operation: types.InitContractCodeHistoryType,
+		CodeID:    src.Code,
+		Updated:   types.NewAbsoluteTxPosition(ctx),
+		Msg:       src.InitMsg,
+	}}
+	assert.Equal(t, expHistory, cInfo.ContractCodeHistory)
+
 }
 
 func TestMigrateProposal(t *testing.T) {
@@ -169,9 +176,21 @@ func TestMigrateProposal(t *testing.T) {
 	cInfo := wasmKeeper.GetContractInfo(ctx, contractAddr)
 	require.NotNil(t, cInfo)
 	assert.Equal(t, uint64(2), cInfo.CodeID)
-	assert.Equal(t, uint64(1), cInfo.PreviousCodeID)
 	assert.Equal(t, anyAddress, cInfo.Admin)
 	assert.Equal(t, "testing", cInfo.Label)
+	expHistory := []types.ContractCodeHistoryEntry{{
+		//	Operation: types.InitContractCodeHistoryType,
+		//	CodeID:    1,
+		//	Updated:   types.NewAbsoluteTxPosition(ctx),
+		//	Msg:       initMsgBz,
+		//}, {
+		Operation: types.MigrateContractCodeHistoryType,
+		CodeID:    src.Code,
+		Updated:   types.NewAbsoluteTxPosition(ctx),
+		Msg:       src.MigrateMsg,
+	}}
+	assert.Equal(t, expHistory, cInfo.ContractCodeHistory)
+
 }
 
 func TestAdminProposals(t *testing.T) {

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -208,7 +208,10 @@ func TestListContractByCodeOrdering(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("contract %d", i), contract.Label)
 		assert.NotEmpty(t, contract.Address)
 		// ensure these are not shown
-		assert.Nil(t, contract.InitMsg)
 		assert.Nil(t, contract.Created)
+		for _, entry := range contract.ContractCodeHistory {
+			assert.Nil(t, entry.Updated)
+			assert.Nil(t, entry.Msg)
+		}
 	}
 }

--- a/x/wasm/internal/types/genesis.go
+++ b/x/wasm/internal/types/genesis.go
@@ -82,6 +82,13 @@ func (c Contract) ValidateBasic() error {
 	if err := c.ContractInfo.ValidateBasic(); err != nil {
 		return sdkerrors.Wrap(err, "contract info")
 	}
+
+	if c.ContractInfo.Created != nil {
+		return sdkerrors.Wrap(ErrInvalid, "created must be empty")
+	}
+	if len(c.ContractInfo.ContractCodeHistory) != 0 {
+		return sdkerrors.Wrap(ErrInvalid, "history must be empty")
+	}
 	for i := range c.ContractState {
 		if err := c.ContractState[i].ValidateBasic(); err != nil {
 			return sdkerrors.Wrapf(err, "contract state %d", i)

--- a/x/wasm/internal/types/genesis_test.go
+++ b/x/wasm/internal/types/genesis_test.go
@@ -121,6 +121,18 @@ func TestContractValidateBasic(t *testing.T) {
 			},
 			expError: true,
 		},
+		"contract with created set": {
+			srcMutator: func(c *Contract) {
+				c.ContractInfo.Created = &AbsoluteTxPosition{}
+			},
+			expError: true,
+		},
+		"contract with history set": {
+			srcMutator: func(c *Contract) {
+				c.ContractInfo.ContractCodeHistory = []ContractCodeHistoryEntry{{}}
+			},
+			expError: true,
+		},
 		"contract state invalid": {
 			srcMutator: func(c *Contract) {
 				c.ContractState = append(c.ContractState, Model{})

--- a/x/wasm/internal/types/msg.go
+++ b/x/wasm/internal/types/msg.go
@@ -133,8 +133,8 @@ func (msg MsgExecuteContract) ValidateBasic() error {
 		return err
 	}
 
-	if msg.SentFunds.IsAnyNegative() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "negative SentFunds")
+	if !msg.SentFunds.IsValid() {
+		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, "sentFunds")
 	}
 	return nil
 }

--- a/x/wasm/internal/types/params.go
+++ b/x/wasm/internal/types/params.go
@@ -147,7 +147,7 @@ func validateAccessType(i interface{}) error {
 
 func (v AccessConfig) ValidateBasic() error {
 	switch v.Type {
-	case Undefined:
+	case Undefined, "":
 		return sdkerrors.Wrap(ErrEmpty, "type")
 	case Nobody, Everybody:
 		if len(v.Address) != 0 {

--- a/x/wasm/internal/types/params_test.go
+++ b/x/wasm/internal/types/params_test.go
@@ -61,16 +61,28 @@ func TestValidateParams(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"reject AccessConfig Everybody with obsolete address": {
+		"reject UploadAccess Everybody with obsolete address": {
 			src: Params{
 				UploadAccess:                 AccessConfig{Type: Everybody, Address: anyAddress},
 				DefaultInstantiatePermission: OnlyAddress,
 			},
 			expErr: true,
 		},
-		"reject AccessConfig Nobody with obsolete address": {
+		"reject UploadAccess Nobody with obsolete address": {
 			src: Params{
 				UploadAccess:                 AccessConfig{Type: Nobody, Address: anyAddress},
+				DefaultInstantiatePermission: OnlyAddress,
+			},
+			expErr: true,
+		},
+		"reject empty UploadAccess": {
+			src: Params{
+				DefaultInstantiatePermission: OnlyAddress,
+			},
+			expErr: true,
+		}, "reject undefined permission in UploadAccess": {
+			src: Params{
+				UploadAccess:                 AccessConfig{Type: Undefined},
 				DefaultInstantiatePermission: OnlyAddress,
 			},
 			expErr: true,

--- a/x/wasm/internal/types/test_fixtures.go
+++ b/x/wasm/internal/types/test_fixtures.go
@@ -80,7 +80,7 @@ func ContractFixture(mutators ...func(*Contract)) Contract {
 	anyAddress := make([]byte, 20)
 	fixture := Contract{
 		ContractAddress: anyAddress,
-		ContractInfo:    ContractInfoFixture(),
+		ContractInfo:    ContractInfoFixture(OnlyGenesisFields),
 		ContractState:   []Model{{Key: []byte("anyKey"), Value: []byte("anyValue")}},
 	}
 
@@ -88,6 +88,11 @@ func ContractFixture(mutators ...func(*Contract)) Contract {
 		m(&fixture)
 	}
 	return fixture
+}
+
+func OnlyGenesisFields(info *ContractInfo) {
+	info.Created = nil
+	info.ContractCodeHistory = nil
 }
 
 func ContractInfoFixture(mutators ...func(*ContractInfo)) ContractInfo {

--- a/x/wasm/internal/types/test_fixtures.go
+++ b/x/wasm/internal/types/test_fixtures.go
@@ -42,15 +42,10 @@ func GenesisFixture(mutators ...func(*GenesisState)) GenesisState {
 
 func CodeFixture(mutators ...func(*Code)) Code {
 	wasmCode := rand.Bytes(100)
-	codeHash := sha256.Sum256(wasmCode)
-	anyAddress := make([]byte, 20)
 
 	fixture := Code{
-		CodeID: 1,
-		CodeInfo: CodeInfo{
-			CodeHash: codeHash[:],
-			Creator:  anyAddress,
-		},
+		CodeID:     1,
+		CodeInfo:   CodeInfoFixture(WithSHA256CodeHash(wasmCode)),
 		CodesBytes: wasmCode,
 	}
 
@@ -65,10 +60,11 @@ func CodeInfoFixture(mutators ...func(*CodeInfo)) CodeInfo {
 	codeHash := sha256.Sum256(wasmCode)
 	anyAddress := make([]byte, 20)
 	fixture := CodeInfo{
-		CodeHash: codeHash[:],
-		Creator:  anyAddress,
-		Source:   "https://example.com",
-		Builder:  "my/builder:tag",
+		CodeHash:          codeHash[:],
+		Creator:           anyAddress,
+		Source:            "https://example.com",
+		Builder:           "my/builder:tag",
+		InstantiateConfig: AllowEverybody,
 	}
 	for _, m := range mutators {
 		m(&fixture)

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -159,16 +159,6 @@ func (a *AbsoluteTxPosition) LessThan(b *AbsoluteTxPosition) bool {
 	return a.BlockHeight < b.BlockHeight || (a.BlockHeight == b.BlockHeight && a.TxIndex < b.TxIndex)
 }
 
-func (a *AbsoluteTxPosition) ValidateBasic() error {
-	if a == nil {
-		return nil
-	}
-	if a.BlockHeight < 0 {
-		return sdkerrors.Wrap(ErrInvalid, "height")
-	}
-	return nil
-}
-
 // NewAbsoluteTxPosition gets a timestamp from the context
 func NewAbsoluteTxPosition(ctx sdk.Context) *AbsoluteTxPosition {
 	// we must safely handle nil gas meters

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -70,6 +70,7 @@ type ContractCodeHistoryOperationType string
 const (
 	InitContractCodeHistoryType    ContractCodeHistoryOperationType = "Init"
 	MigrateContractCodeHistoryType ContractCodeHistoryOperationType = "Migrate"
+	GenesisContractCodeHistoryType ContractCodeHistoryOperationType = "Genesis"
 )
 
 var AllCodeHistoryTypes = []ContractCodeHistoryOperationType{InitContractCodeHistoryType, MigrateContractCodeHistoryType}
@@ -90,7 +91,7 @@ type ContractInfo struct {
 	// never show this in query results, just use for sorting
 	// (Note: when using json tag "-" amino refused to serialize it...)
 	Created             *AbsoluteTxPosition        `json:"created,omitempty"`
-	ContractCodeHistory []ContractCodeHistoryEntry `json:"contract_code_history"`
+	ContractCodeHistory []ContractCodeHistoryEntry `json:"contract_code_history,omitempty"`
 }
 
 func (c *ContractInfo) AddMigration(ctx sdk.Context, codeID uint64, msg []byte) {
@@ -122,14 +123,18 @@ func (c *ContractInfo) ValidateBasic() error {
 	if err := validateLabel(c.Label); err != nil {
 		return sdkerrors.Wrap(err, "label")
 	}
-	if c.Created == nil {
-		return sdkerrors.Wrap(ErrEmpty, "created")
-	}
-	if err := c.Created.ValidateBasic(); err != nil {
-		return sdkerrors.Wrap(err, "created")
-	}
-	// TODO: validate history
 	return nil
+}
+
+// ResetFromGenesis resets contracts timestamp and history.
+func (c *ContractInfo) ResetFromGenesis(ctx sdk.Context) {
+	c.Created = NewAbsoluteTxPosition(ctx)
+	h := ContractCodeHistoryEntry{
+		Operation: GenesisContractCodeHistoryType,
+		CodeID:    c.CodeID,
+		Updated:   c.Created,
+	}
+	c.ContractCodeHistory = []ContractCodeHistoryEntry{h}
 }
 
 // AbsoluteTxPosition can be used to sort contracts

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -51,6 +51,9 @@ func (c CodeInfo) ValidateBasic() error {
 	if err := validateBuilder(c.Builder); err != nil {
 		return sdkerrors.Wrap(err, "builder")
 	}
+	if err := c.InstantiateConfig.ValidateBasic(); err != nil {
+		return sdkerrors.Wrap(err, "instantiate config")
+	}
 	return nil
 }
 

--- a/x/wasm/internal/types/types_test.go
+++ b/x/wasm/internal/types/types_test.go
@@ -42,14 +42,6 @@ func TestContractInfoValidateBasic(t *testing.T) {
 			srcMutator: func(c *ContractInfo) { c.Label = strings.Repeat("a", MaxLabelSize+1) },
 			expError:   true,
 		},
-		"created nil": {
-			srcMutator: func(c *ContractInfo) { c.Created = nil },
-			expError:   true,
-		},
-		"created invalid": {
-			srcMutator: func(c *ContractInfo) { c.Created = &AbsoluteTxPosition{BlockHeight: -1} },
-			expError:   true,
-		},
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {

--- a/x/wasm/internal/types/types_test.go
+++ b/x/wasm/internal/types/types_test.go
@@ -42,9 +42,6 @@ func TestContractInfoValidateBasic(t *testing.T) {
 			srcMutator: func(c *ContractInfo) { c.Label = strings.Repeat("a", MaxLabelSize+1) },
 			expError:   true,
 		},
-		"init msg empty": {
-			srcMutator: func(c *ContractInfo) { c.InitMsg = nil },
-		},
 		"created nil": {
 			srcMutator: func(c *ContractInfo) { c.Created = nil },
 			expError:   true,
@@ -52,12 +49,6 @@ func TestContractInfoValidateBasic(t *testing.T) {
 		"created invalid": {
 			srcMutator: func(c *ContractInfo) { c.Created = &AbsoluteTxPosition{BlockHeight: -1} },
 			expError:   true,
-		},
-		"last updated nil": {
-			srcMutator: func(c *ContractInfo) { c.LastUpdated = nil },
-		},
-		"previous code id empty": {
-			srcMutator: func(c *ContractInfo) { c.PreviousCodeID = 0 },
 		},
 	}
 	for msg, spec := range specs {

--- a/x/wasm/internal/types/types_test.go
+++ b/x/wasm/internal/types/types_test.go
@@ -101,6 +101,10 @@ func TestCodeInfoValidateBasic(t *testing.T) {
 			srcMutator: func(c *CodeInfo) { c.Builder = "invalid" },
 			expError:   true,
 		},
+		"Instantiate config invalid": {
+			srcMutator: func(c *CodeInfo) { c.InstantiateConfig = AccessConfig{} },
+			expError:   true,
+		},
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {


### PR DESCRIPTION
Resolves #130 

A contract history is stored within ContractInfo for:
* Init
* Migrate
* Genesis import

Note: The genesis import/ export was more complex than storing some history data within the entity.

Moving the history out of the ContractInfo makes more sense to me to optimize the workflow and save gas. I will add a ticket to have this as a second step.
______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))