### PR TITLE
Use prefix store for contract history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Features
+* (wasmd) [\#196](https://github.com/CosmWasm/wasmd/issues/196) Move history of contract code migrations to their own prefix store
 * (wasmd) [\#130](https://github.com/CosmWasm/wasmd/issues/130) Full history of contract code migrations
 * (wasmd) [\#187](https://github.com/CosmWasm/wasmd/issues/187) Introduce wasmgovd binary
 * (wasmd) [\#178](https://github.com/CosmWasm/wasmd/issues/178) Add cli support for wasm gov proposals

--- a/api_migration.md
+++ b/api_migration.md
@@ -1,0 +1,36 @@
+# Changes to the api
+
+## [\#196](https://github.com/CosmWasm/wasmd/issues/196) - Move history of contract code migrations to their own prefix store
+
+The `ContractDetails.initMsg` used in cosmJs was moved into a new entity `ContractCodeHistoryEntry`. They contain code updates to a contract.
+
+### Route
+This data is available via a new route `/wasm/contract/{contractAddr}/history`
+
+### Response
+A list of ContractCodeHistoryEntries with following fields:
+* `operation` can be any of `"Init", "Migrate", "Genesis"`
+* `code_id` uint64
+* `msg` as raw json
+
+### Errors
+* 404 - for an unknown contract
+
+### CLI
+`wasmcli query wasm contract-history [bech32_address] to print all the code changes.`
+Example:
+`wasmcli query wasm contract-history cosmos18r5szma8hm93pvx6lwpjwyxruw27e0k5uw835c` 
+```json
+[
+  {
+    "operation": "Init",
+    "code_id": 1,
+    "msg": "\"init-msg\""
+  },
+  {
+    "operation": "Migrate",
+    "code_id": 2,
+    "msg": "\"migrate-msg\""
+  }
+]
+```

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -36,6 +36,7 @@ func GetQueryCmd(cdc *codec.Codec) *cobra.Command {
 		GetCmdListContractByCode(cdc),
 		GetCmdQueryCode(cdc),
 		GetCmdGetContractInfo(cdc),
+		GetCmdGetContractHistory(cdc),
 		GetCmdGetContractState(cdc),
 	)...)
 	return queryCmd
@@ -265,6 +266,32 @@ func GetCmdGetContractStateSmart(cdc *codec.Codec) *cobra.Command {
 	}
 	decoder.RegisterFlags(cmd.PersistentFlags(), "query argument")
 	return cmd
+}
+
+// GetCmdGetContractHistory prints the code history for a given contract
+func GetCmdGetContractHistory(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "contract-history [bech32_address]",
+		Short: "Prints out the code history for a contract given its address",
+		Long:  "Prints out the code history for a contract given its address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			addr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, keeper.QueryContractHistory, addr.String())
+			res, _, err := cliCtx.Query(route)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(res))
+			return nil
+		},
+	}
 }
 
 type argumentDecoder struct {

--- a/x/wasm/client/rest/query.go
+++ b/x/wasm/client/rest/query.go
@@ -23,6 +23,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 	r.HandleFunc("/wasm/code/{codeID}/contracts", listContractsByCodeHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc("/wasm/contract/{contractAddr}", queryContractHandlerFn(cliCtx)).Methods("GET")
 	r.HandleFunc("/wasm/contract/{contractAddr}/state", queryContractStateAllHandlerFn(cliCtx)).Methods("GET")
+	r.HandleFunc("/wasm/contract/{contractAddr}/history", queryContractHistoryFn(cliCtx)).Methods("GET")
 	r.HandleFunc("/wasm/contract/{contractAddr}/smart/{query}", queryContractStateSmartHandlerFn(cliCtx)).Queries("encoding", "{encoding}").Methods("GET")
 	r.HandleFunc("/wasm/contract/{contractAddr}/raw/{key}", queryContractStateRawHandlerFn(cliCtx)).Queries("encoding", "{encoding}").Methods("GET")
 }
@@ -153,7 +154,6 @@ func queryContractStateAllHandlerFn(cliCtx context.CLIContext) http.HandlerFunc 
 		rest.PostProcessResponse(w, cliCtx, resultData)
 	}
 }
-
 func queryContractStateRawHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		decoder := newArgDecoder(hex.DecodeString)
