### PR TITLE
Remove redundant wasm bytes limit in rest

### DIFF
--- a/x/wasm/client/rest/tx.go
+++ b/x/wasm/client/rest/tx.go
@@ -19,9 +19,6 @@ func registerTxRoutes(cliCtx client.Context, r *mux.Router) {
 	r.HandleFunc("/wasm/contract/{contractAddr}", executeContractHandlerFn(cliCtx)).Methods("POST")
 }
 
-// limit max bytes read to prevent gzip bombs
-const maxSize = 400 * 1024
-
 type storeCodeReq struct {
 	BaseReq   rest.BaseReq `json:"base_req" yaml:"base_req"`
 	WasmBytes []byte       `json:"wasm_bytes"`
@@ -55,10 +52,6 @@ func storeCodeHandlerFn(cliCtx client.Context) http.HandlerFunc {
 
 		var err error
 		wasm := req.WasmBytes
-		if len(wasm) > maxSize {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, "Binary size exceeds maximum limit")
-			return
-		}
 
 		// gzip the wasm file
 		if wasmUtils.IsWasm(wasm) {


### PR DESCRIPTION
 There exists a constant used for wasm bytes limit in rest, which is 400K.
 In fact, the size validation will be performed in `ValidateBasic` for `MsgStoreCode`, where the limit is 500K.

 I think the inconsistency is confusing.