### PR TITLE
Use Label from contract's instantiate message

### DIFF
--- a/x/wasm/internal/keeper/handler_plugin.go
+++ b/x/wasm/internal/keeper/handler_plugin.go
@@ -2,8 +2,6 @@ package keeper
 
 import (
 	"encoding/json"
-	"fmt"
-
 	"github.com/CosmWasm/wasmd/x/wasm/internal/types"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -194,10 +192,9 @@ func EncodeWasmMsg(sender sdk.AccAddress, msg *wasmvmtypes.WasmMsg) ([]sdk.Msg, 
 		}
 
 		sdkMsg := types.MsgInstantiateContract{
-			Sender: sender.String(),
-			CodeID: msg.Instantiate.CodeID,
-			// TODO: add this to CosmWasm
-			Label:   fmt.Sprintf("Auto-created by %s", sender),
+			Sender:  sender.String(),
+			CodeID:  msg.Instantiate.CodeID,
+			Label:   msg.Instantiate.Label,
 			InitMsg: msg.Instantiate.Msg,
 			Funds:   coins,
 		}

--- a/x/wasm/internal/keeper/handler_plugin_test.go
+++ b/x/wasm/internal/keeper/handler_plugin_test.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/CosmWasm/wasmd/x/wasm/internal/keeper/wasmtesting"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	ibctransfertypes "github.com/cosmos/cosmos-sdk/x/ibc/applications/transfer/types"
@@ -147,15 +146,15 @@ func TestEncoding(t *testing.T) {
 						Send: []wasmvmtypes.Coin{
 							wasmvmtypes.NewCoin(123, "eth"),
 						},
+						Label: "myLabel",
 					},
 				},
 			},
 			output: []sdk.Msg{
 				&types.MsgInstantiateContract{
-					Sender: addr1.String(),
-					CodeID: 7,
-					// TODO: fix this
-					Label:   fmt.Sprintf("Auto-created by %s", addr1),
+					Sender:  addr1.String(),
+					CodeID:  7,
+					Label:   "myLabel",
 					InitMsg: jsonMsg,
 					Funds:   sdk.NewCoins(sdk.NewInt64Coin("eth", 123)),
 				},


### PR DESCRIPTION
Resolves #376 

This also removes the default label. As labels are required the contracts need to set them proper