### PR TITLE
removed reseting of gas meter each time we enter a query

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -397,8 +397,6 @@ func (k Keeper) GetContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress)
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: query")
 
-	ctx = ctx.WithGasMeter(sdk.NewGasMeter(k.queryGasLimit))
-
 	codeInfo, prefixStore, err := k.contractInstance(ctx, contractAddr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR removes a line that was reseting the gas meter for each query, which meant that recursive queries would not report any gas usage, since it would be charged on a new meter, which the caller has no access to.
We now observe that gas is charged for external queries.
I expect some tests will fail after this first commit. Let;s see if they do. Are there tests that run such contract-to-contract queries?