### PR TITLE
Better calculation of Delegation data

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -299,7 +299,10 @@ func NewWasmApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
 	supportedFeatures := "staking"
-	app.wasmKeeper = wasm.NewKeeper(app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName], app.accountKeeper, app.bankKeeper, app.stakingKeeper, wasmRouter, wasmDir, wasmConfig, supportedFeatures, nil, nil)
+	app.wasmKeeper = wasm.NewKeeper(
+		app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName], app.accountKeeper,
+		app.bankKeeper, app.stakingKeeper, app.distrKeeper, wasmRouter, wasmDir, wasmConfig,
+		supportedFeatures, nil, nil)
 
 	// The gov proposal types can be individually enabled
 	if len(enabledProposals) != 0 {

--- a/x/wasm/internal/keeper/genesis_test.go
+++ b/x/wasm/internal/keeper/genesis_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -496,7 +497,7 @@ func setupKeeper(t *testing.T) (Keeper, sdk.Context, []sdk.StoreKey, func()) {
 	cdc := MakeTestCodec()
 	pk := params.NewKeeper(cdc, keyParams, tkeyParams)
 	wasmConfig := wasmTypes.DefaultWasmConfig()
-	srcKeeper := NewKeeper(cdc, keyWasm, pk.Subspace(wasmTypes.DefaultParamspace), auth.AccountKeeper{}, nil, staking.Keeper{}, nil, tempDir, wasmConfig, "", nil, nil)
+	srcKeeper := NewKeeper(cdc, keyWasm, pk.Subspace(wasmTypes.DefaultParamspace), auth.AccountKeeper{}, nil, staking.Keeper{}, distribution.Keeper{}, nil, tempDir, wasmConfig, "", nil, nil)
 	srcKeeper.setParams(ctx, wasmTypes.DefaultParams())
 
 	return srcKeeper, ctx, []sdk.StoreKey{keyWasm, keyParams}, cleanup

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"encoding/binary"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"path/filepath"
 
 	"github.com/cosmos/cosmos-sdk/x/params/subspace"
@@ -61,7 +62,7 @@ type Keeper struct {
 // NewKeeper creates a new contract Keeper instance
 // If customEncoders is non-nil, we can use this to override some of the message handler, especially custom
 func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspace, accountKeeper auth.AccountKeeper, bankKeeper bank.Keeper,
-	stakingKeeper staking.Keeper,
+	stakingKeeper staking.Keeper, distKeeper distribution.Keeper,
 	router sdk.Router, homeDir string, wasmConfig types.WasmConfig, supportedFeatures string, customEncoders *MessageEncoders, customPlugins *QueryPlugins) Keeper {
 	wasmer, err := wasm.NewWasmer(filepath.Join(homeDir, "wasm"), supportedFeatures)
 	if err != nil {
@@ -84,7 +85,7 @@ func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, paramSpace params.Subspa
 		authZPolicy:   DefaultAuthorizationPolicy{},
 		paramSpace:    paramSpace,
 	}
-	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, &keeper).Merge(customPlugins)
+	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, &keeper).Merge(customPlugins)
 	return keeper
 }
 

--- a/x/wasm/internal/keeper/query_plugins.go
+++ b/x/wasm/internal/keeper/query_plugins.go
@@ -260,7 +260,10 @@ func getAccumulatedRewards(ctx sdk.Context, distKeeper distribution.Keeper, dele
 		return nil, err
 	}
 	req := abci.RequestQuery{Data: data}
-	qres, err := distribution.NewQuerier(distKeeper)(ctx, []string{distribution.QueryDelegationRewards}, req)
+
+	// just to be safe... ensure we do not accidentally write in the querier (which does some funky things)
+	cache, _ := ctx.CacheContext()
+	qres, err := distribution.NewQuerier(distKeeper)(cache, []string{distribution.QueryDelegationRewards}, req)
 	if err != nil {
 		return nil, err
 	}

