### PR TITLE
Make contract address builder public

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.21.0 h1:Q3vdXlfLNT+OftyBHsU0Y445MD+8m8axjKgf2si0QcM=
 github.com/rs/zerolog v1.21.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
+github.com/rs/zerolog v1.22.0 h1:XrVUjV4K+izZpKXZHlPrYQiDtmdGiCylnT4i43AAWxg=
 github.com/rs/zerolog v1.22.0/go.mod h1:ZPhntP/xmq1nnND05hhpAh2QMhSsA4UN3MGZ6O2J3hM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/CosmWasm/wasmd/x/wasm/keeper"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -317,7 +318,7 @@ func getAllContracts(state *types.GenesisState) []contractMeta {
 	for _, m := range state.GenMsgs {
 		if msg := m.GetInstantiateContract(); msg != nil {
 			all = append(all, contractMeta{
-				ContractAddress: contractAddress(msg.CodeID, seq).String(),
+				ContractAddress: keeper.BuildContractAddress(msg.CodeID, seq).String(),
 				Info: types.ContractInfo{
 					CodeID:  msg.CodeID,
 					Creator: msg.Sender,
@@ -358,7 +359,7 @@ func hasContract(state *types.GenesisState, contractAddr string) bool {
 	seq := contractSeqValue(state)
 	for _, m := range state.GenMsgs {
 		if msg := m.GetInstantiateContract(); msg != nil {
-			if contractAddress(msg.CodeID, seq).String() == contractAddr {
+			if keeper.BuildContractAddress(msg.CodeID, seq).String() == contractAddr {
 				return true
 			}
 			seq++
@@ -509,14 +510,6 @@ func getActorAddress(cmd *cobra.Command) (sdk.AccAddress, error) {
 		return nil, fmt.Errorf("failed to get address from Keybase: %w", err)
 	}
 	return info.GetAddress(), nil
-}
-
-// contractAddress builds a contract address. copied from keeper
-func contractAddress(codeID, instanceID uint64) sdk.AccAddress {
-	// NOTE: It is possible to get a duplicate address if either codeID or instanceID
-	// overflow 32 bits. This is highly improbable, but something that could be refactored.
-	contractID := codeID<<32 + instanceID
-	return addrFromUint64(contractID)
 }
 
 // addrFromUint64 is a helper for address generation, copied from keeper

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -552,11 +552,11 @@ func TestGetAllContracts(t *testing.T) {
 			},
 			exp: []contractMeta{
 				{
-					ContractAddress: contractAddress(0, 1).String(),
+					ContractAddress: keeper.BuildContractAddress(0, 1).String(),
 					Info:            types.ContractInfo{Label: "first"},
 				},
 				{
-					ContractAddress: contractAddress(0, 2).String(),
+					ContractAddress: keeper.BuildContractAddress(0, 2).String(),
 					Info:            types.ContractInfo{Label: "second"},
 				},
 			},
@@ -572,7 +572,7 @@ func TestGetAllContracts(t *testing.T) {
 			},
 			exp: []contractMeta{
 				{
-					ContractAddress: contractAddress(0, 100).String(),
+					ContractAddress: keeper.BuildContractAddress(0, 100).String(),
 					Info:            types.ContractInfo{Label: "hundred"},
 				},
 			},
@@ -598,7 +598,7 @@ func TestGetAllContracts(t *testing.T) {
 					Info:            types.ContractInfo{Label: "first"},
 				},
 				{
-					ContractAddress: contractAddress(0, 100).String(),
+					ContractAddress: keeper.BuildContractAddress(0, 100).String(),
 					Info:            types.ContractInfo{Label: "hundred"},
 				},
 			},

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -260,7 +260,7 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					},
 				},
@@ -281,10 +281,10 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					}, {
-						ContractAddress: contractAddress(1, 2).String(),
+						ContractAddress: BuildContractAddress(1, 2).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					},
 				},
@@ -300,7 +300,7 @@ func TestGenesisInit(t *testing.T) {
 			src: types.GenesisState{
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					},
 				},
@@ -316,10 +316,10 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					}, {
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					},
 				},
@@ -335,7 +335,7 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 						ContractState: []types.Model{
 							{
@@ -383,7 +383,7 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: contractAddress(1, 1).String(),
+						ContractAddress: BuildContractAddress(1, 1).String(),
 						ContractInfo:    types.ContractInfoFixture(func(c *wasmTypes.ContractInfo) { c.CodeID = 1 }, types.OnlyGenesisFields),
 					},
 				},
@@ -595,7 +595,7 @@ func TestSupportedGenMsgTypes(t *testing.T) {
 				Sum: &types.GenesisState_GenMsgs_ExecuteContract{
 					ExecuteContract: &types.MsgExecuteContract{
 						Sender:   verifierAddress.String(),
-						Contract: contractAddress(1, 1).String(),
+						Contract: BuildContractAddress(1, 1).String(),
 						Msg:      []byte(`{"release":{}}`),
 					},
 				},
@@ -619,7 +619,7 @@ func TestSupportedGenMsgTypes(t *testing.T) {
 	require.NotNil(t, codeInfo)
 
 	// verify contract instantiated
-	cInfo := keeper.GetContractInfo(ctx, contractAddress(1, 1))
+	cInfo := keeper.GetContractInfo(ctx, BuildContractAddress(1, 1))
 	require.NotNil(t, cInfo)
 
 	// verify contract executed

--- a/x/wasm/keeper/ibc_test.go
+++ b/x/wasm/keeper/ibc_test.go
@@ -40,7 +40,7 @@ func TestBindingPortForIBCContractOnInstantiate(t *testing.T) {
 }
 
 func TestContractFromPortID(t *testing.T) {
-	contractAddr := contractAddress(1, 100)
+	contractAddr := BuildContractAddress(1, 100)
 	specs := map[string]struct {
 		srcPort string
 		expAddr sdk.AccAddress

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
@@ -96,7 +95,7 @@ func NewKeeper(
 	cdc codec.Marshaler,
 	storeKey sdk.StoreKey,
 	paramSpace paramtypes.Subspace,
-	accountKeeper authkeeper.AccountKeeper,
+	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 	stakingKeeper types.StakingKeeper,
 	distKeeper types.DistributionKeeper,

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -9,6 +9,7 @@ import (
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"io/ioutil"
+	"math"
 	"testing"
 	"time"
 
@@ -1471,5 +1472,43 @@ func TestNewDefaultWasmVMContractResponseHandler(t *testing.T) {
 			assert.Equal(t, spec.expData, gotData)
 		})
 	}
+}
 
+func TestBuildContractAddress(t *testing.T) {
+	specs := map[string]struct {
+		srcCodeID     uint64
+		srcInstanceID uint64
+		expPanic      bool
+	}{
+		"both empty": {},
+		"both below max": {
+			srcCodeID:     math.MaxUint32 - 1,
+			srcInstanceID: math.MaxUint32 - 1,
+		},
+		"both at max": {
+			srcCodeID:     math.MaxUint32,
+			srcInstanceID: math.MaxUint32,
+		},
+		"codeID > max": {
+			srcCodeID: math.MaxUint32 + 1,
+			expPanic:  true,
+		},
+		"instanceID > max": {
+			srcInstanceID: math.MaxUint32 + 1,
+			expPanic:      true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			if spec.expPanic {
+				require.Panics(t, func() {
+					BuildContractAddress(spec.srcCodeID, spec.srcInstanceID)
+				})
+				return
+			}
+			gotAddr := BuildContractAddress(spec.srcCodeID, spec.srcInstanceID)
+			require.NotNil(t, gotAddr)
+			assert.Nil(t, sdk.VerifyAddressFormat(gotAddr))
+		})
+	}
 }

--- a/x/wasm/keeper/proposal_integration_test.go
+++ b/x/wasm/keeper/proposal_integration_test.go
@@ -134,7 +134,7 @@ func TestMigrateProposal(t *testing.T) {
 	var (
 		anyAddress   sdk.AccAddress = bytes.Repeat([]byte{0x1}, sdk.AddrLen)
 		otherAddress sdk.AccAddress = bytes.Repeat([]byte{0x2}, sdk.AddrLen)
-		contractAddr                = contractAddress(1, 1)
+		contractAddr                = BuildContractAddress(1, 1)
 	)
 
 	contractInfoFixture := types.ContractInfoFixture(func(c *types.ContractInfo) {
@@ -194,7 +194,7 @@ func TestMigrateProposal(t *testing.T) {
 func TestAdminProposals(t *testing.T) {
 	var (
 		otherAddress sdk.AccAddress = bytes.Repeat([]byte{0x2}, sdk.AddrLen)
-		contractAddr                = contractAddress(1, 1)
+		contractAddr                = BuildContractAddress(1, 1)
 	)
 	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -152,7 +152,7 @@ func TestQuerySmartContractState(t *testing.T) {
 
 func TestQuerySmartContractPanics(t *testing.T) {
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
-	contractAddr := contractAddress(1, 1)
+	contractAddr := BuildContractAddress(1, 1)
 	keepers.WasmKeeper.storeCodeInfo(ctx, 1, types.CodeInfo{})
 	keepers.WasmKeeper.storeContractInfo(ctx, contractAddr, &types.ContractInfo{
 		CodeID:  1,


### PR DESCRIPTION
This can prevent some copy&paste as the contract address algorithm seems useful in other places as well. For example integration tests

Also includes:
* go mod tidy
* Use interface in keeper not struct type