### PR TITLE
Upgrade wasmvm to 0.12.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Folders we don't want to copy to Docker daemon in `docker build . -t cosmwasm/wasmd:latest`
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t cosmwasm/wasmd:latest
 # docker run --rm -it cosmwasm/wasmd:latest /bin/sh
-FROM golang:1.14-alpine3.12 AS go-builder
+FROM golang:1.15-alpine3.12 AS go-builder
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.15
 
 require (
-	github.com/CosmWasm/wasmvm v0.12.0-alpha1
+	github.com/CosmWasm/wasmvm v0.12.0
 	github.com/cosmos/cosmos-sdk v0.40.0-rc3
 	github.com/cosmos/iavl v0.15.0-rc4
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v0.12.0-alpha1 h1:UPaemjM+O/9uQRDCiExXPpcUlMJ5Zo8N/BUvqjheb5A=
-github.com/CosmWasm/wasmvm v0.12.0-alpha1/go.mod h1:tbXGE9Jz6sYpiJroGr71OQ5TFOufq/P5LWsruA2u6JE=
+github.com/CosmWasm/wasmvm v0.12.0 h1:L9ez6fCg2Co1SgCm0YHjbnewZ8myemu2cm/QL0qR1OE=
+github.com/CosmWasm/wasmvm v0.12.0/go.mod h1:tbXGE9Jz6sYpiJroGr71OQ5TFOufq/P5LWsruA2u6JE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=


### PR DESCRIPTION
This includes the following (theoretically independent) changes:

- Upgrade wasmvm to 0 12.0
- Use pre-build .a library and remove the rust-builder
- Upgrade Go from 1.14 to 1.15 by migrating from `cosmwasm/go-ext-builder:0002-alpine` to `golang:1.15-alpine3.12`
- Add .dockerignore to avoid sending dozens of MB unneeded build results to the docker daemon