### PR TITLE
Register upgrade plan for musselnet-v2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -307,7 +307,7 @@ func NewWasmApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 		app.getSubspace(crisistypes.ModuleName), invCheckPeriod, app.bankKeeper, authtypes.FeeCollectorName,
 	)
 	app.upgradeKeeper = upgradekeeper.NewKeeper(skipUpgradeHeights, keys[upgradetypes.StoreKey], appCodec, homePath)
-
+	app.registerUpgradePlans()
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.stakingKeeper = *stakingKeeper.SetHooks(
@@ -646,4 +646,10 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 	paramsKeeper.Subspace(wasm.ModuleName)
 
 	return paramsKeeper
+}
+
+func (app *WasmApp) registerUpgradePlans() {
+	app.upgradeKeeper.SetUpgradeHandler("v0.13.1", func(ctx sdk.Context, plan upgradetypes.Plan) {
+		// do nothing
+	})
 }

--- a/app/app.go
+++ b/app/app.go
@@ -649,7 +649,7 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 }
 
 func (app *WasmApp) registerUpgradePlans() {
-	app.upgradeKeeper.SetUpgradeHandler("v0.13.1", func(ctx sdk.Context, plan upgradetypes.Plan) {
+	app.upgradeKeeper.SetUpgradeHandler("musselnet-v2", func(ctx sdk.Context, plan upgradetypes.Plan) {
 		// do nothing
 	})
 }


### PR DESCRIPTION
This change is required to succesfully executing a cosmovisor assisted upgrade. Reference: https://godoc.org/github.com/cosmos/cosmos-sdk/x/upgrade#hdr-Performing_Upgrades