### PR TITLE
Register v0.15.1 upgrade plan

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -309,6 +309,9 @@ func NewWasmApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 	)
 	app.upgradeKeeper = upgradekeeper.NewKeeper(skipUpgradeHeights, keys[upgradetypes.StoreKey], appCodec, homePath)
 
+	// register upgrade plans
+	app.registerUpgradePlans()
+
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.stakingKeeper = *stakingKeeper.SetHooks(
@@ -653,4 +656,10 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 	paramsKeeper.Subspace(wasm.ModuleName)
 
 	return paramsKeeper
+}
+
+func (app *WasmApp) registerUpgradePlans() {
+	app.upgradeKeeper.SetUpgradeHandler("v0.15.1", func(ctx sdk.Context, plan upgradetypes.Plan) {
+		// do nothing
+	})
 }

--- a/app/app.go
+++ b/app/app.go
@@ -659,7 +659,7 @@ func initParamsKeeper(appCodec codec.BinaryMarshaler, legacyAmino *codec.LegacyA
 }
 
 func (app *WasmApp) registerUpgradePlans() {
-	app.upgradeKeeper.SetUpgradeHandler("v0.15.1", func(ctx sdk.Context, plan upgradetypes.Plan) {
+	app.upgradeKeeper.SetUpgradeHandler("musselnet-3", func(ctx sdk.Context, plan upgradetypes.Plan) {
 		// do nothing
 	})
 }


### PR DESCRIPTION
We need to register this upgrade plan to upgrade musselnet live. After this is merged we need to cut a new release. the tag naming can be different than `v0.15.1`. Let me know if you want to change it.

Re: tag and upgrade name will be `musselnet-3`