@@ -230,6 +230,29 @@ func queryContractStateSmartHandlerFn(cliCtx context.CLIContext) http.HandlerFun
 	}
 }
 
+func queryContractHistoryFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		addr, err := sdk.AccAddressFromBech32(mux.Vars(r)["contractAddr"])
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
+		if !ok {
+			return
+		}
+
+		route := fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, keeper.QueryContractHistory, addr.String())
+		res, height, err := cliCtx.Query(route)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		cliCtx = cliCtx.WithHeight(height)
+		rest.PostProcessResponse(w, cliCtx, json.RawMessage(res))
+	}
+}
+
 type argumentDecoder struct {
 	// dec is the default decoder
 	dec      func(string) ([]byte, error)
@@ -241,7 +264,6 @@ func newArgDecoder(def func(string) ([]byte, error)) *argumentDecoder {
 }
 
 func (a *argumentDecoder) DecodeString(s string) ([]byte, error) {
-
 	switch a.encoding {
 	case "hex":
 		return hex.DecodeString(s)

--- a/x/wasm/internal/keeper/genesis.go
+++ b/x/wasm/internal/keeper/genesis.go
@@ -82,7 +82,6 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 		}
 		// redact contract info
 		contract.Created = nil
-		contract.ContractCodeHistory = nil
 
 		genState.Contracts = append(genState.Contracts, types.Contract{
 			ContractAddress: addr,

--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -454,7 +454,7 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 	},
 	}
-	assert.Equal(t, expHistory, keeper.getContractHistory(ctx, contractAddr))
+	assert.Equal(t, expHistory, keeper.GetContractHistory(ctx, contractAddr))
 }
 
 func setupKeeper(t *testing.T) (Keeper, sdk.Context, []sdk.StoreKey, func()) {

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -378,13 +378,8 @@ func (k Keeper) setContractAdmin(ctx sdk.Context, contractAddress, caller, newAd
 }
 
 func (k Keeper) appendToContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress, newEntries ...types.ContractCodeHistoryEntry) {
+	entries := append(k.GetContractHistory(ctx, contractAddr), newEntries...)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.ContractHistoryStorePrefix)
-	var entries []types.ContractCodeHistoryEntry
-	bz := prefixStore.Get(contractAddr)
-	if bz != nil {
-		k.cdc.MustUnmarshalBinaryBare(bz, &entries)
-	}
-	entries = append(entries, newEntries...)
 	prefixStore.Set(contractAddr, k.cdc.MustMarshalBinaryBare(&entries))
 }
 

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -388,7 +388,7 @@ func (k Keeper) appendToContractHistory(ctx sdk.Context, contractAddr sdk.AccAdd
 	prefixStore.Set(contractAddr, k.cdc.MustMarshalBinaryBare(&entries))
 }
 
-func (k Keeper) getContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress) []types.ContractCodeHistoryEntry {
+func (k Keeper) GetContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress) []types.ContractCodeHistoryEntry {
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.ContractHistoryStorePrefix)
 	var entries []types.ContractCodeHistoryEntry
 	bz := prefixStore.Get(contractAddr)

--- a/x/wasm/internal/keeper/keeper_test.go
+++ b/x/wasm/internal/keeper/keeper_test.go
@@ -321,7 +321,7 @@ func TestInstantiate(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       json.RawMessage(initMsgBz),
 	}}
-	assert.Equal(t, exp, keeper.getContractHistory(ctx, contractAddr))
+	assert.Equal(t, exp, keeper.GetContractHistory(ctx, contractAddr))
 }
 
 func TestInstantiateWithDeposit(t *testing.T) {
@@ -896,7 +896,7 @@ func TestMigrate(t *testing.T) {
 				Updated:   types.NewAbsoluteTxPosition(ctx),
 				Msg:       spec.migrateMsg,
 			}}
-			assert.Equal(t, expHistory, keeper.getContractHistory(ctx, contractAddr))
+			assert.Equal(t, expHistory, keeper.GetContractHistory(ctx, contractAddr))
 
 			m := keeper.QueryRaw(ctx, contractAddr, []byte("config"))
 			require.Len(t, m, 1)