--- a/x/wasm/internal/keeper/query_plugins.go
+++ b/x/wasm/internal/keeper/query_plugins.go
@@ -220,6 +220,7 @@ func sdkToFullDelegation(ctx sdk.Context, keeper staking.Keeper, distKeeper dist
 	delegationCoins := convertSdkCoinToWasmCoin(amount)
 
 	// FIXME: this is very rough but better than nothing...
+	// https://github.com/CosmWasm/wasmd/issues/282
 	// if this (val, delegate) pair is receiving a redelegation, it cannot redelegate more
 	// otherwise, it can redelegate the full amount
 	// (there are cases of partial funds redelegated, but this is a start)
@@ -238,13 +239,11 @@ func sdkToFullDelegation(ctx sdk.Context, keeper staking.Keeper, distKeeper dist
 	}
 
 	return &wasmTypes.FullDelegation{
-		Delegator: delegation.DelegatorAddress.String(),
-		Validator: delegation.ValidatorAddress.String(),
-		Amount:    delegationCoins,
-		// TODO: AccumulatedRewards
+		Delegator:          delegation.DelegatorAddress.String(),
+		Validator:          delegation.ValidatorAddress.String(),
+		Amount:             delegationCoins,
 		AccumulatedRewards: accRewards,
-		// TODO: Determine redelegate
-		CanRedelegate: redelegateCoins,
+		CanRedelegate:      redelegateCoins,
 	}, nil
 }
 
