### PR TITLE
Wasm querier integration tests

### DIFF
--- a/x/wasm/internal/keeper/recurse_test.go
+++ b/x/wasm/internal/keeper/recurse_test.go
@@ -24,7 +24,7 @@ type recurseWrapper struct {
 	Recurse Recurse `json:"recurse"`
 }
 
-func buildQuery(t *testing.T, msg Recurse) []byte {
+func buildRecurseQuery(t *testing.T, msg Recurse) []byte {
 	wrapper := recurseWrapper{Recurse: msg}
 	bz, err := json.Marshal(wrapper)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestGasCostOnQuery(t *testing.T) {
 			// do the query
 			recurse := tc.msg
 			recurse.Contract = contractAddr
-			msg := buildQuery(t, recurse)
+			msg := buildRecurseQuery(t, recurse)
 			data, err := keeper.QuerySmart(ctx, contractAddr, msg)
 			require.NoError(t, err)
 
@@ -219,7 +219,7 @@ func TestGasOnExternalQuery(t *testing.T) {
 
 			recurse := tc.msg
 			recurse.Contract = contractAddr
-			msg := buildQuery(t, recurse)
+			msg := buildRecurseQuery(t, recurse)
 
 			// do the query
 			path := []string{QueryGetContractState, contractAddr.String(), QueryMethodContractStateSmart}
@@ -310,7 +310,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			// prepare the query
 			recurse := tc.msg
 			recurse.Contract = contractAddr
-			msg := buildQuery(t, recurse)
+			msg := buildRecurseQuery(t, recurse)
 
 			// if we expect out of gas, make sure this panics
 			if tc.expectOutOfGas {

--- a/x/wasm/internal/keeper/reflect_test.go
+++ b/x/wasm/internal/keeper/reflect_test.go
@@ -316,7 +316,6 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 
 	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
 	creator := createFakeFundedAccount(ctx, accKeeper, deposit)
-	//_, _, bob := keyPubAddr()
 
 	// upload mask code
 	maskCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
@@ -339,10 +338,10 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 	mustParse(t, res, &ownerRes)
 	require.Equal(t, ownerRes.Owner, creator.String())
 
-	// and a raw query
+	// and a raw query: cosmwasm_storage::Singleton uses 2 byte big-endian length-prefixed to store data
 	configKey := append([]byte{0, 6}, []byte("config")...)
 	models := keeper.QueryRaw(ctx, maskAddr, configKey)
-	require.Equal(t, 1, len(models))
+	require.Len(t, models, 1)
 	var stateRes maskState
 	mustParse(t, models[0].Value, &stateRes)
 	require.Equal(t, stateRes.Owner, []byte(creator))
@@ -380,7 +379,7 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 	// this returns []Model... we need to parse this to actually get the key-value info
 	var reflectModels []types.Model
 	mustParse(t, reflectRawRes.Data, &reflectModels)
-	require.Equal(t, 1, len(reflectModels))
+	require.Len(t, reflectModels, 1)
 	// now, with the raw data, we can parse it into state
 	var reflectStateRes maskState
 	mustParse(t, reflectModels[0].Value, &reflectStateRes)

--- a/x/wasm/internal/keeper/staking_test.go
+++ b/x/wasm/internal/keeper/staking_test.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/json"
-	"fmt"
 	wasmTypes "github.com/CosmWasm/go-cosmwasm/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
@@ -417,8 +416,7 @@ func TestQueryStakingInfo(t *testing.T) {
 	// initial checks of bonding state
 	val, found := stakingKeeper.GetValidator(ctx, valAddr)
 	require.True(t, found)
-	//initPower := val.GetDelegatorShares()
-	assert.Equal(t, val.Tokens, sdk.NewInt(1000000), "%s", val.Tokens)
+	assert.Equal(t, sdk.NewInt(1000000), val.Tokens)
 
 	// full is 2x funds, 1x goes to the contract, other stays on his wallet
 	full := sdk.NewCoins(sdk.NewInt64Coin("stake", 400000))
@@ -469,7 +467,7 @@ func TestQueryStakingInfo(t *testing.T) {
 	mustParse(t, res, &reflectRes)
 	var validatorRes wasmTypes.ValidatorsResponse
 	mustParse(t, reflectRes.Data, &validatorRes)
-	require.Equal(t, 1, len(validatorRes.Validators))
+	require.Len(t, validatorRes.Validators, 1)
 	valInfo := validatorRes.Validators[0]
 	// Note: this ValAddress not AccAddress, may change with #264
 	require.Equal(t, valAddr.String(), valInfo.Address)
@@ -490,9 +488,8 @@ func TestQueryStakingInfo(t *testing.T) {
 	mustParse(t, res, &reflectRes)
 	var allDelegationsRes wasmTypes.AllDelegationsResponse
 	mustParse(t, reflectRes.Data, &allDelegationsRes)
-	require.Equal(t, 1, len(allDelegationsRes.Delegations))
+	require.Len(t, allDelegationsRes.Delegations, 1)
 	delInfo := allDelegationsRes.Delegations[0]
-	fmt.Printf("%#v\n", delInfo)
 	// Note: this ValAddress not AccAddress, may change with #264
 	require.Equal(t, valAddr.String(), delInfo.Validator)
 	// note this is not bob (who staked to the contract), but the contract itself

--- a/x/wasm/internal/keeper/staking_test.go
+++ b/x/wasm/internal/keeper/staking_test.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"encoding/json"
+	"fmt"
+	wasmTypes "github.com/CosmWasm/go-cosmwasm/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/staking"
@@ -402,6 +404,80 @@ func TestReinvest(t *testing.T) {
 	assertBalance(t, ctx, keeper, contractAddr, initInfo.creator, "0")
 	assertClaims(t, ctx, keeper, contractAddr, bob, "0")
 	assertSupply(t, ctx, keeper, contractAddr, "200000", sdk.NewInt64Coin("stake", 236000))
+}
+
+func TestQueryStakingInfo(t *testing.T) {
+	// STEP 1: take a lot of setup from TestReinvest so we have non-zero info
+	initInfo := initializeStaking(t)
+	defer initInfo.cleanup()
+	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr
+	keeper, stakingKeeper, accKeeper := initInfo.wasmKeeper, initInfo.stakingKeeper, initInfo.accKeeper
+	distKeeper := initInfo.distKeeper
+
+	// initial checks of bonding state
+	val, found := stakingKeeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	//initPower := val.GetDelegatorShares()
+	assert.Equal(t, val.Tokens, sdk.NewInt(1000000), "%s", val.Tokens)
+
+	// full is 2x funds, 1x goes to the contract, other stays on his wallet
+	full := sdk.NewCoins(sdk.NewInt64Coin("stake", 400000))
+	funds := sdk.NewCoins(sdk.NewInt64Coin("stake", 200000))
+	bob := createFakeFundedAccount(ctx, accKeeper, full)
+
+	// we will stake 200k to a validator with 1M self-bond
+	// this means we should get 1/6 of the rewards
+	bond := StakingHandleMsg{
+		Bond: &struct{}{},
+	}
+	bondBz, err := json.Marshal(bond)
+	require.NoError(t, err)
+	_, err = keeper.Execute(ctx, contractAddr, bob, bondBz, funds)
+	require.NoError(t, err)
+
+	// update height a bit to solidify the delegation
+	ctx = nextBlock(ctx, stakingKeeper)
+	// we get 1/6, our share should be 40k minus 10% commission = 36k
+	setValidatorRewards(ctx, stakingKeeper, distKeeper, valAddr, "240000")
+
+	// STEP 2: Prepare the mask contract
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit)
+
+	// upload mask code
+	maskCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	require.NoError(t, err)
+	maskID, err := keeper.Create(ctx, creator, maskCode, "", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), maskID)
+
+	// creator instantiates a contract and gives it tokens
+	maskAddr, err := keeper.Instantiate(ctx, maskID, creator, nil, []byte("{}"), "mask contract 2", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, maskAddr)
+
+	// STEP 3: now, let's reflect some queries.
+	// now, let's reflect a smart query into the x/wasm handlers and see if we get the same result
+	reflectValidatorsQuery := MaskQueryMsg{Chain: &ChainQuery{Request: &wasmTypes.QueryRequest{Staking: &wasmTypes.StakingQuery{
+		Validators: &wasmTypes.ValidatorsQuery{},
+	}}}}
+	reflectValidatorsBin := buildMaskQuery(t, &reflectValidatorsQuery)
+	res, err := keeper.QuerySmart(ctx, maskAddr, reflectValidatorsBin)
+	require.NoError(t, err)
+	// first we pull out the data from chain response, before parsing the original response
+	var reflectRes ChainResponse
+	mustParse(t, res, &reflectRes)
+	var validatorRes wasmTypes.ValidatorsResponse
+	mustParse(t, reflectRes.Data, &validatorRes)
+	require.Equal(t, 1, len(validatorRes.Validators))
+	valInfo := validatorRes.Validators[0]
+	// Note: this ValAddress not AccAddress, may change with #264
+	require.Equal(t, valAddr.String(), valInfo.Address)
+	require.Contains(t, valInfo.Commission, "0.100")
+	require.Contains(t, valInfo.MaxCommission, "0.200")
+	require.Contains(t, valInfo.MaxChangeRate, "0.010")
+
+	// TODO: more delegation queries
 }
 
 // adds a few validators and returns a list of validators that are registered


### PR DESCRIPTION
Closes #269 

- [x] Test `WasmQuery::Smart` and `WasmQuery::Raw` via 
- [x] Test basic staking queries with reflect contract

Not done:
-  Update docs explaining how to parse RawQuery (maybe update types in CosmWasm? maybe change from this `[]{Key, Value}` return value...) - this is moved to #275 
