### PR TITLE
Ibc query support

### DIFF
--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -120,7 +120,7 @@ func NewKeeper(
 		authZPolicy:      DefaultAuthorizationPolicy{},
 		paramSpace:       paramSpace,
 	}
-	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, queryRouter, &keeper).Merge(customPlugins)
+	keeper.queryPlugins = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, channelKeeper, queryRouter, &keeper).Merge(customPlugins)
 	for _, o := range opts {
 		o.apply(&keeper)
 	}

--- a/x/wasm/internal/keeper/keeper.go
+++ b/x/wasm/internal/keeper/keeper.go
@@ -268,10 +268,7 @@ func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
 
 	// prepare querier
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddress)
 
 	// instantiate wasm contract
 	gas := gasForContract(ctx)
@@ -340,10 +337,7 @@ func (k Keeper) Execute(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	info := types.NewInfo(caller, coins)
 
 	// prepare querier
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddress)
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.Execute(codeInfo.CodeHash, env, info, msg, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
 	consumeGas(ctx, gasUsed)
@@ -405,10 +399,7 @@ func (k Keeper) migrate(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	env := types.NewEnv(ctx, contractAddress)
 
 	// prepare querier
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddress)
 
 	prefixStoreKey := types.GetContractStorePrefix(contractAddress)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
@@ -454,10 +445,7 @@ func (k Keeper) Sudo(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte
 	env := types.NewEnv(ctx, contractAddress)
 
 	// prepare querier
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddress)
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.Sudo(codeInfo.CodeHash, env, msg, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
 	consumeGas(ctx, gasUsed)
@@ -543,10 +531,7 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 		return nil, err
 	}
 	// prepare querier
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	env := types.NewEnv(ctx, contractAddr)
 	queryResult, gasUsed, qErr := k.wasmer.Query(codeInfo.CodeHash, env, req, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gasForContract(ctx))

--- a/x/wasm/internal/keeper/query_plugins.go
+++ b/x/wasm/internal/keeper/query_plugins.go
@@ -173,9 +173,6 @@ func IBCQuerier(wasm *Keeper, channelKeeper types.ChannelKeeper) func(ctx sdk.Co
 			}
 			return json.Marshal(res)
 		}
-		// I just discovered we cannot query by port (how odd since they store it like this)
-		// Anyway, I will allow Port as an optional filter
-		// TODO: let's revisit this query (if needed, if we should change it)
 		if request.ListChannels != nil {
 			portID := request.ListChannels.PortID
 			var channels wasmvmtypes.IBCEndpoints
@@ -196,7 +193,6 @@ func IBCQuerier(wasm *Keeper, channelKeeper types.ChannelKeeper) func(ctx sdk.Co
 		}
 		if request.Channel != nil {
 			channelID := request.Channel.ChannelID
-			_ = channelID
 			portID := request.Channel.PortID
 			if portID == "" {
 				contractInfo := wasm.GetContractInfo(ctx, caller)
@@ -216,7 +212,7 @@ func IBCQuerier(wasm *Keeper, channelKeeper types.ChannelKeeper) func(ctx sdk.Co
 					},
 					Order:               got.Ordering.String(),
 					Version:             got.Version,
-					CounterpartyVersion: got.Version, // FIXME: maybe we change the type? This data is not stored AFAIK
+					CounterpartyVersion: "",
 					ConnectionID:        got.ConnectionHops[0],
 				}
 			}

--- a/x/wasm/internal/keeper/relay.go
+++ b/x/wasm/internal/keeper/relay.go
@@ -23,10 +23,7 @@ func (k Keeper) OnOpenChannel(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	gasUsed, execErr := k.wasmer.IBCChannelOpen(codeInfo.CodeHash, env, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
@@ -56,10 +53,7 @@ func (k Keeper) OnConnectChannel(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.IBCChannelConnect(codeInfo.CodeHash, env, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
@@ -95,10 +89,7 @@ func (k Keeper) OnCloseChannel(
 	}
 
 	params := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.IBCChannelClose(codeInfo.CodeHash, params, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
@@ -134,10 +125,7 @@ func (k Keeper) OnRecvPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.IBCPacketReceive(codeInfo.CodeHash, env, packet, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
@@ -174,10 +162,7 @@ func (k Keeper) OnAckPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.IBCPacketAck(codeInfo.CodeHash, env, acknowledgement, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
@@ -210,10 +195,7 @@ func (k Keeper) OnTimeoutPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := QueryHandler{
-		Ctx:     ctx,
-		Plugins: k.queryPlugins,
-	}
+	querier := NewQueryHandler(ctx, k.queryPlugins, contractAddr)
 
 	gas := gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmer.IBCPacketTimeout(codeInfo.CodeHash, env, packet, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)

--- a/x/wasm/internal/keeper/wasmtesting/mock_keepers.go
+++ b/x/wasm/internal/keeper/wasmtesting/mock_keepers.go
@@ -12,6 +12,7 @@ type MockChannelKeeper struct {
 	GetNextSequenceSendFn func(ctx sdk.Context, portID, channelID string) (uint64, bool)
 	SendPacketFn          func(ctx sdk.Context, channelCap *capabilitytypes.Capability, packet ibcexported.PacketI) error
 	ChanCloseInitFn       func(ctx sdk.Context, portID, channelID string, chanCap *capabilitytypes.Capability) error
+	GetAllChannelsFn      func(ctx sdk.Context) []channeltypes.IdentifiedChannel
 }
 
 func (m *MockChannelKeeper) GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool) {
@@ -19,6 +20,24 @@ func (m *MockChannelKeeper) GetChannel(ctx sdk.Context, srcPort, srcChan string)
 		panic("not supposed to be called!")
 	}
 	return m.GetChannelFn(ctx, srcPort, srcChan)
+}
+
+func (m *MockChannelKeeper) GetAllChannels(ctx sdk.Context) []channeltypes.IdentifiedChannel {
+	if m.GetAllChannelsFn == nil {
+		panic("not supposed to be called!")
+	}
+	return m.GetAllChannelsFn(ctx)
+}
+
+// Auto-implemented from GetAllChannels data
+func (m *MockChannelKeeper) IterateChannels(ctx sdk.Context, cb func(channeltypes.IdentifiedChannel) bool) {
+	channels := m.GetAllChannels(ctx)
+	for _, channel := range channels {
+		stop := cb(channel)
+		if stop {
+			break
+		}
+	}
 }
 
 func (m *MockChannelKeeper) GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool) {

--- a/x/wasm/internal/types/ibc.go
+++ b/x/wasm/internal/types/ibc.go
@@ -16,7 +16,11 @@ type ChannelKeeper interface {
 	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
 	SendPacket(ctx sdk.Context, channelCap *capabilitytypes.Capability, packet ibcexported.PacketI) error
 	ChanCloseInit(ctx sdk.Context, portID, channelID string, chanCap *capabilitytypes.Capability) error
+	GetAllChannels(ctx sdk.Context) (channels []channeltypes.IdentifiedChannel)
+	IterateChannels(ctx sdk.Context, cb func(channeltypes.IdentifiedChannel) bool)
 }
+
+type IdentifiedChannel = channeltypes.IdentifiedChannel
 
 // ClientKeeper defines the expected IBC client keeper
 type ClientKeeper interface {


### PR DESCRIPTION
Closes #434

Code "complete", but needs testing

The `IbcQuery.Channels` variant doesn't seem to match what we can get from the IBC Keeper (we cannot filter by port). This will be very expensive to call.

Let us reconsider what we want to do here. We can still modify the queries we expose to the contracts (remove or adjust them). CosmWasm is still in `-alpha2`, so we can change types.