### PR TITLE
Add cost and api cost options

### DIFF
--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -29,7 +29,6 @@ const (
 	ProposalTypeMigrateContract     = types.ProposalTypeMigrateContract
 	ProposalTypeUpdateAdmin         = types.ProposalTypeUpdateAdmin
 	ProposalTypeClearAdmin          = types.ProposalTypeClearAdmin
-	GasMultiplier                   = keeper.GasMultiplier
 	QueryListContractByCode         = keeper.QueryListContractByCode
 	QueryGetContract                = keeper.QueryGetContract
 	QueryGetContractState           = keeper.QueryGetContractState

--- a/x/wasm/keeper/api.go
+++ b/x/wasm/keeper/api.go
@@ -6,21 +6,28 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const (
+	// DefaultGasCostHumanAddress is how moch SDK gas we charge to convert to a human address format
+	DefaultGasCostHumanAddress = 5
+	// DefaultGasCostCanonicalAddress is how moch SDK gas we charge to convert to a canonical address format
+	DefaultGasCostCanonicalAddress = 4
+)
+
 var (
-	CostHumanize  = 5 * GasMultiplier
-	CostCanonical = 4 * GasMultiplier
+	costHumanize  = DefaultGasCostHumanAddress * DefaultGasMultiplier
+	costCanonical = DefaultGasCostCanonicalAddress * DefaultGasMultiplier
 )
 
 func humanAddress(canon []byte) (string, uint64, error) {
 	if len(canon) != sdk.AddrLen {
-		return "", CostHumanize, fmt.Errorf("Expected %d byte address", sdk.AddrLen)
+		return "", costHumanize, fmt.Errorf("Expected %d byte address", sdk.AddrLen)
 	}
-	return sdk.AccAddress(canon).String(), CostHumanize, nil
+	return sdk.AccAddress(canon).String(), costHumanize, nil
 }
 
 func canonicalAddress(human string) ([]byte, uint64, error) {
 	bz, err := sdk.AccAddressFromBech32(human)
-	return bz, CostCanonical, err
+	return bz, costCanonical, err
 }
 
 var cosmwasmAPI = wasmvm.GoAPI{

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -20,20 +20,20 @@ import (
 	"time"
 )
 
-// GasMultiplier is how many cosmwasm gas points = 1 sdk gas point
+// DefaultGasMultiplier is how many cosmwasm gas points = 1 sdk gas point
 // SDK reference costs can be found here: https://github.com/cosmos/cosmos-sdk/blob/02c6c9fafd58da88550ab4d7d494724a477c8a68/store/types/gas.go#L153-L164
 // A write at ~3000 gas and ~200us = 10 gas per us (microsecond) cpu/io
 // Rough timing have 88k gas at 90us, which is equal to 1k sdk gas... (one read)
 //
 // Please note that all gas prices returned to the wasmer engine should have this multiplied
-const GasMultiplier uint64 = 100
+const DefaultGasMultiplier uint64 = 100
 
-// InstanceCost is how much SDK gas we charge each time we load a WASM instance.
+// DefaultInstanceCost is how much SDK gas we charge each time we load a WASM instance.
 // Creating a new instance is costly, and this helps put a recursion limit to contracts calling contracts.
-const InstanceCost uint64 = 40_000
+const DefaultInstanceCost uint64 = 40_000
 
-// CompileCost is how much SDK gas we charge *per byte* for compiling WASM code.
-const CompileCost uint64 = 2
+// DefaultCompileCost is how much SDK gas we charge *per byte* for compiling WASM code.
+const DefaultCompileCost uint64 = 2
 
 // contractMemoryLimit is the memory limit of each contract execution (in MiB)
 // constant value so all nodes run with the same limit.
@@ -83,6 +83,9 @@ type Keeper struct {
 	// queryGasLimit is the max wasmvm gas that can be spent on executing a query with a contract
 	queryGasLimit uint64
 	paramSpace    paramtypes.Subspace
+	instanceCost  uint64
+	compileCost   uint64
+	gasMultiplier uint64
 }
 
 // NewKeeper creates a new contract Keeper instance
@@ -126,6 +129,9 @@ func NewKeeper(
 		messenger:        NewDefaultMessageHandler(router, channelKeeper, capabilityKeeper, bankKeeper, cdc, portSource),
 		queryGasLimit:    wasmConfig.SmartQueryGasLimit,
 		paramSpace:       paramSpace,
+		instanceCost:     DefaultInstanceCost,
+		compileCost:      DefaultCompileCost,
+		gasMultiplier:    DefaultGasMultiplier,
 	}
 
 	keeper.wasmVMQueryHandler = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, channelKeeper, queryRouter, keeper)
@@ -174,7 +180,7 @@ func (k Keeper) create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte,
 	if err != nil {
 		return 0, sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
 	}
-	ctx.GasMeter().ConsumeGas(CompileCost*uint64(len(wasmCode)), "Compiling WASM Bytecode")
+	ctx.GasMeter().ConsumeGas(k.compileCost*uint64(len(wasmCode)), "Compiling WASM Bytecode")
 
 	codeHash, err := k.wasmVM.Create(wasmCode)
 	if err != nil {
@@ -222,7 +228,7 @@ func (k Keeper) importCode(ctx sdk.Context, codeID uint64, codeInfo types.CodeIn
 func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.AccAddress, initMsg []byte, label string, deposit sdk.Coins, authZ AuthorizationPolicy) (sdk.AccAddress, []byte, error) {
 	defer telemetry.MeasureSince(time.Now(), "wasm", "contract", "instantiate")
 	if !k.IsPinnedCode(ctx, codeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: instantiate")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: instantiate")
 	}
 
 	// create contract address
@@ -268,12 +274,12 @@ func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
 
 	// prepare querier
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddress)
+	querier := k.newQueryHandler(ctx, contractAddress)
 
 	// instantiate wasm contract
-	gas := gasForContract(ctx)
-	res, gasUsed, err := k.wasmVM.Instantiate(codeInfo.CodeHash, env, info, initMsg, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
-	consumeGas(ctx, gasUsed)
+	gas := k.gasForContract(ctx)
+	res, gasUsed, err := k.wasmVM.Instantiate(codeInfo.CodeHash, env, info, initMsg, prefixStore, cosmwasmAPI, querier, k.gasMeter(ctx), gas)
+	k.consumeGas(ctx, gasUsed)
 	if err != nil {
 		return contractAddress, nil, sdkerrors.Wrap(types.ErrInstantiateFailed, err.Error())
 	}
@@ -324,7 +330,7 @@ func (k Keeper) execute(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	}
 
 	if !k.IsPinnedCode(ctx, contractInfo.CodeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: execute")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: execute")
 	}
 
 	// add more funds
@@ -338,10 +344,10 @@ func (k Keeper) execute(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	info := types.NewInfo(caller, coins)
 
 	// prepare querier
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddress)
-	gas := gasForContract(ctx)
-	res, gasUsed, execErr := k.wasmVM.Execute(codeInfo.CodeHash, env, info, msg, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
-	consumeGas(ctx, gasUsed)
+	querier := k.newQueryHandler(ctx, contractAddress)
+	gas := k.gasForContract(ctx)
+	res, gasUsed, execErr := k.wasmVM.Execute(codeInfo.CodeHash, env, info, msg, prefixStore, cosmwasmAPI, querier, k.gasMeter(ctx), gas)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return nil, sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -364,7 +370,7 @@ func (k Keeper) execute(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 func (k Keeper) migrate(ctx sdk.Context, contractAddress sdk.AccAddress, caller sdk.AccAddress, newCodeID uint64, msg []byte, authZ AuthorizationPolicy) (*sdk.Result, error) {
 	defer telemetry.MeasureSince(time.Now(), "wasm", "contract", "migrate")
 	if !k.IsPinnedCode(ctx, newCodeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: migrate")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: migrate")
 	}
 
 	contractInfo := k.GetContractInfo(ctx, contractAddress)
@@ -399,13 +405,13 @@ func (k Keeper) migrate(ctx sdk.Context, contractAddress sdk.AccAddress, caller 
 	env := types.NewEnv(ctx, contractAddress)
 
 	// prepare querier
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddress)
+	querier := k.newQueryHandler(ctx, contractAddress)
 
 	prefixStoreKey := types.GetContractStorePrefix(contractAddress)
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), prefixStoreKey)
-	gas := gasForContract(ctx)
-	res, gasUsed, err := k.wasmVM.Migrate(newCodeInfo.CodeHash, env, msg, &prefixStore, cosmwasmAPI, &querier, gasMeter(ctx), gas)
-	consumeGas(ctx, gasUsed)
+	gas := k.gasForContract(ctx)
+	res, gasUsed, err := k.wasmVM.Migrate(newCodeInfo.CodeHash, env, msg, &prefixStore, cosmwasmAPI, &querier, k.gasMeter(ctx), gas)
+	k.consumeGas(ctx, gasUsed)
 	if err != nil {
 		return nil, sdkerrors.Wrap(types.ErrMigrationFailed, err.Error())
 	}
@@ -444,16 +450,16 @@ func (k Keeper) Sudo(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte
 	}
 
 	if !k.IsPinnedCode(ctx, contractInfo.CodeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: sudo")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: sudo")
 	}
 
 	env := types.NewEnv(ctx, contractAddress)
 
 	// prepare querier
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddress)
-	gas := gasForContract(ctx)
-	res, gasUsed, execErr := k.wasmVM.Sudo(codeInfo.CodeHash, env, msg, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
-	consumeGas(ctx, gasUsed)
+	querier := k.newQueryHandler(ctx, contractAddress)
+	gas := k.gasForContract(ctx)
+	res, gasUsed, execErr := k.wasmVM.Sudo(codeInfo.CodeHash, env, msg, prefixStore, cosmwasmAPI, querier, k.gasMeter(ctx), gas)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return nil, sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -483,7 +489,7 @@ func (k Keeper) reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply was
 
 	// current thought is to charge gas like a fresh run, we can revisit whether to give it a discount later
 	if !k.IsPinnedCode(ctx, contractInfo.CodeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: reply")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: reply")
 	}
 
 	env := types.NewEnv(ctx, contractAddress)
