### PR TITLE
Update to 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 This repository hosts `Wasmd`, the first implementation of a cosmos zone with wasm smart contracts enabled.
 
-This code was forked from the `cosmos/gaia` repository and the majority of the codebase is the same as `gaia`.
+This code was forked from the `cosmos/gaia` repository as a basis and then we added `x/wasm` and cleaned up 
+many gaia-specific files. However, the `wasmd` binary should function just like `gaiad` except for the
+addition of the `x/wasm` module.
 
 **Note**: Requires [Go 1.13+](https://golang.org/dl/)
-
-**Compatibility**: Last merge from `cosmos/gaia` was `090c545347b03e59415a18107a0a279c703c8f40` (Jan 23, 2020)
 
 ## Supported Systems
 
@@ -38,16 +38,21 @@ and everything with `v0.7.x` tags is compatible with each other.
 We will have a series of minor version updates prior to `v1.0.0`, 
 where we offer strong backwards compatibility guarantees. 
 
-We are currently on `v0.9` and targeting `v0.10` for late July, at which point
-we will have feature freeze for the `v1` tag and only perform needed bugfixes
-(which may be API breaking).
+We released `v0.10` on  July 31, 2020, and have a `v1.0` feature freeze now.
+We will be performing bug fixes, security patches, and performance improvements,
+but the API should be stable and compatible with `v1.0`.
 
 Thank you to all projects who have run this code in your testnets and
 given feedback to improve stability.
 
 ## Encoding
 
-We use standard cosmos-sdk encoding (amino) for all sdk Messages. However, the message body sent to all contracts, as well as the internal state is encoded using JSON. Cosmwasm allows arbitrary bytes with the contract itself responsible for decodng. For better UX, we often use `json.RawMessage` to contain these bytes, which enforces that it is valid json, but also give a much more readable interface.  If you want to use another encoding in the contracts, that is a relatively minor change to wasmd but would currently require a fork. Please open in issue if this is important for your use case.
+We use standard cosmos-sdk encoding (amino) for all sdk Messages. However, the message body sent to all contracts, 
+as well as the internal state is encoded using JSON. Cosmwasm allows arbitrary bytes with the contract itself 
+responsible for decodng. For better UX, we often use `json.RawMessage` to contain these bytes, which enforces that it is
+valid json, but also give a much more readable interface.  If you want to use another encoding in the contracts, that is
+a relatively minor change to wasmd but would currently require a fork. Please open in issue if this is important for 
+your use case.
 
 ## Quick Start
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.13
 
 require (
-	github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4
+	github.com/CosmWasm/go-cosmwasm v0.10.0
 	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/google/gofuzz v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4 h1:1a3j/vdhnyYvUV+67Hg3GU87M9wn1jR6bReXDwy+TZQ=
-github.com/CosmWasm/go-cosmwasm v0.10.0-alpha4/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
+github.com/CosmWasm/go-cosmwasm v0.10.0 h1:3DBOiGtLllevLgf8PQO5+hRCKKqYEQJIw6cgaZzr1Ag=
+github.com/CosmWasm/go-cosmwasm v0.10.0/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=


### PR DESCRIPTION
This updated to `go-cosmwasm` `v0.10.0` and some README changes. This can be our official v0.10.0 release of `wasmd`