### PR TITLE
Allow subsecond block times

### DIFF
--- a/docker/setup_wasmd.sh
+++ b/docker/setup_wasmd.sh
@@ -10,16 +10,21 @@ MONIKER=${MONIKER:-node001}
 wasmd init --chain-id "$CHAIN_ID" "$MONIKER"
 # staking/governance token is hardcoded in config, change this
 sed -i "s/\"stake\"/\"$STAKE\"/" "$HOME"/.wasmd/config/genesis.json
+# this is essential for sub-1s block times (or header times go crazy)
+sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.wasmd/config/genesis.json
+
 if ! wasmd keys show validator; then
   (echo "$PASSWORD"; echo "$PASSWORD") | wasmd keys add validator
 fi
 # hardcode the validator account for this instance
 echo "$PASSWORD" | wasmd add-genesis-account validator "1000000000$STAKE,1000000000$FEE"
+
 # (optionally) add a few more genesis accounts
 for addr in "$@"; do
   echo $addr
   wasmd add-genesis-account "$addr" "1000000000$STAKE,1000000000$FEE"
 done
+
 # submit a genesis validator tx
 ## Workraround for https://github.com/cosmos/cosmos-sdk/issues/8251
 (echo "$PASSWORD"; echo "$PASSWORD"; echo "$PASSWORD") | wasmd gentx validator "250000000$STAKE" --chain-id="$CHAIN_ID" --amount="250000000$STAKE"


### PR DESCRIPTION
We need to adjust the genesis file in docker setup script to allow sub-second block times.

Solution from here: https://github.com/tendermint/tendermint/issues/6217#issuecomment-795589506 and manually tested on simapp in https://github.com/confio/ts-relayer/pull/100.

Let's get this in before we tag a wasmd release.