--- a/x/wasm/internal/keeper/proposal_integration_test.go
+++ b/x/wasm/internal/keeper/proposal_integration_test.go
@@ -110,8 +110,7 @@ func TestInstantiateProposal(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.InitMsg,
 	}}
-	assert.Equal(t, expHistory, cInfo.ContractCodeHistory)
-
+	assert.Equal(t, expHistory, wasmKeeper.getContractHistory(ctx, contractAddr))
 }
 
 func TestMigrateProposal(t *testing.T) {
@@ -188,7 +187,7 @@ func TestMigrateProposal(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.MigrateMsg,
 	}}
-	assert.Equal(t, expHistory, cInfo.ContractCodeHistory)
+	assert.Equal(t, expHistory, wasmKeeper.getContractHistory(ctx, contractAddr))
 
 }
 

--- a/x/wasm/internal/keeper/proposal_integration_test.go
+++ b/x/wasm/internal/keeper/proposal_integration_test.go
@@ -110,7 +110,7 @@ func TestInstantiateProposal(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.InitMsg,
 	}}
-	assert.Equal(t, expHistory, wasmKeeper.getContractHistory(ctx, contractAddr))
+	assert.Equal(t, expHistory, wasmKeeper.GetContractHistory(ctx, contractAddr))
 }
 
 func TestMigrateProposal(t *testing.T) {
@@ -187,7 +187,7 @@ func TestMigrateProposal(t *testing.T) {
 		Updated:   types.NewAbsoluteTxPosition(ctx),
 		Msg:       src.MigrateMsg,
 	}}
-	assert.Equal(t, expHistory, wasmKeeper.getContractHistory(ctx, contractAddr))
+	assert.Equal(t, expHistory, wasmKeeper.GetContractHistory(ctx, contractAddr))
 
 }
 

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -35,26 +35,23 @@ type ContractInfoWithAddress struct {
 	Address sdk.AccAddress `json:"address"`
 }
 
-// controls error output on querier - set true when testing/debugging
-const debug = false
-
 // NewQuerier creates a new querier
 func NewQuerier(keeper Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
 		switch path[0] {
 		case QueryGetContract:
-			return queryContractInfo(ctx, path[1], req, keeper)
+			return queryContractInfo(ctx, path[1], keeper)
 		case QueryListContractByCode:
-			return queryContractListByCode(ctx, path[1], req, keeper)
+			return queryContractListByCode(ctx, path[1], keeper)
 		case QueryGetContractState:
 			if len(path) < 3 {
 				return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown data query endpoint")
 			}
 			return queryContractState(ctx, path[1], path[2], req, keeper)
 		case QueryGetCode:
-			return queryCode(ctx, path[1], req, keeper)
+			return queryCode(ctx, path[1], keeper)
 		case QueryListCode:
-			return queryCodeList(ctx, req, keeper)
+			return queryCodeList(ctx, keeper)
 		case QueryContractHistory:
 			return queryContractHistory(ctx, path[1], keeper)
 		default:
@@ -63,7 +60,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 	}
 }
 