@@ -493,9 +499,9 @@ func (k Keeper) reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply was
 		Ctx:     ctx,
 		Plugins: k.wasmVMQueryHandler,
 	}
-	gas := gasForContract(ctx)
-	res, gasUsed, execErr := k.wasmVM.Reply(codeInfo.CodeHash, env, reply, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gas)
-	consumeGas(ctx, gasUsed)
+	gas := k.gasForContract(ctx)
+	res, gasUsed, execErr := k.wasmVM.Reply(codeInfo.CodeHash, env, reply, prefixStore, cosmwasmAPI, querier, k.gasMeter(ctx), gas)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return nil, sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -598,15 +604,15 @@ func (k Keeper) QuerySmart(ctx sdk.Context, contractAddr sdk.AccAddress, req []b
 		return nil, err
 	}
 	if !k.IsPinnedCode(ctx, contractInfo.CodeID) {
-		ctx.GasMeter().ConsumeGas(InstanceCost, "Loading CosmWasm module: query")
+		ctx.GasMeter().ConsumeGas(k.instanceCost, "Loading CosmWasm module: query")
 	}
 
 	// prepare querier
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
 	env := types.NewEnv(ctx, contractAddr)
-	queryResult, gasUsed, qErr := k.wasmVM.Query(codeInfo.CodeHash, env, req, prefixStore, cosmwasmAPI, querier, gasMeter(ctx), gasForContract(ctx))
-	consumeGas(ctx, gasUsed)
+	queryResult, gasUsed, qErr := k.wasmVM.Query(codeInfo.CodeHash, env, req, prefixStore, cosmwasmAPI, querier, k.gasMeter(ctx), k.gasForContract(ctx))
+	k.consumeGas(ctx, gasUsed)
 	if qErr != nil {
 		return nil, sdkerrors.Wrap(types.ErrQueryFailed, qErr.Error())
 	}
