### PR TITLE
Round up in consumeGas

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -569,7 +569,7 @@ func gasForContract(ctx sdk.Context) uint64 {
 }
 
 func consumeGas(ctx sdk.Context, gas uint64) {
-	consumed := gas / GasMultiplier
+	consumed := (gas / GasMultiplier) + 1
 	ctx.GasMeter().ConsumeGas(consumed, "wasm contract")
 	// throw OutOfGas error if we ran out (got exactly to zero due to better limit enforcing)
 	if ctx.GasMeter().IsOutOfGas() {


### PR DESCRIPTION
This makes for a much more consistent behavior. Now out-of-gas inside of WASM will result in out-of-gas in cosmos instead of returning an "out of gas" string to the user.
If `gas_used == gas_limit`, cosmos doesn't throw an out of gas and instead an StdError with an "out of gas" string returns to the user. 