### PR TITLE
fixed recursive queries losing context

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -82,7 +82,7 @@ func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspa
 		authZPolicy:   DefaultAuthorizationPolicy{},
 		paramSpace:    paramSpace,
 	}
-	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, keeper).Merge(customPlugins)
+	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, &keeper).Merge(customPlugins)
 	return keeper
 }
 

--- a/x/wasm/internal/keeper/query_plugins.go
+++ b/x/wasm/internal/keeper/query_plugins.go
@@ -46,7 +46,7 @@ type QueryPlugins struct {
 	Wasm    func(ctx sdk.Context, request *wasmTypes.WasmQuery) ([]byte, error)
 }
 
-func DefaultQueryPlugins(bank bank.ViewKeeper, staking staking.Keeper, wasm Keeper) QueryPlugins {
+func DefaultQueryPlugins(bank bank.ViewKeeper, staking staking.Keeper, wasm *Keeper) QueryPlugins {
 	return QueryPlugins{
 		Bank:    BankQuerier(bank),
 		Custom:  NoCustomQuerier,
@@ -225,7 +225,7 @@ func sdkToFullDelegation(ctx sdk.Context, keeper staking.Keeper, delegation stak
 	}, nil
 }
 
-func WasmQuerier(wasm Keeper) func(ctx sdk.Context, request *wasmTypes.WasmQuery) ([]byte, error) {
+func WasmQuerier(wasm *Keeper) func(ctx sdk.Context, request *wasmTypes.WasmQuery) ([]byte, error) {
 	return func(ctx sdk.Context, request *wasmTypes.WasmQuery) ([]byte, error) {
 		if request.Smart != nil {
 			addr, err := sdk.AccAddressFromBech32(request.Smart.ContractAddr)


### PR DESCRIPTION
This PR fixes an issue where performing recursive Smart Queries would fail on the second recursion, because `keeper.queryPlugins` would be uninitialized. The problem was that `DefaultQueryPlugins` and `WasmQuerier` were getting partially initialized copies of the keeper object, and would try to use the partly initialized copy instead of the concrete object.
In our testing in SecretNetwork, this fix allowed us to recurse queries multiple times (x >= 5) :)

CC: @assafmo 