@@ -812,17 +818,17 @@ func (k *Keeper) handleContractResponse(ctx sdk.Context, contractAddr sdk.AccAdd
 	return k.wasmVMResponseHandler.Handle(ctx, contractAddr, ibcPort, res.Submessages, res.Messages, res.Data)
 }
 
-func gasForContract(ctx sdk.Context) uint64 {
+func (k Keeper) gasForContract(ctx sdk.Context) uint64 {
 	meter := ctx.GasMeter()
 	if meter.IsOutOfGas() {
 		return 0
 	}
-	remaining := (meter.Limit() - meter.GasConsumedToLimit()) * GasMultiplier
+	remaining := (meter.Limit() - meter.GasConsumedToLimit()) * k.gasMultiplier
 	return remaining
 }
 
-func consumeGas(ctx sdk.Context, gas uint64) {
-	consumed := gas / GasMultiplier
+func (k Keeper) consumeGas(ctx sdk.Context, gas uint64) {
+	consumed := gas / k.gasMultiplier
 	ctx.GasMeter().ConsumeGas(consumed, "wasm contract")
 	// throw OutOfGas error if we ran out (got exactly to zero due to better limit enforcing)
 	if ctx.GasMeter().IsOutOfGas() {
@@ -907,6 +913,10 @@ func (k Keeper) importContract(ctx sdk.Context, contractAddr sdk.AccAddress, c *
 	return k.importContractState(ctx, contractAddr, state)
 }
 
+func (k Keeper) newQueryHandler(ctx sdk.Context, contractAddress sdk.AccAddress) QueryHandler {
+	return NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddress, k.gasMultiplier)
+}
+
 func addrFromUint64(id uint64) sdk.AccAddress {
 	addr := make([]byte, 20)
 	addr[0] = 'C'
@@ -917,18 +927,21 @@ func addrFromUint64(id uint64) sdk.AccAddress {
 // MultipliedGasMeter wraps the GasMeter from context and multiplies all reads by out defined multiplier
 type MultipliedGasMeter struct {
 	originalMeter sdk.GasMeter
+	gasMultiplier uint64
+}
+
+func NewMultipliedGasMeter(originalMeter sdk.GasMeter, gasMultiplier uint64) MultipliedGasMeter {
+	return MultipliedGasMeter{originalMeter: originalMeter, gasMultiplier: gasMultiplier}
 }
 
 var _ wasmvm.GasMeter = MultipliedGasMeter{}
 
 func (m MultipliedGasMeter) GasConsumed() sdk.Gas {
-	return m.originalMeter.GasConsumed() * GasMultiplier
+	return m.originalMeter.GasConsumed() * m.gasMultiplier
 }
 
-func gasMeter(ctx sdk.Context) MultipliedGasMeter {
-	return MultipliedGasMeter{
-		originalMeter: ctx.GasMeter(),
-	}
+func (k Keeper) gasMeter(ctx sdk.Context) MultipliedGasMeter {
+	return NewMultipliedGasMeter(ctx.GasMeter(), k.gasMultiplier)
 }
 
 // Logger returns a module-specific logger.

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -81,3 +81,26 @@ func WithVMCacheMetrics(r prometheus.Registerer) Option {
 		NewWasmVMMetricsCollector(k.wasmVM).Register(r)
 	})
 }
+
+// WithCosts sets custom gas costs and multiplier.
+// See DefaultCompileCost, DefaultInstanceCost, DefaultGasMultiplier
+// Uses WithApiCosts with defaults and given multiplier.
+func WithCosts(compile, instance, multiplier uint64) Option {
+	return optsFn(func(k *Keeper) {
+		k.compileCost = compile
+		k.instanceCost = instance
+		k.gasMultiplier = multiplier
+		WithApiCosts(
+			DefaultGasCostHumanAddress*multiplier,
+			DefaultGasCostCanonicalAddress*multiplier,
+		).apply(k)
+	})
+}
+
+// WithApiCosts sets custom api costs. Amounts are in cosmwasm gas Not SDK gas.
+func WithApiCosts(human, canonical uint64) Option {
+	return optsFn(func(_ *Keeper) {
+		costHumanize = human
+		costCanonical = canonical
+	})
+}

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -14,38 +14,62 @@ import (
 func TestConstructorOptions(t *testing.T) {
 	specs := map[string]struct {
 		srcOpt Option
-		verify func(Keeper)
+		verify func(*testing.T, Keeper)
 	}{
 		"wasm engine": {
 			srcOpt: WithWasmEngine(&wasmtesting.MockWasmer{}),
-			verify: func(k Keeper) {
+			verify: func(t *testing.T, k Keeper) {
 				assert.IsType(t, k.wasmVM, &wasmtesting.MockWasmer{})
 			},
 		},
 		"message handler": {
 			srcOpt: WithMessageHandler(&wasmtesting.MockMessageHandler{}),
-			verify: func(k Keeper) {
+			verify: func(t *testing.T, k Keeper) {
 				assert.IsType(t, k.messenger, &wasmtesting.MockMessageHandler{})
 			},
 		},
 		"query plugins": {
 			srcOpt: WithQueryHandler(&wasmtesting.MockQueryHandler{}),
-			verify: func(k Keeper) {
+			verify: func(t *testing.T, k Keeper) {
 				assert.IsType(t, k.wasmVMQueryHandler, &wasmtesting.MockQueryHandler{})
 			},
 		},
 		"coin transferrer": {
 			srcOpt: WithCoinTransferrer(&wasmtesting.MockCoinTransferrer{}),
-			verify: func(k Keeper) {
+			verify: func(t *testing.T, k Keeper) {
 				assert.IsType(t, k.bank, &wasmtesting.MockCoinTransferrer{})
+			},
+		},
+		"costs": {
+			srcOpt: WithCosts(1, 2, 3),
+			verify: func(t *testing.T, k Keeper) {
+				t.Cleanup(setApiDefaults)
+				assert.Equal(t, uint64(1), k.compileCost)
+				assert.Equal(t, uint64(2), k.instanceCost)
+				assert.Equal(t, uint64(3), k.gasMultiplier)
+				assert.Equal(t, uint64(15), costHumanize)
+				assert.Equal(t, uint64(12), costCanonical)
+			},
+		},
+		"api costs": {
+			srcOpt: WithApiCosts(1, 2),
+			verify: func(t *testing.T, k Keeper) {
+				t.Cleanup(setApiDefaults)
+				assert.Equal(t, uint64(1), costHumanize)
+				assert.Equal(t, uint64(2), costCanonical)
 			},
 		},
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			k := NewKeeper(nil, nil, paramtypes.NewSubspace(nil, nil, nil, nil, ""), authkeeper.AccountKeeper{}, nil, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, "tempDir", types.DefaultWasmConfig(), SupportedFeatures, spec.srcOpt)
-			spec.verify(k)
+			spec.verify(t, k)
 		})
 	}
 
+}
+
+func setApiDefaults() {
+	costHumanize = DefaultGasCostHumanAddress * DefaultGasMultiplier
+	costCanonical = DefaultGasCostCanonicalAddress * DefaultGasMultiplier
 }

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -158,7 +158,7 @@ func TestQuerySmartContractPanics(t *testing.T) {
 		CodeID:  1,
 		Created: types.NewAbsoluteTxPosition(ctx),
 	})
-	ctx = ctx.WithGasMeter(sdk.NewGasMeter(InstanceCost)).WithLogger(log.TestingLogger())
+	ctx = ctx.WithGasMeter(sdk.NewGasMeter(DefaultInstanceCost)).WithLogger(log.TestingLogger())
 
 	specs := map[string]struct {
 		doInContract func()

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -15,16 +15,18 @@ import (
 )
 
 type QueryHandler struct {
-	Ctx     sdk.Context
-	Plugins WasmVMQueryHandler
-	Caller  sdk.AccAddress
+	Ctx           sdk.Context
+	Plugins       WasmVMQueryHandler
+	Caller        sdk.AccAddress
+	GasMultiplier uint64
 }
 
-func NewQueryHandler(ctx sdk.Context, vmQueryHandler WasmVMQueryHandler, caller sdk.AccAddress) QueryHandler {
+func NewQueryHandler(ctx sdk.Context, vmQueryHandler WasmVMQueryHandler, caller sdk.AccAddress, gasMultiplier uint64) QueryHandler {
 	return QueryHandler{
-		Ctx:     ctx,
-		Plugins: vmQueryHandler,
-		Caller:  caller,
+		Ctx:           ctx,
+		Plugins:       vmQueryHandler,
+		Caller:        caller,
+		GasMultiplier: gasMultiplier,
 	}
 }
 
@@ -44,7 +46,7 @@ var _ wasmvmtypes.Querier = QueryHandler{}
 
 func (q QueryHandler) Query(request wasmvmtypes.QueryRequest, gasLimit uint64) ([]byte, error) {
 	// set a limit for a subctx
-	sdkGas := gasLimit / GasMultiplier
+	sdkGas := gasLimit / q.GasMultiplier
 	subctx := q.Ctx.WithGasMeter(sdk.NewGasMeter(sdkGas))
 
 	// make sure we charge the higher level context even on panic

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -145,7 +145,7 @@ func TestGasCostOnQuery(t *testing.T) {
 
 func TestGasOnExternalQuery(t *testing.T) {
 	const (
-		GasWork50 uint64 = InstanceCost + 8_464
+		GasWork50 uint64 = DefaultInstanceCost + 8_464
 	)
 
 	cases := map[string]struct {

--- a/x/wasm/keeper/relay.go
+++ b/x/wasm/keeper/relay.go
@@ -27,11 +27,11 @@ func (k Keeper) OnOpenChannel(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	gasUsed, execErr := k.wasmVM.IBCChannelOpen(codeInfo.CodeHash, env, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -58,11 +58,11 @@ func (k Keeper) OnConnectChannel(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmVM.IBCChannelConnect(codeInfo.CodeHash, env, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -96,11 +96,11 @@ func (k Keeper) OnCloseChannel(
 	}
 
 	params := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmVM.IBCChannelClose(codeInfo.CodeHash, params, channel, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -133,11 +133,11 @@ func (k Keeper) OnRecvPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmVM.IBCPacketReceive(codeInfo.CodeHash, env, packet, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return nil, sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -167,11 +167,11 @@ func (k Keeper) OnAckPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmVM.IBCPacketAck(codeInfo.CodeHash, env, acknowledgement, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}
@@ -202,11 +202,11 @@ func (k Keeper) OnTimeoutPacket(
 	}
 
 	env := types.NewEnv(ctx, contractAddr)
-	querier := NewQueryHandler(ctx, k.wasmVMQueryHandler, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
 
-	gas := gasForContract(ctx)
+	gas := k.gasForContract(ctx)
 	res, gasUsed, execErr := k.wasmVM.IBCPacketTimeout(codeInfo.CodeHash, env, packet, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas)
-	consumeGas(ctx, gasUsed)
+	k.consumeGas(ctx, gasUsed)
 	if execErr != nil {
 		return sdkerrors.Wrap(types.ErrExecuteFailed, execErr.Error())
 	}

--- a/x/wasm/keeper/relay_test.go
+++ b/x/wasm/keeper/relay_test.go
@@ -32,7 +32,7 @@ func TestOnOpenChannel(t *testing.T) {
 		},
 		"consume max gas": {
 			contractAddr: example.Contract,
-			contractGas:  math.MaxUint64 / GasMultiplier,
+			contractGas:  math.MaxUint64 / DefaultGasMultiplier,
 		},
 		"consume gas on error": {
 			contractAddr: example.Contract,
@@ -50,7 +50,7 @@ func TestOnOpenChannel(t *testing.T) {
 			myChannel := wasmvmtypes.IBCChannel{Version: "my test channel"}
 			m.IBCChannelOpenFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, channel wasmvmtypes.IBCChannel, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (uint64, error) {
 				assert.Equal(t, myChannel, channel)
-				return spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()
@@ -143,7 +143,7 @@ func TestOnConnectChannel(t *testing.T) {
 			myChannel := wasmvmtypes.IBCChannel{Version: "my test channel"}
 			m.IBCChannelConnectFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, channel wasmvmtypes.IBCChannel, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
 				assert.Equal(t, channel, myChannel)
-				return spec.contractResp, spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractResp, spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()
@@ -253,7 +253,7 @@ func TestOnCloseChannel(t *testing.T) {
 			myChannel := wasmvmtypes.IBCChannel{Version: "my test channel"}
 			m.IBCChannelCloseFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, channel wasmvmtypes.IBCChannel, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
 				assert.Equal(t, channel, myChannel)
-				return spec.contractResp, spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractResp, spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()
@@ -376,7 +376,7 @@ func TestOnRecvPacket(t *testing.T) {
 
 			m.IBCPacketReceiveFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, packet wasmvmtypes.IBCPacket, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (*wasmvmtypes.IBCReceiveResponse, uint64, error) {
 				assert.Equal(t, myPacket, packet)
-				return spec.contractResp, spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractResp, spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()
@@ -491,7 +491,7 @@ func TestOnAckPacket(t *testing.T) {
 			myAck := wasmvmtypes.IBCAcknowledgement{Acknowledgement: []byte("myAck")}
 			m.IBCPacketAckFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, ack wasmvmtypes.IBCAcknowledgement, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
 				assert.Equal(t, myAck, ack)
-				return spec.contractResp, spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractResp, spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()
@@ -602,7 +602,7 @@ func TestOnTimeoutPacket(t *testing.T) {
 			myPacket := wasmvmtypes.IBCPacket{Data: []byte("my test packet")}
 			m.IBCPacketTimeoutFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, packet wasmvmtypes.IBCPacket, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
 				assert.Equal(t, myPacket, packet)
-				return spec.contractResp, spec.contractGas * GasMultiplier, spec.contractErr
+				return spec.contractResp, spec.contractGas * DefaultGasMultiplier, spec.contractErr
 			}
 
 			ctx, cancel := parentCtx.CacheContext()


### PR DESCRIPTION
Resolves #525 

I have started with public vars but stopped as this would open the door for concurrent access from outside the module. As a library we should protect against that. A simple but safe alternative are constructor `Options`. It was not in my original lists of proposals though.