@@ -274,13 +273,12 @@ func getAccumulatedRewards(ctx sdk.Context, distKeeper distribution.Keeper, dele
 	// **** all this above should be ONE method call
 
 	// now we have it, convert it into wasmTypes
-	var rewards []wasmTypes.Coin
-	for _, r := range decRewards {
-		c := wasmTypes.Coin{
+	rewards := make([]wasmTypes.Coin, len(decRewards))
+	for i, r := range decRewards {
+		rewards[i] = wasmTypes.Coin{
 			Denom:  r.Denom,
 			Amount: r.Amount.TruncateInt().String(),
 		}
-		rewards = append(rewards, c)
 	}
 	return rewards, nil
 }

--- a/x/wasm/internal/keeper/staking_test.go
+++ b/x/wasm/internal/keeper/staking_test.go
@@ -535,7 +535,6 @@ func TestQueryStakingInfo(t *testing.T) {
 	require.Equal(t, funds[0].Denom, delInfo2.Amount.Denom)
 	require.Equal(t, funds[0].Amount.String(), delInfo2.Amount.Amount)
 
-	// TODO: fix this - these should return real values!!! Issue #263
 	require.Equal(t, wasmTypes.NewCoin(200000, "stake"), delInfo2.CanRedelegate)
 	require.Len(t, delInfo2.AccumulatedRewards, 1)
 	// see bonding above to see how we calculate 36000 (240000 / 6 - 10% commission)

--- a/x/wasm/internal/keeper/staking_test.go
+++ b/x/wasm/internal/keeper/staking_test.go
@@ -369,7 +369,7 @@ func TestReinvest(t *testing.T) {
 	// we get 1/6, our share should be 40k minus 10% commission = 36k
 	setValidatorRewards(ctx, stakingKeeper, distKeeper, valAddr, "240000")
 
-	// this should withdraw our outstanding 40k of rewards and reinvest them in the same delegation
+	// this should withdraw our outstanding 36k of rewards and reinvest them in the same delegation
 	reinvest := StakingHandleMsg{
 		Reinvest: &struct{}{},
 	}
@@ -536,8 +536,10 @@ func TestQueryStakingInfo(t *testing.T) {
 	require.Equal(t, funds[0].Amount.String(), delInfo2.Amount.Amount)
 
 	// TODO: fix this - these should return real values!!! Issue #263
-	require.Len(t, delInfo2.AccumulatedRewards, 0)
 	require.Equal(t, wasmTypes.NewCoin(200000, "stake"), delInfo2.CanRedelegate)
+	require.Len(t, delInfo2.AccumulatedRewards, 1)
+	// see bonding above to see how we calculate 36000 (240000 / 6 - 10% commission)
+	require.Equal(t, wasmTypes.NewCoin(36000, "stake"), delInfo2.AccumulatedRewards[0])
 }
 
 func TestQueryStakingPlugin(t *testing.T) {
@@ -580,7 +582,7 @@ func TestQueryStakingPlugin(t *testing.T) {
 			Validator: valAddr.String(),
 		},
 	}
-	raw, err := StakingQuerier(stakingKeeper)(ctx, &query)
+	raw, err := StakingQuerier(stakingKeeper, distKeeper)(ctx, &query)
 	require.NoError(t, err)
 	var res wasmTypes.DelegationResponse
 	mustParse(t, raw, &res)
@@ -594,9 +596,10 @@ func TestQueryStakingPlugin(t *testing.T) {
 	require.Equal(t, funds[0].Denom, delInfo.Amount.Denom)
 	require.Equal(t, funds[0].Amount.String(), delInfo.Amount.Amount)
 
-	// TODO: fix this - these should return real values!!! Issue #263
 	require.Equal(t, wasmTypes.NewCoin(200000, "stake"), delInfo.CanRedelegate)
-	require.Len(t, delInfo.AccumulatedRewards, 0)
+	require.Len(t, delInfo.AccumulatedRewards, 1)
+	// see bonding above to see how we calculate 36000 (240000 / 6 - 10% commission)
+	require.Equal(t, wasmTypes.NewCoin(36000, "stake"), delInfo.AccumulatedRewards[0])
 }
 
 // adds a few validators and returns a list of validators that are registered

--- a/x/wasm/internal/keeper/staking_test.go
+++ b/x/wasm/internal/keeper/staking_test.go
@@ -438,6 +438,9 @@ func TestQueryStakingInfo(t *testing.T) {
 	// we get 1/6, our share should be 40k minus 10% commission = 36k
 	setValidatorRewards(ctx, stakingKeeper, distKeeper, valAddr, "240000")
 
+	// see what the current rewards are
+	origReward := distKeeper.GetValidatorCurrentRewards(ctx, valAddr)
+
 	// STEP 2: Prepare the mask contract
 	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
 	creator := createFakeFundedAccount(ctx, accKeeper, deposit)
@@ -539,6 +542,10 @@ func TestQueryStakingInfo(t *testing.T) {
 	require.Len(t, delInfo2.AccumulatedRewards, 1)
 	// see bonding above to see how we calculate 36000 (240000 / 6 - 10% commission)
 	require.Equal(t, wasmTypes.NewCoin(36000, "stake"), delInfo2.AccumulatedRewards[0])
+
+	// ensure rewards did not change when querying (neither amount nor period)
+	finalReward := distKeeper.GetValidatorCurrentRewards(ctx, valAddr)
+	require.Equal(t, origReward, finalReward)
 }
 
 func TestQueryStakingPlugin(t *testing.T) {
@@ -574,6 +581,9 @@ func TestQueryStakingPlugin(t *testing.T) {
 	// we get 1/6, our share should be 40k minus 10% commission = 36k
 	setValidatorRewards(ctx, stakingKeeper, distKeeper, valAddr, "240000")
 
+	// see what the current rewards are
+	origReward := distKeeper.GetValidatorCurrentRewards(ctx, valAddr)
+
 	// Step 2: Try out the query plugins
 	query := wasmTypes.StakingQuery{
 		Delegation: &wasmTypes.DelegationQuery{
@@ -599,6 +609,10 @@ func TestQueryStakingPlugin(t *testing.T) {
 	require.Len(t, delInfo.AccumulatedRewards, 1)
 	// see bonding above to see how we calculate 36000 (240000 / 6 - 10% commission)
 	require.Equal(t, wasmTypes.NewCoin(36000, "stake"), delInfo.AccumulatedRewards[0])
+
+	// ensure rewards did not change when querying (neither amount nor period)
+	finalReward := distKeeper.GetValidatorCurrentRewards(ctx, valAddr)
+	require.Equal(t, origReward, finalReward)
 }
 
 // adds a few validators and returns a list of validators that are registered

--- a/x/wasm/internal/keeper/test_common.go
+++ b/x/wasm/internal/keeper/test_common.go
@@ -171,7 +171,7 @@ func CreateTestInput(t *testing.T, isCheckTx bool, tempDir string, supportedFeat
 	// Load default wasm config
 	wasmConfig := wasmtypes.DefaultWasmConfig()
 	keeper := NewKeeper(cdc, keyContract, paramsKeeper.Subspace(wasmtypes.DefaultParamspace),
-		accountKeeper, bankKeeper, stakingKeeper, router, tempDir, wasmConfig,
+		accountKeeper, bankKeeper, stakingKeeper, distKeeper, router, tempDir, wasmConfig,
 		supportedFeatures, encoders, queriers,
 	)
 	keeper.setParams(ctx, wasmtypes.DefaultParams())


### PR DESCRIPTION
Closes #263 

Hoping for https://github.com/cosmos/cosmos-sdk/issues/7466 to make `query_plugins.go :: getAccumulatedRewards` easier to write/maintain. But we cannot block on launchpad release, just be ready to update with a patch release when it is out.