### PR TITLE
Multiply default wasm size by 2

### DIFF
--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -16,7 +16,7 @@ const (
 	// DefaultParamspace for params keeper
 	DefaultParamspace = ModuleName
 	// DefaultMaxWasmCodeSize limit max bytes read to prevent gzip bombs
-	DefaultMaxWasmCodeSize = 600 * 1024
+	DefaultMaxWasmCodeSize = 600 * 1024 * 2
 )
 
 var ParamStoreKeyUploadAccess = []byte("uploadAccess")

--- a/x/wasm/types/params_test.go
+++ b/x/wasm/types/params_test.go
@@ -168,7 +168,7 @@ func TestParamsUnmarshalJson(t *testing.T) {
 		"defaults": {
 			src: `{"code_upload_access": {"permission": "Everybody"},
 				"instantiate_default_permission": "Everybody",
-				"max_wasm_code_size": 614400}`,
+				"max_wasm_code_size": 1228800}`,
 			exp: DefaultParams(),
 		},
 	}


### PR DESCRIPTION
On testnets, we multiply this limit by 2. In the past we have seen contracts exceeding this limit. We can increase this by default if you see fit.