### PR TITLE
Better genesis import

### DIFF
--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -70,7 +70,7 @@ func TestGenesisExportImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// reset contract history in source DB for comparision with dest DB
-	srcKeeper.ListContractInfo(srcCtx, func(address sdk.AccAddress, info wasmTypes.ContractInfo) bool {
+	srcKeeper.IterateContractInfo(srcCtx, func(address sdk.AccAddress, info wasmTypes.ContractInfo) bool {
 		info.ResetFromGenesis(srcCtx)
 		srcKeeper.setContractInfo(srcCtx, address, &info)
 		return false
@@ -91,7 +91,7 @@ func TestGenesisExportImport(t *testing.T) {
 		dstIT := dstCtx.KVStore(dstStoreKeys[j]).Iterator(nil, nil)
 
 		for i := 0; srcIT.Valid(); i++ {
-			require.True(t, dstIT.Valid(), "destination DB has less elements than source. Missing: %q", srcIT.Key())
+			require.True(t, dstIT.Valid(), "[%s] destination DB has less elements than source. Missing: %s", srcStoreKeys[j].Name(), srcIT.Key())
 			require.Equal(t, srcIT.Key(), dstIT.Key(), i)
 			require.Equal(t, srcIT.Value(), dstIT.Value(), "[%s] element (%d): %s", srcStoreKeys[j].Name(), i, srcIT.Key())
 			srcIT.Next()

--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -438,24 +438,58 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
 	keeper, ctx, _, dstCleanup := setupKeeper(t)
 	defer dstCleanup()
 
+	ctx = ctx.WithBlockHeight(0).WithGasMeter(sdk.NewInfiniteGasMeter())
 	var importState wasmTypes.GenesisState
 	err = json.Unmarshal([]byte(fmt.Sprintf(genesis, base64.StdEncoding.EncodeToString(wasmCode))), &importState)
 	require.NoError(t, err)
 	require.NoError(t, importState.ValidateBasic())
+
+	// when
 	InitGenesis(ctx, keeper, importState)
 
-	contractAddr, err := sdk.AccAddressFromBech32("cosmos18vd8fpwxzck93qlwghaj6arh4p7c5n89uzcee5")
+	// verify wasm code
+	gotWasmCode, err := keeper.GetByteCode(ctx, 1)
 	require.NoError(t, err)
-	contractInfo := keeper.GetContractInfo(ctx, contractAddr)
-	require.NotNil(t, contractInfo)
-	require.Len(t, contractInfo.ContractCodeHistory, 1)
-	exp := []types.ContractCodeHistoryEntry{{
-		Operation: types.GenesisContractCodeHistoryType,
-		CodeID:    1,
-		Updated:   types.NewAbsoluteTxPosition(ctx),
-	},
+	assert.Equal(t, wasmCode, gotWasmCode)
+
+	// verify code info
+	gotCodeInfo := keeper.GetCodeInfo(ctx, 1)
+	require.NotNil(t, gotCodeInfo)
+	codeCreatorAddr, _ := sdk.AccAddressFromBech32("cosmos1qtu5n0cnhfkjj6l2rq97hmky9fd89gwca9yarx")
+	codeHash := sha256.Sum256(wasmCode)
+	expCodeInfo := types.CodeInfo{
+		CodeHash: codeHash[:],
+		Creator:  codeCreatorAddr,
+		Source:   "https://example.com",
+		Builder:  "foo/bar:tag",
+		InstantiateConfig: wasmTypes.AccessConfig{
+			Type:    types.OnlyAddress,
+			Address: codeCreatorAddr,
+		},
 	}
-	assert.Equal(t, exp, contractInfo.ContractCodeHistory)
+	assert.Equal(t, expCodeInfo, *gotCodeInfo)
+
+	// verify contract
+	contractAddr, _ := sdk.AccAddressFromBech32("cosmos18vd8fpwxzck93qlwghaj6arh4p7c5n89uzcee5")
+	gotContractInfo := keeper.GetContractInfo(ctx, contractAddr)
+	require.NotNil(t, gotContractInfo)
+	contractCreatorAddr, _ := sdk.AccAddressFromBech32("cosmos13x849jzd03vne42ynpj25hn8npjecxqrjghd8x")
+	adminAddr, _ := sdk.AccAddressFromBech32("cosmos1h5t8zxmjr30e9dqghtlpl40f2zz5cgey6esxtn")
+
+	expContractInfo := types.ContractInfo{
+		CodeID:  1,
+		Creator: contractCreatorAddr,
+		Admin:   adminAddr,
+		Label:   "ȀĴnZV芢毤",
+		Created: &types.AbsoluteTxPosition{BlockHeight: 0, TxIndex: 0},
+		ContractCodeHistory: []types.ContractCodeHistoryEntry{{
+			Operation: types.GenesisContractCodeHistoryType,
+			CodeID:    1,
+			Updated:   types.NewAbsoluteTxPosition(ctx),
+		},
+		},
+	}
+	assert.Equal(t, expContractInfo, *gotContractInfo)
 }
 
 func setupKeeper(t *testing.T) (Keeper, sdk.Context, []sdk.StoreKey, func()) {

--- a/x/wasm/internal/keeper/proposal_integration_test.go
+++ b/x/wasm/internal/keeper/proposal_integration_test.go
@@ -106,7 +106,7 @@ func TestInstantiateProposal(t *testing.T) {
 	assert.Equal(t, "testing", cInfo.Label)
 	expHistory := []types.ContractCodeHistoryEntry{{
 		Operation: types.InitContractCodeHistoryType,
-		CodeID:    src.Code,
+		CodeID:    src.CodeID,
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.InitMsg,
 	}}
@@ -184,7 +184,7 @@ func TestMigrateProposal(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 	}, {
 		Operation: types.MigrateContractCodeHistoryType,
-		CodeID:    src.Code,
+		CodeID:    src.CodeID,
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.MigrateMsg,
 	}}

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -97,7 +97,7 @@ func queryContractListByCode(ctx sdk.Context, codeIDstr string, req abci.Request
 	}
 
 	var contracts []ContractInfoWithAddress
-	keeper.ListContractInfo(ctx, func(addr sdk.AccAddress, info types.ContractInfo) bool {
+	keeper.IterateContractInfo(ctx, func(addr sdk.AccAddress, info types.ContractInfo) bool {
 		if info.CodeID == codeID {
 			// and add the address
 			infoWithAddress := ContractInfoWithAddress{


### PR DESCRIPTION
🚧  After #195 
This started as #144 when I realized that the work was done already.

Some additional improvements: 
* Export CodeInfo via prefix iterator
* Added `IterateCodeInfos` to keeper
* Renamed `ListContractInfo` to `IterateContractInfo`

And some additional genesis import assertions.

Reviewer note:
Only the last 2 commits. The others are from #195 
______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))