### PR TITLE
Polish types in message handler

### DIFF
--- a/x/wasm/handler.go
+++ b/x/wasm/handler.go
@@ -16,34 +16,16 @@ func NewHandler(k Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		case MsgStoreCode:
 			return handleStoreCode(ctx, k, &msg)
-		case *MsgStoreCode:
-			return handleStoreCode(ctx, k, msg)
-
 		case MsgInstantiateContract:
 			return handleInstantiate(ctx, k, &msg)
-		case *MsgInstantiateContract:
-			return handleInstantiate(ctx, k, msg)
-
 		case MsgExecuteContract:
 			return handleExecute(ctx, k, &msg)
-		case *MsgExecuteContract:
-			return handleExecute(ctx, k, msg)
-
-		case *MsgMigrateContract:
-			return handleMigration(ctx, k, msg)
 		case MsgMigrateContract:
 			return handleMigration(ctx, k, &msg)
-
-		case *MsgUpdateAdmin:
-			return handleUpdateContractAdmin(ctx, k, msg)
 		case MsgUpdateAdmin:
 			return handleUpdateContractAdmin(ctx, k, &msg)
-
-		case *MsgClearAdmin:
-			return handleClearContractAdmin(ctx, k, msg)
 		case MsgClearAdmin:
 			return handleClearContractAdmin(ctx, k, &msg)
-
 		default:
 			errMsg := fmt.Sprintf("unrecognized wasm message type: %T", msg)
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -325,7 +325,7 @@ func TestHandleExecuteEscrow(t *testing.T) {
 		Sender:       creator,
 		WASMByteCode: testContract,
 	}
-	res, err := h(data.ctx, &msg)
+	res, err := h(data.ctx, msg)
 	require.NoError(t, err)
 	require.Equal(t, res.Data, []byte("1"))
 


### PR DESCRIPTION
No pointer message types by sdk convention. 
______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))