### PR TITLE
Test WasmQuery::Raw with missing data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.14
 
 require (
-	github.com/CosmWasm/go-cosmwasm v0.11.0-alpha2
+	github.com/CosmWasm/go-cosmwasm v0.11.0-rc
 	github.com/cosmos/cosmos-sdk v0.39.1-0.20200727135228-9d00f712e334
 	github.com/golang/mock v1.4.3 // indirect
 	github.com/google/gofuzz v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/CosmWasm/go-cosmwasm v0.11.0-alpha1 h1:5c87JcnA+ncQlSJO/mEK6z9oIi/oS4
 github.com/CosmWasm/go-cosmwasm v0.11.0-alpha1/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/CosmWasm/go-cosmwasm v0.11.0-alpha2 h1:w42GtYC4P/6dXOVlqEutr96tSsy/EO0aC9d3sbkk5hs=
 github.com/CosmWasm/go-cosmwasm v0.11.0-alpha2/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
+github.com/CosmWasm/go-cosmwasm v0.11.0-rc h1:qKMUR/84LluMStwuOgaWxupQj8STmnRaxFgFXrhY95o=
+github.com/CosmWasm/go-cosmwasm v0.11.0-rc/go.mod h1:gAFCwllx97ejI+m9SqJQrmd2SBW7HA0fOjvWWJjM2uc=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/x/wasm/internal/keeper/querier_test.go
+++ b/x/wasm/internal/keeper/querier_test.go
@@ -135,12 +135,10 @@ func TestQueryContractState(t *testing.T) {
 
 			// if smart query, check custom response
 			if spec.srcPath[2] != QueryMethodContractStateAll {
-				fmt.Printf("path: %s\n", spec.srcPath[2])
 				require.Equal(t, spec.expRes, binResult)
 				return
 			}
 
-			fmt.Printf("all state: %s\n", spec.srcPath[2])
 			// otherwise, check returned models
 			var r []types.Model
 			if spec.expErr == nil {

--- a/x/wasm/internal/keeper/reflect_test.go
+++ b/x/wasm/internal/keeper/reflect_test.go
@@ -425,8 +425,8 @@ func TestWasmRawQueryWithNil(t *testing.T) {
 	mustParse(t, res, &reflectRawRes)
 	// and make sure there is no data
 	require.Empty(t, reflectRawRes.Data)
-	// TODO: check between []byte{} and nil
-	require.Nil(t, reflectRawRes.Data)
+	// we get an empty byte slice not nil (if anyone care in go-land)
+	require.Equal(t, []byte{}, reflectRawRes.Data)
 }
 
 func checkAccount(t *testing.T, ctx sdk.Context, accKeeper auth.AccountKeeper, addr sdk.AccAddress, expected sdk.Coins) {

--- a/x/wasm/internal/keeper/reflect_test.go
+++ b/x/wasm/internal/keeper/reflect_test.go
@@ -379,7 +379,54 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 	var reflectStateRes maskState
 	mustParse(t, reflectRawRes.Data, &reflectStateRes)
 	require.Equal(t, reflectStateRes.Owner, []byte(creator))
+}
 
+func TestWasmRawQueryWithNil(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "wasm")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+	ctx, keepers := CreateTestInput(t, false, tempDir, MaskFeatures, maskEncoders(MakeTestCodec()), nil)
+	accKeeper, keeper := keepers.AccountKeeper, keepers.WasmKeeper
+
+	deposit := sdk.NewCoins(sdk.NewInt64Coin("denom", 100000))
+	creator := createFakeFundedAccount(ctx, accKeeper, deposit)
+
+	// upload mask code
+	maskCode, err := ioutil.ReadFile("./testdata/reflect.wasm")
+	require.NoError(t, err)
+	maskID, err := keeper.Create(ctx, creator, maskCode, "", "", nil)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), maskID)
+
+	// creator instantiates a contract and gives it tokens
+	maskStart := sdk.NewCoins(sdk.NewInt64Coin("denom", 40000))
+	maskAddr, err := keeper.Instantiate(ctx, maskID, creator, nil, []byte("{}"), "mask contract 2", maskStart)
+	require.NoError(t, err)
+	require.NotEmpty(t, maskAddr)
+
+	// control: query directly
+	missingKey := []byte{0, 1, 2, 3, 4}
+	raw := keeper.QueryRaw(ctx, maskAddr, missingKey)
+	require.Nil(t, raw)
+
+	// and with queryRaw
+	reflectQuery := MaskQueryMsg{Chain: &ChainQuery{Request: &wasmTypes.QueryRequest{Wasm: &wasmTypes.WasmQuery{
+		Raw: &wasmTypes.RawQuery{
+			ContractAddr: maskAddr.String(),
+			Key:          missingKey,
+		},
+	}}}}
+	reflectStateBin := buildMaskQuery(t, &reflectQuery)
+	res, err := keeper.QuerySmart(ctx, maskAddr, reflectStateBin)
+	require.NoError(t, err)
+
+	// first we pull out the data from chain response, before parsing the original response
+	var reflectRawRes ChainResponse
+	mustParse(t, res, &reflectRawRes)
+	// and make sure there is no data
+	require.Empty(t, reflectRawRes.Data)
+	// TODO: check between []byte{} and nil
+	require.Nil(t, reflectRawRes.Data)
 }
 
 func checkAccount(t *testing.T, ctx sdk.Context, accKeeper auth.AccountKeeper, addr sdk.AccAddress, expected sdk.Coins) {


### PR DESCRIPTION
- [x] Add tests 
- [x] Fix (Go-)CosmWasm (https://github.com/CosmWasm/go-cosmwasm/pull/143 and https://github.com/CosmWasm/cosmwasm/pull/567)
- [x] Update wasmd to work

Error message:

```
Error Trace:    reflect_test.go:421
                Error:          Received unexpected error:
                                
                                github.com/CosmWasm/wasmd/x/wasm/internal/keeper.Keeper.QuerySmart
                                        /home/ethan/go/src/github.com/cosmwasm/wasmd/x/wasm/internal/keeper/keeper.go:419
                                github.com/CosmWasm/wasmd/x/wasm/internal/keeper.TestWasmRawQueryWithNil
                                        /home/ethan/go/src/github.com/cosmwasm/wasmd/x/wasm/internal/keeper/reflect_test.go:420
                                query wasm contract failed: Generic error: Querier system error: Cannot parse response: Parsing Go response: expected value at line 1 column 8 in: {"ok":{}}
                Test:           TestWasmRawQueryWithNil
```

This is what we got from the reflect contract: `Generic error: Querier system error: Cannot parse response: Parsing Go response: expected value at line 1 column 8 in: {"ok":{}}`, which seems to be a bit Go's "omitempty"