### PR TITLE
Set bech32 prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=wasm \
 		  -X github.com/cosmos/cosmos-sdk/version.AppName=wasmd \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+		  -X github.com/CosmWasm/wasmd/app.Bech32Prefix=wasm \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)"
 
 ifeq ($(WITH_CLEVELDB),yes)

--- a/app/app.go
+++ b/app/app.go
@@ -96,7 +96,7 @@ const appName = "WasmApp"
 // We pull these out so we can set them with LDFLAGS in the Makefile
 var (
 	NodeDir      = ".wasmd"
-	Bech32Prefix = sdk.Bech32MainPrefix
+	Bech32Prefix = "wasm"
 
 	// If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.
 	// If EnabledSpecificProposals is "", and this is not "true", then disable all x/wasm proposals.


### PR DESCRIPTION
Resolves #313 

* Default "wasm" in app 
* Set prefix in build (not really needed with app default but consistent with building other artifacts)

No covered are cosmos prefixes in unit tests