### PR TITLE
Fix gas calculation on QuerySmart

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -399,8 +399,6 @@ func (k Keeper) GetContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress)
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: query")
 
-	ctx = ctx.WithGasMeter(sdk.NewGasMeter(k.queryGasLimit))
-
 	codeInfo, prefixStore, err := k.contractInstance(ctx, contractAddr)
 	if err != nil {
 		return nil, err

--- a/x/wasm/internal/keeper/querier.go
+++ b/x/wasm/internal/keeper/querier.go
@@ -144,6 +144,8 @@ func queryContractState(ctx sdk.Context, bech, queryMethod string, req abci.Requ
 		// this returns a serialized json object
 		resultData = keeper.QueryRaw(ctx, contractAddr, req.Data)
 	case QueryMethodContractStateSmart:
+		// we enforce a subjective gas limit on all queries to avoid infinite loops
+		ctx = ctx.WithGasMeter(sdk.NewGasMeter(keeper.queryGasLimit))
 		// this returns raw bytes (must be base64-encoded)
 		return keeper.QuerySmart(ctx, contractAddr, req.Data)
 	default:

--- a/x/wasm/internal/keeper/recurse_test.go
+++ b/x/wasm/internal/keeper/recurse_test.go
@@ -1,0 +1,107 @@
+package keeper
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Recurse struct {
+	Depth    uint32         `json:"depth"`
+	Work     uint32         `json:"work"`
+	Contract sdk.AccAddress `json:"contract"`
+}
+
+type recurseWrapper struct {
+	Recurse Recurse `json:"recurse"`
+}
+
+func buildQuery(t *testing.T, msg Recurse) []byte {
+	wrapper := recurseWrapper{Recurse: msg}
+	bz, err := json.Marshal(wrapper)
+	require.NoError(t, err)
+	return bz
+}
+
+type recurseResponse struct {
+	Hashed []byte `json:"hashed"`
+}
+
+func TestGasCostOnQuery(t *testing.T) {
+	cases := map[string]struct {
+		gasLimit uint64
+		msg      Recurse
+	}{
+		"no recursion, no work": {
+			gasLimit: 400_000,
+			msg:      Recurse{},
+		},
+		"no recursion, some work": {
+			gasLimit: 400_000,
+			msg: Recurse{
+				Work: 5, // 5 rounds of sha256 inside the contract
+			},
+		},
+	}
+
+	// we do one basic setup before all test cases (which are read-only and don't change state)
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	ctx, keepers := CreateTestInput(t, false, tempDir, SupportedFeatures, nil, nil)
+	accKeeper, keeper := keepers.AccountKeeper, keepers.WasmKeeper
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit.Add(deposit...))
+
+	// store the code
+	wasmCode, err := ioutil.ReadFile("./testdata/contract.wasm")
+	require.NoError(t, err)
+	codeID, err := keeper.Create(ctx, creator, wasmCode, "", "", nil)
+	require.NoError(t, err)
+
+	// instantiate the contract
+	_, _, bob := keyPubAddr()
+	_, _, fred := keyPubAddr()
+	initMsg := InitMsg{
+		Verifier:    fred,
+		Beneficiary: bob,
+	}
+	initMsgBz, err := json.Marshal(initMsg)
+	require.NoError(t, err)
+	contractAddr, err := keeper.Instantiate(ctx, codeID, creator, nil, initMsgBz, "recursive contract", deposit)
+	require.NoError(t, err)
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			// make sure we set a limit before calling
+			ctx = ctx.WithGasMeter(sdk.NewGasMeter(tc.gasLimit))
+			require.Equal(t, uint64(0), ctx.GasMeter().GasConsumed())
+
+			recurse := tc.msg
+			recurse.Contract = contractAddr
+			msg := buildQuery(t, recurse)
+
+			// this should throw out of gas exception (panic)
+			data, err := keeper.QuerySmart(ctx, contractAddr, msg)
+			require.NoError(t, err)
+			var resp recurseResponse
+			err = json.Unmarshal(data, &resp)
+			require.NoError(t, err)
+
+			// TODO: assert result? - now just that it is 32 byte sha256 hash (or contractAddr if no hash)
+			if recurse.Work == 0 {
+				assert.Equal(t, len(resp.Hashed), len(creator.String()))
+			} else {
+				assert.Equal(t, len(resp.Hashed), 32)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Inspired by and replaces #216 

* We only enforce the query gas limit (with a different context) when calling in from external queries (see Querier)
* Add tests that queries charge gas
* Add tests that queries charge gas when recusing one level
* Add tests that recursing 4 times doesn't cause errors (fixed in #213 but lacking tests)

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/gaia/blob/master/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))