### PR TITLE
Submessage reply can overwrite caller response

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -51,7 +51,7 @@ type Option interface {
 }
 
 // WasmVMQueryHandler is an extension point for custom query handler implementations
-type WASMVMQueryHandler interface {
+type WasmVMQueryHandler interface {
 	// HandleQuery executes the requested query
 	HandleQuery(ctx sdk.Context, caller sdk.AccAddress, request wasmvmtypes.QueryRequest) ([]byte, error)
 }
@@ -76,7 +76,7 @@ type Keeper struct {
 	portKeeper         types.PortKeeper
 	capabilityKeeper   types.CapabilityKeeper
 	wasmVM             types.WasmerEngine
-	wasmVMQueryHandler WASMVMQueryHandler
+	wasmVMQueryHandler WasmVMQueryHandler
 	messenger          Messenger
 	// queryGasLimit is the max wasmvm gas that can be spent on executing a query with a contract
 	queryGasLimit uint64

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -965,6 +965,7 @@ func NewDefaultWasmVMContractResponseHandler(md msgDispatcher) *DefaultWasmVMCon
 	return &DefaultWasmVMContractResponseHandler{md: md}
 }
 
+// Handle processes the data returned by a contract invocation.
 func (h DefaultWasmVMContractResponseHandler) Handle(
 	ctx sdk.Context,
 	contractAddr sdk.AccAddress,

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -1,0 +1,174 @@
+package keeper
+
+import (
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// Messenger is an extension point for custom wasmd message handling
+type Messenger interface {
+	// DispatchMsg encodes the wasmVM message and dispatches it.
+	DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error)
+}
+
+// replyer is a subset of keeper that can handle replies to submessages
+type replyer interface {
+	reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error)
+}
+
+// MessageDispatcher coordinates message sending and submessage reply/ state commits
+type MessageDispatcher struct {
+	messenger Messenger
+	keeper    replyer
+}
+
+// NewMessageDispatcher constructor
+func NewMessageDispatcher(messenger Messenger, keeper replyer) *MessageDispatcher {
+	return &MessageDispatcher{messenger: messenger, keeper: keeper}
+}
+
+// DispatchMessages sends all messages.
+func (d MessageDispatcher) DispatchMessages(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.CosmosMsg) error {
+	for _, msg := range msgs {
+		events, _, err := d.messenger.DispatchMsg(ctx, contractAddr, ibcPort, msg)
+		if err != nil {
+			return err
+		}
+		// redispatch all events, (type sdk.EventTypeMessage will be filtered out in the handler)
+		ctx.EventManager().EmitEvents(events)
+	}
+	return nil
+}
+
+// dispatchMsgWithGasLimit sends a message with gas limit applied
+func (d MessageDispatcher) dispatchMsgWithGasLimit(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msg wasmvmtypes.CosmosMsg, gasLimit uint64) (events []sdk.Event, data [][]byte, err error) {
+	limitedMeter := sdk.NewGasMeter(gasLimit)
+	subCtx := ctx.WithGasMeter(limitedMeter)
+
+	// catch out of gas panic and just charge the entire gas limit
+	defer func() {
+		if r := recover(); r != nil {
+			// if it's not an OutOfGas error, raise it again
+			if _, ok := r.(sdk.ErrorOutOfGas); !ok {
+				// log it to get the original stack trace somewhere (as panic(r) keeps message but stacktrace to here
+				moduleLogger(ctx).Info("SubMsg rethrowing panic: %#v", r)
+				panic(r)
+			}
+			ctx.GasMeter().ConsumeGas(gasLimit, "Sub-Message OutOfGas panic")
+			err = sdkerrors.Wrap(sdkerrors.ErrOutOfGas, "SubMsg hit gas limit")
+		}
+	}()
+	events, data, err = d.messenger.DispatchMsg(subCtx, contractAddr, ibcPort, msg)
+
+	// make sure we charge the parent what was spent
+	spent := subCtx.GasMeter().GasConsumed()
+	ctx.GasMeter().ConsumeGas(spent, "From limited Sub-Message")
+
+	return events, data, err
+}
+
+// DispatchSubmessages builds a sandbox to execute these messages and returns the execution result to the contract
+// that dispatched them, both on success as well as failure
+func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.SubMsg) ([]byte, error) {
+	var rsp []byte
+	for _, msg := range msgs {
+		switch msg.ReplyOn {
+		case wasmvmtypes.ReplySuccess, wasmvmtypes.ReplyError, wasmvmtypes.ReplyAlways:
+		default:
+			return nil, sdkerrors.Wrap(types.ErrInvalid, "replyOn")
+		}
+		// first, we build a sub-context which we can use inside the submessages
+		subCtx, commit := ctx.CacheContext()
+
+		// check how much gas left locally, optionally wrap the gas meter
+		gasRemaining := ctx.GasMeter().Limit() - ctx.GasMeter().GasConsumed()
+		limitGas := msg.GasLimit != nil && (*msg.GasLimit < gasRemaining)
+
+		var err error
+		var events []sdk.Event
+		var data [][]byte
+		if limitGas {
+			events, data, err = d.dispatchMsgWithGasLimit(subCtx, contractAddr, ibcPort, msg.Msg, *msg.GasLimit)
+		} else {
+			events, data, err = d.messenger.DispatchMsg(subCtx, contractAddr, ibcPort, msg.Msg)
+		}
+
+		// if it succeeds, commit state changes from submessage, and pass on events to Event Manager
+		if err == nil {
+			commit()
+			ctx.EventManager().EmitEvents(events)
+		}
+		// on failure, revert state from sandbox, and ignore events (just skip doing the above)
+
+		// we only callback if requested. Short-circuit here the two cases we don't want to
+		if msg.ReplyOn == wasmvmtypes.ReplySuccess && err != nil {
+			return nil, err
+		}
+		if msg.ReplyOn == wasmvmtypes.ReplyError && err == nil {
+			continue
+		}
+
+		// otherwise, we create a SubcallResult and pass it into the calling contract
+		var result wasmvmtypes.SubcallResult
+		if err == nil {
+			// just take the first one for now if there are multiple sub-sdk messages
+			// and safely return nothing if no data
+			var responseData []byte
+			if len(data) > 0 {
+				responseData = data[0]
+			}
+			result = wasmvmtypes.SubcallResult{
+				Ok: &wasmvmtypes.SubcallResponse{
+					Events: sdkEventsToWasmVmEvents(events),
+					Data:   responseData,
+				},
+			}
+		} else {
+			result = wasmvmtypes.SubcallResult{
+				Err: err.Error(),
+			}
+		}
+
+		// now handle the reply, we use the parent context, and abort on error
+		reply := wasmvmtypes.Reply{
+			ID:     msg.ID,
+			Result: result,
+		}
+
+		// we can ignore any result returned as there is nothing to do with the data
+		// and the events are already in the ctx.EventManager()
+		rData, err := d.keeper.reply(ctx, contractAddr, reply)
+		switch {
+		case err != nil:
+			return nil, err
+		case rData.Data != nil:
+			rsp = rData.Data
+		}
+	}
+	return rsp, nil
+}
+
+func sdkEventsToWasmVmEvents(events []sdk.Event) []wasmvmtypes.Event {
+	res := make([]wasmvmtypes.Event, len(events))
+	for i, ev := range events {
+		res[i] = wasmvmtypes.Event{
+			Type:       ev.Type,
+			Attributes: sdkAttributesToWasmVmAttributes(ev.Attributes),
+		}
+	}
+	return res
+}
+
+func sdkAttributesToWasmVmAttributes(attrs []abci.EventAttribute) []wasmvmtypes.EventAttribute {
+	res := make([]wasmvmtypes.EventAttribute, len(attrs))
+	for i, attr := range attrs {
+		res[i] = wasmvmtypes.EventAttribute{
+			Key:   string(attr.Key),
+			Value: string(attr.Value),
+		}
+	}
+	return res
+}

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -143,7 +143,7 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 		rData, err := d.keeper.reply(ctx, contractAddr, reply)
 		switch {
 		case err != nil:
-			return nil, err
+			return nil, sdkerrors.Wrap(err, "reply")
 		case rData.Data != nil:
 			rsp = rData.Data
 		}

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -1,0 +1,236 @@
+package keeper
+
+import (
+	"errors"
+	"fmt"
+	"github.com/CosmWasm/wasmd/x/wasm/keeper/wasmtesting"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"testing"
+)
+
+func TestDispatchSubmessages(t *testing.T) {
+	noReplyCalled := &mockReplyer{}
+	var anyGasLimit uint64 = 1
+	specs := map[string]struct {
+		msgs       []wasmvmtypes.SubMsg
+		replyer    *mockReplyer
+		msgHandler *wasmtesting.MockMessageHandler
+		expErr     bool
+		expData    []byte
+		expCommits []bool
+		expEvents  sdk.Events
+	}{
+		"no reply on error without error": {
+			msgs:    []wasmvmtypes.SubMsg{{ReplyOn: wasmvmtypes.ReplyError}},
+			replyer: noReplyCalled,
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, [][]byte{[]byte("myData")}, nil
+				},
+			},
+			expCommits: []bool{true},
+		},
+		"no reply on success without success": {
+			msgs:    []wasmvmtypes.SubMsg{{ReplyOn: wasmvmtypes.ReplySuccess}},
+			replyer: noReplyCalled,
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, nil, errors.New("test, ignore")
+				},
+			},
+			expCommits: []bool{false},
+			expErr:     true,
+		},
+		"reply on success - received": {
+			msgs: []wasmvmtypes.SubMsg{{
+				ReplyOn: wasmvmtypes.ReplySuccess,
+			}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return &sdk.Result{Data: []byte("myReplyData")}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, [][]byte{[]byte("myData")}, nil
+				},
+			},
+			expData:    []byte("myReplyData"),
+			expCommits: []bool{true},
+		},
+		"reply on error - handled": {
+			msgs: []wasmvmtypes.SubMsg{{
+				ReplyOn: wasmvmtypes.ReplyError,
+			}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return &sdk.Result{Data: []byte("myReplyData")}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, nil, errors.New("my error")
+				},
+			},
+			expData:    []byte("myReplyData"),
+			expCommits: []bool{false},
+		},
+		"with reply events": {
+			msgs: []wasmvmtypes.SubMsg{{
+				ReplyOn: wasmvmtypes.ReplySuccess,
+			}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return &sdk.Result{Data: []byte("myReplyData")}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					myEvents := []sdk.Event{{Type: "myEvent", Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}}}}
+					return myEvents, [][]byte{[]byte("myData")}, nil
+				},
+			},
+			expData:    []byte("myReplyData"),
+			expCommits: []bool{true},
+			expEvents: []sdk.Event{{
+				Type:       "myEvent",
+				Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}},
+			}},
+		},
+		"reply returns error": {
+			msgs: []wasmvmtypes.SubMsg{{
+				ReplyOn: wasmvmtypes.ReplySuccess,
+			}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return nil, errors.New("reply failed")
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, nil, nil
+				},
+			},
+			expCommits: []bool{false},
+			expErr:     true,
+		},
+		"with gas limit - out of gas": {
+			msgs: []wasmvmtypes.SubMsg{{
+				GasLimit: &anyGasLimit,
+				ReplyOn:  wasmvmtypes.ReplyError,
+			}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return &sdk.Result{Data: []byte("myReplyData")}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					ctx.GasMeter().ConsumeGas(sdk.Gas(101), "testing")
+					return nil, [][]byte{[]byte("someData")}, nil
+				},
+			},
+			expData:    []byte("myReplyData"),
+			expCommits: []bool{false},
+		},
+		"with gas limit - within limit no error": {
+			msgs: []wasmvmtypes.SubMsg{{
+				GasLimit: &anyGasLimit,
+				ReplyOn:  wasmvmtypes.ReplyError,
+			}},
+			replyer: &mockReplyer{},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					ctx.GasMeter().ConsumeGas(sdk.Gas(1), "testing")
+					return nil, [][]byte{[]byte("someData")}, nil
+				},
+			},
+			expCommits: []bool{true},
+		},
+		"multiple msg - last reply": {
+			msgs: []wasmvmtypes.SubMsg{{ID: 1, ReplyOn: wasmvmtypes.ReplyError}, {ID: 2, ReplyOn: wasmvmtypes.ReplyError}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					return &sdk.Result{Data: []byte(fmt.Sprintf("myReplyData:%d", reply.ID))}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, nil, errors.New("my error")
+				},
+			},
+			expData:    []byte("myReplyData:2"),
+			expCommits: []bool{false, false},
+		},
+		"multiple msg - last reply with non nil": {
+			msgs: []wasmvmtypes.SubMsg{{ID: 1, ReplyOn: wasmvmtypes.ReplyError}, {ID: 2, ReplyOn: wasmvmtypes.ReplyError}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+					if reply.ID == 2 {
+						return &sdk.Result{}, nil
+					}
+					return &sdk.Result{Data: []byte("myReplyData:1")}, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					return nil, nil, errors.New("my error")
+				},
+			},
+			expData:    []byte("myReplyData:1"),
+			expCommits: []bool{false, false},
+		},
+		"empty replyOn rejected": {
+			msgs:       []wasmvmtypes.SubMsg{{}},
+			replyer:    noReplyCalled,
+			msgHandler: &wasmtesting.MockMessageHandler{},
+			expErr:     true,
+		},
+		"invalid replyOn rejected": {
+			msgs:       []wasmvmtypes.SubMsg{{ReplyOn: "invalid"}},
+			replyer:    noReplyCalled,
+			msgHandler: &wasmtesting.MockMessageHandler{},
+			expCommits: []bool{false},
+			expErr:     true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			var mockStore wasmtesting.MockCommitMultiStore
+			em := sdk.NewEventManager()
+			ctx := sdk.Context{}.WithMultiStore(&mockStore).
+				WithGasMeter(sdk.NewGasMeter(100)).
+				WithEventManager(em)
+			d := NewMessageDispatcher(spec.msgHandler, spec.replyer)
+			gotData, gotErr := d.DispatchSubmessages(ctx, RandomAccountAddress(t), "any_port", spec.msgs)
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			} else {
+				require.NoError(t, gotErr)
+				assert.Equal(t, spec.expData, gotData)
+			}
+			assert.Equal(t, spec.expCommits, mockStore.Committed)
+			if len(spec.expEvents) == 0 {
+				assert.Empty(t, em.Events())
+			} else {
+				assert.Equal(t, spec.expEvents, em.Events())
+			}
+		})
+	}
+}
+
+type mockReplyer struct {
+	replyFn func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error)
+}
+
+func (m mockReplyer) reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) (*sdk.Result, error) {
+	if m.replyFn == nil {
+		panic("not expected to be called")
+	}
+	return m.replyFn(ctx, contractAddress, reply)
+}

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -29,7 +29,7 @@ func WithMessageHandler(x Messenger) Option {
 
 // WithQueryHandler is an optional constructor parameter to set custom query handler for wasmVM requests.
 // This option should not be combined with Option `WithQueryPlugins`.
-func WithQueryHandler(x WASMVMQueryHandler) Option {
+func WithQueryHandler(x WasmVMQueryHandler) Option {
 	return optsFn(func(k *Keeper) {
 		k.wasmVMQueryHandler = x
 	})

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -11,7 +11,7 @@ func (f optsFn) apply(keeper *Keeper) {
 	f(keeper)
 }
 
-// WithMessageHandler is an optional constructor parameter to replace the default wasmVM engine with the
+// WithWasmEngine is an optional constructor parameter to replace the default wasmVM engine with the
 // given one.
 func WithWasmEngine(x types.WasmerEngine) Option {
 	return optsFn(func(k *Keeper) {

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -16,11 +16,11 @@ import (
 
 type QueryHandler struct {
 	Ctx     sdk.Context
-	Plugins WASMVMQueryHandler
+	Plugins WasmVMQueryHandler
 	Caller  sdk.AccAddress
 }
 
-func NewQueryHandler(ctx sdk.Context, vmQueryHandler WASMVMQueryHandler, caller sdk.AccAddress) QueryHandler {
+func NewQueryHandler(ctx sdk.Context, vmQueryHandler WasmVMQueryHandler, caller sdk.AccAddress) QueryHandler {
 	return QueryHandler{
 		Ctx:     ctx,
 		Plugins: vmQueryHandler,

--- a/x/wasm/keeper/relay.go
+++ b/x/wasm/keeper/relay.go
@@ -71,7 +71,7 @@ func (k Keeper) OnConnectChannel(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
+	if _, err := k.wasmVMResponseHandler.Handle(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -109,7 +109,7 @@ func (k Keeper) OnCloseChannel(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
+	if _, err := k.wasmVMResponseHandler.Handle(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -145,7 +145,7 @@ func (k Keeper) OnRecvPacket(
 	// emit all events from this contract itself
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
-	return k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, res.Acknowledgement)
+	return k.wasmVMResponseHandler.Handle(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, res.Acknowledgement)
 }
 
 // OnAckPacket calls the contract to handle the "acknowledgement" data which can contain success or failure of a packet
@@ -180,7 +180,7 @@ func (k Keeper) OnAckPacket(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
+	if _, err := k.wasmVMResponseHandler.Handle(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -215,7 +215,7 @@ func (k Keeper) OnTimeoutPacket(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
+	if _, err := k.wasmVMResponseHandler.Handle(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil

--- a/x/wasm/keeper/relay.go
+++ b/x/wasm/keeper/relay.go
@@ -71,7 +71,7 @@ func (k Keeper) OnConnectChannel(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if err := k.dispatchAll(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages); err != nil {
+	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -109,7 +109,7 @@ func (k Keeper) OnCloseChannel(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if err := k.dispatchAll(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages); err != nil {
+	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -145,11 +145,7 @@ func (k Keeper) OnRecvPacket(
 	// emit all events from this contract itself
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
-
-	if err := k.dispatchAll(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages); err != nil {
-		return nil, err
-	}
-	return res.Acknowledgement, nil
+	return k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, res.Acknowledgement)
 }
 
 // OnAckPacket calls the contract to handle the "acknowledgement" data which can contain success or failure of a packet
@@ -184,7 +180,7 @@ func (k Keeper) OnAckPacket(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if err := k.dispatchAll(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages); err != nil {
+	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil
@@ -219,7 +215,7 @@ func (k Keeper) OnTimeoutPacket(
 	events := types.ParseEvents(res.Attributes, contractAddr)
 	ctx.EventManager().EmitEvents(events)
 
-	if err := k.dispatchAll(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages); err != nil {
+	if _, err := k.handleContractResponseX(ctx, contractAddr, contractInfo.IBCPortID, res.Submessages, res.Messages, nil); err != nil {
 		return err
 	}
 	return nil

--- a/x/wasm/keeper/relay_test.go
+++ b/x/wasm/keeper/relay_test.go
@@ -15,7 +15,8 @@ import (
 func TestOnOpenChannel(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -74,7 +75,8 @@ func TestOnOpenChannel(t *testing.T) {
 func TestOnConnectChannel(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -82,7 +84,7 @@ func TestOnConnectChannel(t *testing.T) {
 		contractGas           sdk.Gas
 		contractResp          *wasmvmtypes.IBCBasicResponse
 		contractErr           error
-		overwriteMessenger    Messenger
+		overwriteMessenger    *wasmtesting.MockMessageHandler
 		expErr                bool
 		expContractEventAttrs int
 		expNoEvents           bool
@@ -148,10 +150,9 @@ func TestOnConnectChannel(t *testing.T) {
 			defer cancel()
 			before := ctx.GasMeter().GasConsumed()
 			msger, capturedMsgs := wasmtesting.NewCapturingMessageHandler()
-			keepers.WasmKeeper.messenger = msger
-
+			*messenger = *msger
 			if spec.overwriteMessenger != nil {
-				keepers.WasmKeeper.messenger = spec.overwriteMessenger
+				*messenger = *spec.overwriteMessenger
 			}
 
 			// when
@@ -184,7 +185,8 @@ func TestOnConnectChannel(t *testing.T) {
 func TestOnCloseChannel(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -192,7 +194,7 @@ func TestOnCloseChannel(t *testing.T) {
 		contractGas           sdk.Gas
 		contractResp          *wasmvmtypes.IBCBasicResponse
 		contractErr           error
-		overwriteMessenger    Messenger
+		overwriteMessenger    *wasmtesting.MockMessageHandler
 		expErr                bool
 		expContractEventAttrs int
 		expNoEvents           bool
@@ -257,10 +259,10 @@ func TestOnCloseChannel(t *testing.T) {
 			defer cancel()
 			before := ctx.GasMeter().GasConsumed()
 			msger, capturedMsgs := wasmtesting.NewCapturingMessageHandler()
-			keepers.WasmKeeper.messenger = msger
+			*messenger = *msger
 
 			if spec.overwriteMessenger != nil {
-				keepers.WasmKeeper.messenger = spec.overwriteMessenger
+				*messenger = *spec.overwriteMessenger
 			}
 
 			// when
@@ -294,7 +296,8 @@ func TestOnCloseChannel(t *testing.T) {
 func TestOnRecvPacket(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -302,7 +305,7 @@ func TestOnRecvPacket(t *testing.T) {
 		contractGas           sdk.Gas
 		contractResp          *wasmvmtypes.IBCReceiveResponse
 		contractErr           error
-		overwriteMessenger    Messenger
+		overwriteMessenger    *wasmtesting.MockMessageHandler
 		expErr                bool
 		expContractEventAttrs int
 		expNoEvents           bool
@@ -380,10 +383,10 @@ func TestOnRecvPacket(t *testing.T) {
 			before := ctx.GasMeter().GasConsumed()
 
 			msger, capturedMsgs := wasmtesting.NewCapturingMessageHandler()
-			keepers.WasmKeeper.messenger = msger
+			*messenger = *msger
 
 			if spec.overwriteMessenger != nil {
-				keepers.WasmKeeper.messenger = spec.overwriteMessenger
+				*messenger = *spec.overwriteMessenger
 			}
 
 			// when
@@ -419,7 +422,8 @@ func TestOnRecvPacket(t *testing.T) {
 func TestOnAckPacket(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -427,7 +431,7 @@ func TestOnAckPacket(t *testing.T) {
 		contractGas           sdk.Gas
 		contractResp          *wasmvmtypes.IBCBasicResponse
 		contractErr           error
-		overwriteMessenger    Messenger
+		overwriteMessenger    *wasmtesting.MockMessageHandler
 		expErr                bool
 		expContractEventAttrs int
 		expNoEvents           bool
@@ -493,10 +497,10 @@ func TestOnAckPacket(t *testing.T) {
 			defer cancel()
 			before := ctx.GasMeter().GasConsumed()
 			msger, capturedMsgs := wasmtesting.NewCapturingMessageHandler()
-			keepers.WasmKeeper.messenger = msger
+			*messenger = *msger
 
 			if spec.overwriteMessenger != nil {
-				keepers.WasmKeeper.messenger = spec.overwriteMessenger
+				*messenger = *spec.overwriteMessenger
 			}
 
 			// when
@@ -530,7 +534,8 @@ func TestOnAckPacket(t *testing.T) {
 func TestOnTimeoutPacket(t *testing.T) {
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures)
+	var messenger = &wasmtesting.MockMessageHandler{}
+	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 
 	specs := map[string]struct {
@@ -538,7 +543,7 @@ func TestOnTimeoutPacket(t *testing.T) {
 		contractGas           sdk.Gas
 		contractResp          *wasmvmtypes.IBCBasicResponse
 		contractErr           error
-		overwriteMessenger    Messenger
+		overwriteMessenger    *wasmtesting.MockMessageHandler
 		expErr                bool
 		expContractEventAttrs int
 		expNoEvents           bool
@@ -603,10 +608,10 @@ func TestOnTimeoutPacket(t *testing.T) {
 			defer cancel()
 			before := ctx.GasMeter().GasConsumed()
 			msger, capturedMsgs := wasmtesting.NewCapturingMessageHandler()
-			keepers.WasmKeeper.messenger = msger
+			*messenger = *msger
 
 			if spec.overwriteMessenger != nil {
-				keepers.WasmKeeper.messenger = spec.overwriteMessenger
+				*messenger = *spec.overwriteMessenger
 			}
 
 			// when

--- a/x/wasm/keeper/wasmtesting/msg_dispatcher.go
+++ b/x/wasm/keeper/wasmtesting/msg_dispatcher.go
@@ -1,0 +1,25 @@
+package wasmtesting
+
+import (
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type MockMsgDispatcher struct {
+	DispatchMessagesFn    func(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.CosmosMsg) error
+	DispatchSubmessagesFn func(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.SubMsg) ([]byte, error)
+}
+
+func (m MockMsgDispatcher) DispatchMessages(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.CosmosMsg) error {
+	if m.DispatchMessagesFn == nil {
+		panic("not expected to be called")
+	}
+	return m.DispatchMessagesFn(ctx, contractAddr, ibcPort, msgs)
+}
+
+func (m MockMsgDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.SubMsg) ([]byte, error) {
+	if m.DispatchSubmessagesFn == nil {
+		panic("not expected to be called")
+	}
+	return m.DispatchSubmessagesFn(ctx, contractAddr, ibcPort, msgs)
+}

--- a/x/wasm/keeper/wasmtesting/store.go
+++ b/x/wasm/keeper/wasmtesting/store.go
@@ -1,0 +1,26 @@
+package wasmtesting
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MockCommitMultiStore mock with a CacheMultiStore to capture commits
+type MockCommitMultiStore struct {
+	sdk.CommitMultiStore
+	Committed []bool
+}
+
+func (m *MockCommitMultiStore) CacheMultiStore() storetypes.CacheMultiStore {
+	m.Committed = append(m.Committed, false)
+	return &mockCMS{m, &m.Committed[len(m.Committed)-1]}
+}
+
+type mockCMS struct {
+	sdk.CommitMultiStore
+	committed *bool
+}
+
+func (m *mockCMS) Write() {
+	*m.committed = true
+}


### PR DESCRIPTION
Resolves #495

Although there a good tests for submessages that work with wasm contracts I found it very hard to to test the reply workflow without mocks. As a result I extracted:
* `MessageDispatcher` to handle the message/submessage flow 
* `DefaultWasmVMContractResponseHandler` to coordinate the dispatching order and result overwrite. This may become a nice extension point

Not related to the task but "refactored as needed" : rename of `WASMVMQueryHandler`