### PR TITLE
Restrict querier redispatched gas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.13
 
 require (
-	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb
+	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4
 	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/google/gofuzz v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.13
 
 require (
-	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2
+	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3
 	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/google/gofuzz v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.13
 
 require (
-	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3
+	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb
 	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/google/gofuzz v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2 h1:k069wQF0f24w3A52mjR3AK6AfkuvQ5
 github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3 h1:+LJxN6oHNdHDoB9JT8v6Zh373MvBbFkKoikSnh4GGWM=
 github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb h1:JHeFb9Dle3c3RvXkxZbo6YURaS3aQf+7zdUn5P3TP04=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2 h1:k069wQF0f24w3A52mjR3AK6AfkuvQ5d0Mdu/rpB5nEk=
 github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3 h1:+LJxN6oHNdHDoB9JT8v6Zh373MvBbFkKoikSnh4GGWM=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/go.sum
+++ b/go.sum
@@ -9,12 +9,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2 h1:k069wQF0f24w3A52mjR3AK6AfkuvQ5d0Mdu/rpB5nEk=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha2/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3 h1:+LJxN6oHNdHDoB9JT8v6Zh373MvBbFkKoikSnh4GGWM=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb h1:JHeFb9Dle3c3RvXkxZbo6YURaS3aQf+7zdUn5P3TP04=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha3.0.20200729195610-18b861d95ddb/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4 h1:1a3j/vdhnyYvUV+67Hg3GU87M9wn1jR6bReXDwy+TZQ=
+github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -42,6 +42,9 @@ const InstanceCost uint64 = 40_000
 // CompileCost is how much SDK gas we charge *per byte* for compiling WASM code.
 const CompileCost uint64 = 2
 
+// TODO: remove this - this is just for one test
+var TimesQueryCalled int = 0
+
 // Keeper will have a reference to Wasmer with it's own data directory.
 type Keeper struct {
 	storeKey      sdk.StoreKey
@@ -398,6 +401,7 @@ func (k Keeper) GetContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress)
 // QuerySmart queries the smart contract itself.
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: query")
+	TimesQueryCalled++
 
 	codeInfo, prefixStore, err := k.contractInstance(ctx, contractAddr)
 	if err != nil {

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -42,9 +42,6 @@ const InstanceCost uint64 = 40_000
 // CompileCost is how much SDK gas we charge *per byte* for compiling WASM code.
 const CompileCost uint64 = 2
 
-// TODO: remove this - this is just for one test
-var TimesQueryCalled int = 0
-
 // Keeper will have a reference to Wasmer with it's own data directory.
 type Keeper struct {
 	storeKey      sdk.StoreKey
@@ -401,7 +398,6 @@ func (k Keeper) GetContractHistory(ctx sdk.Context, contractAddr sdk.AccAddress)
 // QuerySmart queries the smart contract itself.
 func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []byte) ([]byte, error) {
 	ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: query")
-	TimesQueryCalled++
 
 	codeInfo, prefixStore, err := k.contractInstance(ctx, contractAddr)
 	if err != nil {

--- a/x/wasm/internal/keeper/recurse_test.go
+++ b/x/wasm/internal/keeper/recurse_test.go
@@ -314,7 +314,8 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			// if we expect out of gas, make sure this panics
 			if tc.expectOutOfGas {
 				require.Panics(t, func() {
-					_, _ = keeper.QuerySmart(ctx, contractAddr, msg)
+					_, err := keeper.QuerySmart(ctx, contractAddr, msg)
+					t.Logf("Got error not panic: %#v", err)
 				})
 				assert.Equal(t, tc.expectQueriesFromContract, totalWasmQueryCounter)
 				return

--- a/x/wasm/internal/keeper/recurse_test.go
+++ b/x/wasm/internal/keeper/recurse_test.go
@@ -35,7 +35,6 @@ type recurseResponse struct {
 	Hashed []byte `json:"hashed"`
 }
 
-
 // number os wasm queries called from a contract
 var totalWasmQueryCounter int
 
@@ -228,7 +227,8 @@ func TestGasOnExternalQuery(t *testing.T) {
 			if tc.expectPanic {
 				require.Panics(t, func() {
 					// this should run out of gas
-					_, _ = NewQuerier(keeper)(ctx, path, req)
+					_, err := NewQuerier(keeper)(ctx, path, req)
+					t.Logf("%v", err)
 				})
 			} else {
 				// otherwise, make sure we get a good success
@@ -280,7 +280,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			expectedGas:               GasWork2k + 5*(GasWork2k+GasReturnHashed),
 		},
 		// this is where we expect an error...
-		// it has enough gas to run 4 times and die on the 5th
+		// it has enough gas to run 4 times and die on the 5th (4th time dispatching to sub-contract)
 		// however, if we don't charge the cpu gas before sub-dispatching, we can recurse over 20 times
 		// TODO: figure out how to asset how deep it went
 		"deep recursion, should die on 5th level": {
@@ -289,7 +289,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 				Depth: 50,
 				Work:  2000,
 			},
-			expectQueriesFromContract: 5,
+			expectQueriesFromContract: 4,
 			expectOutOfGas:            true,
 		},
 	}


### PR DESCRIPTION
Closes https://github.com/CosmWasm/cosmwasm/issues/456

So far this just adds a test to see when the recursive queries stop. I am not sure how to assert the depth that it hits before
the panic, as the output is panic in both times. The only difference is if it calls Query 5 times or 23 times. 

@alpe Any ideas how to test this better?