### PR TITLE
Exclude generate proto code files in coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           command: |
             excludelist="$(find . -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
             for filename in ${excludelist}; do
-              filename=$(echo $filename | sed 's/^./github.com\/cosmos\/gaia/g')
+              filename=$(echo $filename | sed 's/^./github.com\/CosmWasm\/wasmd/g')
               echo "Excluding ${filename} from coverage report..."
               sed -i.bak "/$(echo $filename | sed 's/\//\\\//g')/d" coverage.txt
             done

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,12 +15,15 @@ coverage:
         threshold: 1% # allow this much decrease on project
       app:
         target: 70%
-        flags: app
+        flags:
+          - app
       modules:
         target: 70%
-        flags: modules
+        flags:
+          - modules
       client:
-        flags: client
+        flags:
+          - client
     changes: false
 
 comment:
@@ -51,4 +54,4 @@ ignore:
   - "x/**/*.pb.go"
   - "x/**/*.pb.gw.go"
   - "x/**/test_common.go"
-  - "x/**/testdata/**/*"
+  - "x/**/testdata/"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,9 +14,13 @@ coverage:
       default:
         threshold: 1% # allow this much decrease on project
       app:
-        target: 80%
-        paths: "app/"
-
+        target: 70%
+        flags: app
+      modules:
+        target: 70%
+        flags: modules
+      client:
+        flags: client
     changes: false
 
 comment:
@@ -24,10 +28,27 @@ comment:
   behavior: default # update if exists else create new
   require_changes: true
 
+flags:
+  app:
+    paths:
+      - "app/"
+  modules:
+    paths:
+      - "x/"
+      - "!x/**/client/" # ignore client package
+  client:
+    paths:
+      - "x/**/client/"
+
 ignore:
-  - "*.md"
-  - "*.rst"
   - "cmd/"
   - "contrib/"
   - "docs/"
-  - "networks/"
+  - "docker/"
+  - "scripts/"
+  - "*.md"
+  - "*.rst"
+  - "x/**/*.pb.go"
+  - "x/**/*.pb.gw.go"
+  - "x/**/test_common.go"
+  - "x/**/testdata/**/*"


### PR DESCRIPTION
Resolves #298 

With this patch we just ignore the Go files generated by protobuf and some test files.

Most of this is copied from https://github.com/cosmos/cosmos-sdk/blob/master/.codecov.yml . Thanks 💐 