### PR TITLE
Document upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,12 @@ docker volume rm -f wasmd_data
 docker run --rm -it \
     -e PASSWORD=xxxxxxxxx \
     --mount type=volume,source=wasmd_data,target=/root \
-    cosmwasm/wasmd:latest ./setup_wasmd.sh cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6
+    cosmwasm/wasmd:latest /opt/setup_wasmd.sh cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6
 
-# This will start both wasmd and rest-server, only rest-serve output is shown on the screen
+# This will start both wasmd and rest-server, both are logged
 docker run --rm -it -p 26657:26657 -p 26656:26656 -p 1317:1317 \
     --mount type=volume,source=wasmd_data,target=/root \
-    cosmwasm/wasmd:latest ./run_all.sh
-
-# view wasmd logs in another shell
-docker run --rm -it \
-    --mount type=volume,source=wasmd_data,target=/root,readonly \
-    cosmwasm/wasmd:latest ./logs.sh
+    cosmwasm/wasmd:latest /opt/run_wasmd.sh
 ```
 
 ### CI
@@ -142,7 +137,7 @@ rm -rf ./template && mkdir ./template
 docker run --rm -it \
     -e PASSWORD=xxxxxxxxx \
     --mount type=bind,source=$(pwd)/template,target=/root \
-    cosmwasm/wasmd:latest ./setup_wasmd.sh cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6
+    cosmwasm/wasmd:latest /opt/setup_wasmd.sh cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6
 
 sudo chown -R $(id -u):$(id -g) ./template
 
@@ -153,17 +148,12 @@ docker volume rm -f wasmd_data
 docker run --rm -it -p 26657:26657 -p 26656:26656 -p 9090:9090 \
     --mount type=bind,source=$(pwd)/template,target=/template \
     --mount type=volume,source=wasmd_data,target=/root \
-    cosmwasm/wasmd:latest ./run_all.sh /template
+    cosmwasm/wasmd:latest /opt/run_wasmd.sh /template
 
 # RESTART CHAIN with existing state
 docker run --rm -it -p 26657:26657 -p 26656:26656 -p 1317:1317 \
     --mount type=volume,source=wasmd_data,target=/root \
-    cosmwasm/wasmd:latest ./run_all.sh
-
-# view wasmd logs in another shell
-docker run --rm -it \
-    --mount type=volume,source=wasmd_data,target=/root,readonly \
-    cosmwasm/wasmd:latest ./logs.sh
+    cosmwasm/wasmd:latest /opt/run_wasmd.sh
 ```
 
 ## Runtime flags

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,122 @@
+# Upgrading
+
+With stargate, we have access to the `x/upgrade` module, which we can use to perform
+inline upgrades. Please first read both the basic 
+[x/upgrade spec](https://github.com/cosmos/cosmos-sdk/blob/master/x/upgrade/spec/01_concepts.md)
+and [go docs](https://godoc.org/github.com/cosmos/cosmos-sdk/x/upgrade#hdr-Performing_Upgrades)
+for the background on the module.
+
+In this case, we will demo an update with no state migration. This is for cases when
+there is a state-machine-breaking (but not state-breaking) bugfix or enhancement.
+There are some
+[open issues running some state migrations](https://github.com/cosmos/cosmos-sdk/issues/8265)
+and we will wait for that to be fixed before trying those.
+
+The following will lead through running an upgrade on a local node, but the same process
+would work on a real network (with more ops and governance coordination).
+
+## Setup
+
+We need to have two different versions of `wasmd` which depend on state-compatible
+versions of the Cosmos SDK. We only focus on upgrade starting with stargate. You will
+have to use the "dump state and restart" approach to move from launchpad to stargate.
+
+For this demo, we will show an upgrade to our Musselnet going from `v0.12.1` to
+`v0.14.0`.
+
+### Handler
+
+You will need to register a handler for the upgrade. This is specific to a particular
+testnet and upgrade path, and the default `wasmd` will never have a registered handler
+on master. In this case, we make a `musselnet` branch off of `v0.14.0` just
+registering one handler with a given name. 
+
+Look at [PR 351](https://github.com/CosmWasm/wasmd/pull/351/files) for an example
+of a minimal handler. We do not make any state migrations, but rather use this
+as a flag to coordinate all validators to stop the old version at one height, and
+start the specified v2 version on the next block.
+
+### Prepare binaries
+
+Let's get the two binaries we want to test, the pre-upgrade and the post-upgrade
+binaries. In this case the pre-release is already a published to docker hub and
+can be downloaded simply via:
+
+`docker pull cosmwasm/wasmd:v0.12.1`
+
+The post-release is not published, so we can build it ourselves. Check out this
+`wasmd` repo, and the proper `musselnet` branch:
+
+```
+# use musselnet-v2 tag once that exists
+git checkout musselnet
+docker build . -t wasmd:musselnet-v2
+```
+
+Verify they are both working for you locally:
+
+```
+docker run cosmwasm/wasmd:v0.12.1 wasmd version
+docker run wasmd:musselnet-v2 wasmd version
+```
+
+## Start the pre-release chain
+
+Follow the normal setup stage, but in this case we will want to have super short
+governance voting period, 5 minutes rather than 2 days (or 2 weeks!).
+
+**Setup a client with private key**
+
+```sh
+## TODO: I think we need to do this locally???
+docker volume rm -f musselnet_client
+
+docker run --rm -it \
+    -e PASSWORD=1234567890 \
+    --mount type=volume,source=musselnet_client,target=/root \
+    cosmwasm/wasmd:v0.12.1 /opt/setup_wasmd.sh
+
+# enter "1234567890" when prompted
+docker run --rm -it \
+    --mount type=volume,source=musselnet_client,target=/root \
+    cosmwasm/wasmd:v0.12.1 wasmd keys show -a validator
+# use the address returned above here
+CLIENT=wasm1anavj4eyxkdljp27sedrdlt9dm26c8a7a8p44l
+```
+
+**Setup the blockchain node**
+
+```sh
+docker volume rm -f musselnet
+
+# add your testing address here, so you can do something with the client
+docker run --rm -it \
+    --mount type=volume,source=musselnet,target=/root \
+    cosmwasm/wasmd:v0.12.1 /opt/setup_wasmd.sh $CLIENT
+
+# Update the voting times in the genesis file
+docker run --rm -it \
+    --mount type=volume,source=musselnet,target=/root \
+    cosmwasm/wasmd:v0.12.1 sed -ie 's/172800s/300s/' /root/.wasmd/config/genesis.json
+
+# This will start both wasmd and rest-server, only rest-serve output is shown on the screen
+docker run --rm -it -p 26657:26657 -p 26656:26656 -p 1317:1317 \
+    --mount type=volume,source=musselnet,target=/root \
+    cosmwasm/wasmd:v0.12.1 /opt/run_wasmd.sh
+```
+
+## Sanity checks
+
+**TODO** move some tokens around
+
+## Vote on the upgrade
+
+**TODO**
+
+## Swap out binaries
+
+**TODO**
+
+## Check final state
+
+**TODO** Same balances in the final one

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -248,6 +248,39 @@ On a real network, operators will have to be awake when the upgrade plan is acti
 and manually perform this switch, or use some automated tooling like 
 [cosmosvisor](https://github.com/cosmos/cosmos-sdk/blob/master/cosmovisor/README.md).
 
+**WARNING** the described path above will fail. There is some breaking changes we do
+not handle. Here is the error message when starting the new chain:
+
+```
+$ docker run --rm -it -p 26657:26657 -p 26656:26656 -p 1317:1317 \
+>     --mount type=volume,source=musselnet,target=/root \
+>     wasmd:musselnet-v2 /opt/run_wasmd.sh
+
+8:04PM INF starting ABCI with Tendermint
+8:04PM INF Starting multiAppConn service impl={"Logger":{}} module=proxy
+8:04PM INF Starting localClient service connection=query impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
+8:04PM INF Starting localClient service connection=snapshot impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
+8:04PM INF Starting localClient service connection=mempool impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
+8:04PM INF Starting localClient service connection=consensus impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
+8:04PM INF Starting EventBus service impl={"Logger":{}} module=events
+8:04PM INF Starting PubSub service impl={"Logger":{}} module=pubsub
+8:04PM INF Starting IndexerService service impl={"Logger":{}} module=txindex
+8:04PM INF ABCI Handshake App Info hash=BF31EF7E9B8D1273E338C7C1CF2A21EA878DC9E6195ECE3289C0D35DC5582F03 height=499 module=consensus protocol-version=0 software-version=
+8:04PM INF ABCI Replay Blocks appHeight=499 module=consensus stateHeight=499 storeHeight=500
+8:04PM INF Replay last block using real app module=consensus
+8:04PM INF applying upgrade "musselnet-v2" at height: 500
+8:04PM INF minted coins from module account amount=41ustake from=mint module=x/bank
+panic: Validator consensus-address wasmvalcons1r0lklmvxkhf7lwcjeeqp5vf68mlvqk2wwmg7l0 not found
+
+goroutine 1 [running]:
+github.com/cosmos/cosmos-sdk/x/slashing/keeper.Keeper.HandleValidatorSignature(0x295c3c0, 0xc0001151f0, 0x2993580, 0xc000694190, 0x298dc20, 0xc00023e480, 0x29810c0, 0xc00018b5c0, 0x297ce00, 0xc000042038, ...)
+        github.com/cosmos/cosmos-sdk@v0.40.0-rc6/x/slashing/keeper/infractions.go:19 +0x22d7
+github.com/cosmos/cosmos-sdk/x/slashing.BeginBlocker(0x297ce00, 0xc000042038, 0x2992f00, 0xc0011320c0, 0xb, 0x0, 0xc0004dec58, 0x7, 0x1f4, 0x1a385af2, ...)
+        github.com/cosmos/cosmos-sdk@v0.40.0-rc6/x/slashing/abci.go:23 +0x287
+github.com/cosmos/cosmos-sdk/x/slashing.AppModule.BeginBlock(...)
+        github.com/cosmos/cosmos-sdk@v0.40.0-rc6/x/slashing/module.go:164
+```
+
 ## Check final state
 
 Now that we have upgraded, we can use the new client version. Let's do a brief


### PR DESCRIPTION
Added some detailed docs (and step-by-step guide) for using `x/upgrade` to upgrade the chain.

This failed for musselnet due to state changed (in block sigs I think) between sdk 0.40.0-rc3 and 0.40.0-rc6. Looks like we will need a dump state and restart for this. Or just make a new testnet. 

Check out the new [UPGRADING.md](https://github.com/CosmWasm/wasmd/blob/document-upgrade/UPGRADING.md) or skip directly to the [panic on starting the new version](https://github.com/CosmWasm/wasmd/blob/document-upgrade/UPGRADING.md#swap-out-binaries)