-func queryContractInfo(ctx sdk.Context, bech string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+func queryContractInfo(ctx sdk.Context, bech string, keeper Keeper) ([]byte, error) {
 	addr, err := sdk.AccAddressFromBech32(bech)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, err.Error())
@@ -89,7 +86,7 @@ func redact(info *types.ContractInfo) {
 	info.Created = nil
 }
 
-func queryContractListByCode(ctx sdk.Context, codeIDstr string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+func queryContractListByCode(ctx sdk.Context, codeIDstr string, keeper Keeper) ([]byte, error) {
 	codeID, err := strconv.ParseUint(codeIDstr, 10, 64)
 	if err != nil {
 		return nil, err
@@ -165,7 +162,7 @@ type GetCodeResponse struct {
 	Data []byte `json:"data" yaml:"data"`
 }
 
-func queryCode(ctx sdk.Context, codeIDstr string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+func queryCode(ctx sdk.Context, codeIDstr string, keeper Keeper) ([]byte, error) {
 	codeID, err := strconv.ParseUint(codeIDstr, 10, 64)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "invalid codeID: "+err.Error())
@@ -204,7 +201,7 @@ type ListCodeResponse struct {
 	Builder  string           `json:"builder"`
 }
 
-func queryCodeList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, error) {
+func queryCodeList(ctx sdk.Context, keeper Keeper) ([]byte, error) {
 	var info []ListCodeResponse
 
 	var i uint64

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -240,7 +240,6 @@ func queryContractHistory(ctx sdk.Context, bech string, keeper Keeper) ([]byte, 
 	// redact response
 	for i := range entries {
 		entries[i].Updated = nil
-		entries[i].Msg = nil
 	}
 
 	bz, err := json.MarshalIndent(entries, "", "  ")

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -84,10 +84,6 @@ func queryContractInfo(ctx sdk.Context, bech string, req abci.RequestQuery, keep
 // redact clears all fields not in the public api
 func redact(info *types.ContractInfo) {
 	info.Created = nil
-	for i := range info.ContractCodeHistory {
-		info.ContractCodeHistory[i].Updated = nil
-		info.ContractCodeHistory[i].Msg = nil
-	}
 }
 
 func queryContractListByCode(ctx sdk.Context, codeIDstr string, req abci.RequestQuery, keeper Keeper) ([]byte, error) {

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -214,9 +214,5 @@ func TestListContractByCodeOrdering(t *testing.T) {
 		assert.NotEmpty(t, contract.Address)
 		// ensure these are not shown
 		assert.Nil(t, contract.Created)
-		for _, entry := range contract.ContractCodeHistory {
-			assert.Nil(t, entry.Updated)
-			assert.Nil(t, entry.Msg)
-		}
 	}
 }

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -244,6 +244,7 @@ func TestQueryContractHistory(t *testing.T) {
 			expContent: []types.ContractCodeHistoryEntry{{
 				Operation: types.GenesisContractCodeHistoryType,
 				CodeID:    1,
+				Msg:       []byte(`"init message"`),
 			}},
 		},
 		"response with multiple entries": {
@@ -266,12 +267,15 @@ func TestQueryContractHistory(t *testing.T) {
 			expContent: []types.ContractCodeHistoryEntry{{
 				Operation: types.InitContractCodeHistoryType,
 				CodeID:    1,
+				Msg:       []byte(`"init message"`),
 			}, {
 				Operation: types.MigrateContractCodeHistoryType,
 				CodeID:    2,
+				Msg:       []byte(`"migrate message 1"`),
 			}, {
 				Operation: types.MigrateContractCodeHistoryType,
 				CodeID:    3,
+				Msg:       []byte(`"migrate message 2"`),
 			}},
 		},
 		"unknown contract address": {

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -214,5 +215,102 @@ func TestListContractByCodeOrdering(t *testing.T) {
 		assert.NotEmpty(t, contract.Address)
 		// ensure these are not shown
 		assert.Nil(t, contract.Created)
+	}
+}
+
+func TestQueryContractHistory(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	ctx, keepers := CreateTestInput(t, false, tempDir, SupportedFeatures, nil, nil)
+	keeper := keepers.WasmKeeper
+
+	var (
+		otherAddr sdk.AccAddress = bytes.Repeat([]byte{0x2}, sdk.AddrLen)
+	)
+
+	specs := map[string]struct {
+		srcQueryAddr sdk.AccAddress
+		srcHistory   []types.ContractCodeHistoryEntry
+		expContent   []types.ContractCodeHistoryEntry
+	}{
+		"response with internal fields cleared": {
+			srcHistory: []types.ContractCodeHistoryEntry{{
+				Operation: types.GenesisContractCodeHistoryType,
+				CodeID:    1,
+				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Msg:       []byte(`"init message"`),
+			}},
+			expContent: []types.ContractCodeHistoryEntry{{
+				Operation: types.GenesisContractCodeHistoryType,
+				CodeID:    1,
+			}},
+		},
+		"response with multiple entries": {
+			srcHistory: []types.ContractCodeHistoryEntry{{
+				Operation: types.InitContractCodeHistoryType,
+				CodeID:    1,
+				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Msg:       []byte(`"init message"`),
+			}, {
+				Operation: types.MigrateContractCodeHistoryType,
+				CodeID:    2,
+				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Msg:       []byte(`"migrate message 1"`),
+			}, {
+				Operation: types.MigrateContractCodeHistoryType,
+				CodeID:    3,
+				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Msg:       []byte(`"migrate message 2"`),
+			}},
+			expContent: []types.ContractCodeHistoryEntry{{
+				Operation: types.InitContractCodeHistoryType,
+				CodeID:    1,
+			}, {
+				Operation: types.MigrateContractCodeHistoryType,
+				CodeID:    2,
+			}, {
+				Operation: types.MigrateContractCodeHistoryType,
+				CodeID:    3,
+			}},
+		},
+		"unknown contract address": {
+			srcQueryAddr: otherAddr,
+			srcHistory: []types.ContractCodeHistoryEntry{{
+				Operation: types.GenesisContractCodeHistoryType,
+				CodeID:    1,
+				Updated:   types.NewAbsoluteTxPosition(ctx),
+				Msg:       []byte(`"init message"`),
+			}},
+			expContent: nil,
+		},
+	}
+	for msg, spec := range specs {
+		t.Run(msg, func(t *testing.T) {
+			_, _, myContractAddr := keyPubAddr()
+			keeper.appendToContractHistory(ctx, myContractAddr, spec.srcHistory...)
+			q := NewQuerier(keeper)
+			queryContractAddr := spec.srcQueryAddr
+			if queryContractAddr == nil {
+				queryContractAddr = myContractAddr
+			}
+
+			// when
+			query := []string{QueryContractHistory, queryContractAddr.String()}
+			data := abci.RequestQuery{}
+			resData, err := q(ctx, query, data)
+
+			// then
+			require.NoError(t, err)
+			if spec.expContent == nil {
+				require.Nil(t, resData)
+				return
+			}
+			var got []types.ContractCodeHistoryEntry
+			err = json.Unmarshal(resData, &got)
+			require.NoError(t, err)
+
+			assert.Equal(t, spec.expContent, got)
+		})
 	}
 }

--- a/x/wasm/internal/keeper/test_fuzz.go
+++ b/x/wasm/internal/keeper/test_fuzz.go
@@ -27,11 +27,6 @@ func FuzzContractInfo(m *types.ContractInfo, c fuzz.Continue) {
 	FuzzAddr(&m.Admin, c)
 	m.Label = c.RandString()
 	c.Fuzz(&m.Created)
-	historyElements := c.Int() % 128 // 128 should be enough for tests
-	m.ContractCodeHistory = make([]types.ContractCodeHistoryEntry, historyElements)
-	for i := range m.ContractCodeHistory {
-		c.Fuzz(&m.ContractCodeHistory[i])
-	}
 }
 
 func FuzzContractCodeHistory(m *types.ContractCodeHistoryEntry, c fuzz.Continue) {

--- a/x/wasm/internal/types/codec.go
+++ b/x/wasm/internal/types/codec.go
@@ -6,12 +6,12 @@ import (
 
 // RegisterCodec registers the account types and interface
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(&MsgStoreCode{}, "wasm/MsgStoreCode", nil)
-	cdc.RegisterConcrete(&MsgInstantiateContract{}, "wasm/MsgInstantiateContract", nil)
-	cdc.RegisterConcrete(&MsgExecuteContract{}, "wasm/MsgExecuteContract", nil)
-	cdc.RegisterConcrete(&MsgMigrateContract{}, "wasm/MsgMigrateContract", nil)
-	cdc.RegisterConcrete(&MsgUpdateAdmin{}, "wasm/MsgUpdateAdmin", nil)
-	cdc.RegisterConcrete(&MsgClearAdmin{}, "wasm/MsgClearAdmin", nil)
+	cdc.RegisterConcrete(MsgStoreCode{}, "wasm/MsgStoreCode", nil)
+	cdc.RegisterConcrete(MsgInstantiateContract{}, "wasm/MsgInstantiateContract", nil)
+	cdc.RegisterConcrete(MsgExecuteContract{}, "wasm/MsgExecuteContract", nil)
+	cdc.RegisterConcrete(MsgMigrateContract{}, "wasm/MsgMigrateContract", nil)
+	cdc.RegisterConcrete(MsgUpdateAdmin{}, "wasm/MsgUpdateAdmin", nil)
+	cdc.RegisterConcrete(MsgClearAdmin{}, "wasm/MsgClearAdmin", nil)
 
 	cdc.RegisterConcrete(StoreCodeProposal{}, "wasm/StoreCodeProposal", nil)
 	cdc.RegisterConcrete(InstantiateContractProposal{}, "wasm/InstantiateContractProposal", nil)

--- a/x/wasm/internal/types/genesis.go
+++ b/x/wasm/internal/types/genesis.go
@@ -86,9 +86,6 @@ func (c Contract) ValidateBasic() error {
 	if c.ContractInfo.Created != nil {
 		return sdkerrors.Wrap(ErrInvalid, "created must be empty")
 	}
-	if len(c.ContractInfo.ContractCodeHistory) != 0 {
-		return sdkerrors.Wrap(ErrInvalid, "history must be empty")
-	}
 	for i := range c.ContractState {
 		if err := c.ContractState[i].ValidateBasic(); err != nil {
 			return sdkerrors.Wrapf(err, "contract state %d", i)

--- a/x/wasm/internal/types/genesis_test.go
+++ b/x/wasm/internal/types/genesis_test.go
@@ -127,12 +127,6 @@ func TestContractValidateBasic(t *testing.T) {
 			},
 			expError: true,
 		},
-		"contract with history set": {
-			srcMutator: func(c *Contract) {
-				c.ContractInfo.ContractCodeHistory = []ContractCodeHistoryEntry{{}}
-			},
-			expError: true,
-		},
 		"contract state invalid": {
 			srcMutator: func(c *Contract) {
 				c.ContractState = append(c.ContractState, Model{})

--- a/x/wasm/internal/types/keys.go
+++ b/x/wasm/internal/types/keys.go
@@ -31,12 +31,14 @@ const ( // event attributes
 
 // nolint
 var (
-	KeyLastCodeID     = []byte("lastCodeId")
-	KeyLastInstanceID = []byte("lastContractId")
+	CodeKeyPrefix              = []byte{0x01}
+	ContractKeyPrefix          = []byte{0x02}
+	ContractStorePrefix        = []byte{0x03}
+	SequenceKeyPrefix          = []byte{0x04}
+	ContractHistoryStorePrefix = []byte{0x05}
 
-	CodeKeyPrefix       = []byte{0x01}
-	ContractKeyPrefix   = []byte{0x02}
-	ContractStorePrefix = []byte{0x03}
+	KeyLastCodeID     = append(SequenceKeyPrefix, []byte("lastCodeId")...)
+	KeyLastInstanceID = append(SequenceKeyPrefix, []byte("lastContractId")...)
 )
 
 // GetCodeKey constructs the key for retreiving the ID for the WASM code

--- a/x/wasm/internal/types/test_fixtures.go
+++ b/x/wasm/internal/types/test_fixtures.go
@@ -88,7 +88,6 @@ func ContractFixture(mutators ...func(*Contract)) Contract {
 
 func OnlyGenesisFields(info *ContractInfo) {
 	info.Created = nil
-	info.ContractCodeHistory = nil
 }
 
 func ContractInfoFixture(mutators ...func(*ContractInfo)) ContractInfo {

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"encoding/json"
-	"sort"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	tmBytes "github.com/tendermint/tendermint/libs/bytes"
@@ -93,24 +92,19 @@ type ContractInfo struct {
 	Label   string         `json:"label"`
 	// never show this in query results, just use for sorting
 	// (Note: when using json tag "-" amino refused to serialize it...)
-	Created             *AbsoluteTxPosition        `json:"created,omitempty"`
-	ContractCodeHistory []ContractCodeHistoryEntry `json:"contract_code_history,omitempty"`
+	Created *AbsoluteTxPosition `json:"created,omitempty"`
 }
 
-func (c *ContractInfo) AddMigration(ctx sdk.Context, codeID uint64, msg []byte) {
-	h := ContractCodeHistoryEntry{
-		Operation: MigrateContractCodeHistoryType,
-		CodeID:    codeID,
-		Updated:   NewAbsoluteTxPosition(ctx),
-		Msg:       msg,
+// NewContractInfo creates a new instance of a given WASM contract info
+func NewContractInfo(codeID uint64, creator, admin sdk.AccAddress, label string, createdAt *AbsoluteTxPosition) ContractInfo {
+	return ContractInfo{
+		CodeID:  codeID,
+		Creator: creator,
+		Admin:   admin,
+		Label:   label,
+		Created: createdAt,
 	}
-	c.ContractCodeHistory = append(c.ContractCodeHistory, h)
-	sort.Slice(c.ContractCodeHistory, func(i, j int) bool {
-		return c.ContractCodeHistory[i].Updated.LessThan(c.ContractCodeHistory[j].Updated)
-	})
-	c.CodeID = codeID
 }
-
 func (c *ContractInfo) ValidateBasic() error {
 	if c.CodeID == 0 {
 		return sdkerrors.Wrap(ErrEmpty, "code id")
@@ -129,15 +123,34 @@ func (c *ContractInfo) ValidateBasic() error {
 	return nil
 }
 
-// ResetFromGenesis resets contracts timestamp and history.
-func (c *ContractInfo) ResetFromGenesis(ctx sdk.Context) {
-	c.Created = NewAbsoluteTxPosition(ctx)
+func (c ContractInfo) InitialHistory(initMsg []byte) ContractCodeHistoryEntry {
+	return ContractCodeHistoryEntry{
+		Operation: InitContractCodeHistoryType,
+		CodeID:    c.CodeID,
+		Updated:   c.Created,
+		Msg:       initMsg,
+	}
+}
+
+func (c *ContractInfo) AddMigration(ctx sdk.Context, codeID uint64, msg []byte) ContractCodeHistoryEntry {
 	h := ContractCodeHistoryEntry{
+		Operation: MigrateContractCodeHistoryType,
+		CodeID:    codeID,
+		Updated:   NewAbsoluteTxPosition(ctx),
+		Msg:       msg,
+	}
+	c.CodeID = codeID
+	return h
+}
+
+// ResetFromGenesis resets contracts timestamp and history.
+func (c *ContractInfo) ResetFromGenesis(ctx sdk.Context) ContractCodeHistoryEntry {
+	c.Created = NewAbsoluteTxPosition(ctx)
+	return ContractCodeHistoryEntry{
 		Operation: GenesisContractCodeHistoryType,
 		CodeID:    c.CodeID,
 		Updated:   c.Created,
 	}
-	c.ContractCodeHistory = []ContractCodeHistoryEntry{h}
 }
 
 // AbsoluteTxPosition can be used to sort contracts
@@ -170,23 +183,6 @@ func NewAbsoluteTxPosition(ctx sdk.Context) *AbsoluteTxPosition {
 	return &AbsoluteTxPosition{
 		BlockHeight: ctx.BlockHeight(),
 		TxIndex:     index,
-	}
-}
-
-// NewContractInfo creates a new instance of a given WASM contract info
-func NewContractInfo(codeID uint64, creator, admin sdk.AccAddress, initMsg []byte, label string, createdAt *AbsoluteTxPosition) ContractInfo {
-	return ContractInfo{
-		CodeID:  codeID,
-		Creator: creator,
-		Admin:   admin,
-		Label:   label,
-		Created: createdAt,
-		ContractCodeHistory: []ContractCodeHistoryEntry{{
-			Operation: InitContractCodeHistoryType,
-			CodeID:    codeID,
-			Updated:   createdAt,
-			Msg:       initMsg,
-		}},
 	}
 }
 

--- a/x/wasm/internal/types/types.go
+++ b/x/wasm/internal/types/types.go
@@ -77,6 +77,7 @@ const (
 
 var AllCodeHistoryTypes = []ContractCodeHistoryOperationType{InitContractCodeHistoryType, MigrateContractCodeHistoryType}
 
+// ContractCodeHistoryEntry stores code updates to a contract.
 type ContractCodeHistoryEntry struct {
 	Operation ContractCodeHistoryOperationType `json:"operation"`
 	CodeID    uint64                           `json:"code_id"`


### PR DESCRIPTION
Resolves #196 
After #199 

Includes new CLI command: 
`wasmcli query wasm contract-history [bech32_address]` to print all the code changes.
```json
wasmcli q wasm contract-history cosmos18r5szma8hm93pvx6lwpjwyxruw27e0k5uw835c
[
  {
    "operation": "Init",
    "code_id": 1
  },
  {
    "operation": "Migrate",
    "code_id": 2
  }
]
```

Note: to be on the safe side sequences have their own prefix as well.

**This PR also updates the codec to fix the message decoding issue.**
______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))