### PR TITLE
Document event handling

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -1,0 +1,69 @@
+# Event System
+
+## Usage in the SDK
+
+Events are an essential part of the Cosmos SDK. They are similar to "logs" in Ethereum and allow a blockchain
+app to attach key-value pairs to a transaction that can later be used to search for it or extract some information
+in human readable form. Events are not written to the application state, nor do they form part of the AppHash,
+but mainly intended for client use (and become an essential API for any reactive app or app that searches for txs). 
+
+In contrast, transactions also have a binary "data" field that is part of the AppHash (provable with light client proofs,
+part of consensus). This data is not searchable, but given a tx hash, you can be gauranteed what the data returned is.
+This is often empty, but sometimes custom protobuf formats to return essential information from an execution.
+
+Every message in the SDK may add events to the EventManager and these are then added to the final ABCI result that is returned
+to Tendermint. Events are exposed in 3 different ways over the Tendermint API (which is the only way a client can query).
+First of all is the `events` field on the transaction result (when you query a transaction by hash, you can see all event emitted
+by it). Secondly is the `log` field on the same transaction result. And third is the query interface to search or subscribe for
+transactions. 
+
+The `log` field actually has the best data. It contains an array of array of events. The first array is one entry per incoming message.
+Transactions in the Cosmos SDK may consist of multiple messages that are executed atomically. Maybe we send tokens, then issue a swap
+on a DEX. Each action would return it's own list of Events and in the logs, these are separated. For each message, it maintains a list
+of Events, exactly in the order returned by the application. This is JSON encoded and can be parsed by a client.
+
+In Tendermint 0.35, the `events` field will be one flattened list of events over all messages. Just appending the lists returned
+from each message. However, currently (until Tendermint 0.34 used in Cosmos SDK 0.40-0.43), they are flattened on type. Meaning all events
+with type `wasm` get merged into one. This makes the API not very useful to understanding more complex events currently. (TODO: link PR fixing this)
+
+In the search/subscribe interface, you can query for transactions by `AND`ing a number of conditions. Each is expressed like
+`<type>.<key>=<value>`. For example, `message.signer=cosmos1234567890`. It will return all transactions that emitted an event matching this filter.
+
+### Examples
+
+TODO: show event structure.
+
+TODO: contrast flattened/unflattened events
+
+### Standard Events in the SDK
+
+TODO: what is added by the AnteHandlers
+
+TODO: what is emitted by bank (transfer event), as this is a very important base event
+
+## Usage in wasmd
+
+In `x/wasm` we also use Events system. On one hand, `x/wasm` emits standard event for each message it processes to convey,
+for example, "uploaded code, id 6" or "executed code, address wasm1234567890". Furthermore, it allows contracts to
+emit custom events based on their execution state, so they can for example say "dex swap, BTC-ATOM, in 0.23, out 512"
+which require internal knowledge of the contract and is very useful for custom dApp UIs.
+
+In addition, when a smart contract executes a SubMsg and processes the reply, it receives not only the `data` response
+from the message exection, but also the list of events 
+
+### Standard Events in x/wasm
+
+TODO: document what we emit in `x/wasm` regardless of the contract return results
+
+### Emitted Custom Events from a Contract
+
+TODO: document how we process attributes and events fields in the Response.
+
+* Base event `wasm`
+* Event name mangling (prepend `wasm-`)
+* Append trusted attribute _contract_address
+* Validation requirements (_ reserved, non-empty, min-length 2 for type)
+
+## Event Details for wasmd
+
+Beyond the basic Event system and emitted events, we 

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -37,7 +37,7 @@ TODO: contrast flattened/unflattened events
 
 ### Standard Events in the SDK
 
-TODO: what is added by the AnteHandlers
+TODO: what is added by the AnteHandlers (message.signer? auth?)
 
 TODO: what is emitted by bank (transfer event), as this is a very important base event
 
@@ -66,4 +66,24 @@ TODO: document how we process attributes and events fields in the Response.
 
 ## Event Details for wasmd
 
-Beyond the basic Event system and emitted events, we 
+Beyond the basic Event system and emitted events, we must handle more advanced cases in `x/wasm`
+and thus add some more logic to the event processing. Remember that CosmWasm contracts dispatch other
+messages themselves, so far from the flattened event structure, or even a list of list (separated
+by message index in the tx), we actually have a tree of messages, each with their own events. And we must
+flatten that in a meaningful way to feed it into the event system.
+
+Furthermore, with the sub-message reply handlers, we end up with eg. "Contract A execute", "Contract B execute",
+"Contract A reply". If we return all events by all of these, we may end up with many repeated event types and
+a confusing results, especially for Tendermint 0.34 where they are merged together.
+
+While designing this, we wish to make something that is usable with Tendermint 0.34, but focus on using the
+behavior of Tendermint 0.35+ (which is the same behavior as we have internally in the SDK... submessages
+all have their own list of Events). Thus, we may emit more events than in previous wasmd versions (as we assume
+they will be returned in an ordered list rather than merged).
+
+### Combining Events from Sub-Messages
+
+TODO
+### Exposing Events to Reply
+
+TODO

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -167,14 +167,12 @@ sdk.NewEvent(
     "instantiate",
     sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(data)),
 )
 
 // Execute Contract
 sdk.NewEvent(
     "execute",
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(data)),
 )
 
 // Migrate Contract
@@ -183,7 +181,6 @@ sdk.NewEvent(
     // Note: this is the new code id that is being migrated to
     sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(data)),
 )
 
 // Set new admin
@@ -339,7 +336,6 @@ sdk.NewEvent(
 sdk.NewEvent(
     "execute",
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(data)),
 ),
 sdk.NewEvent(
     "wasm",
@@ -352,7 +348,6 @@ sdk.NewEvent(
     "instantiate",
     sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", newContract.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(initData)),
 )
 // didn't emit any attributes, but one event
 sdk.NewEvent(
@@ -392,7 +387,6 @@ sdk.NewEvent(
     "instantiate",
     sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", newContract.String()),
-    sdk.NewAttribute("result", hex.EncodeToString(initData)),
 )
 sdk.NewEvent(
     "wasm-custom",

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -212,7 +212,10 @@ sdk.NewEvent(
 sdk.NewEvent(
     "reply",
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("success", strconv.FormatBool(err == nil)),
+    // If the submessage was successful, and reply is processing the success case
+    sdk.NewAttribute("mode", "handle_success"),
+    // If the submessage returned an error that was "caught" by the reply block
+    sdk.NewAttribute("mode", "handle_failure"),
 )
 
 // Emitted when handling sudo
@@ -360,7 +363,7 @@ sdk.NewEvent(
 sdk.NewEvent(
     "reply",
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
-    sdk.NewAttribute("success", "true"),
+    sdk.NewAttribute("mode", "handle_success"),
 ),
 sdk.NewEvent(
     "wasm",

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -155,8 +155,7 @@ Here are some examples:
 // Store Code
 sdk.NewEvent(
     "store_code",
-    // Update in 0.18: _code_id is also a reserved prefix
-    sdk.NewAttribute("_code_id", fmt.Sprintf("%d", codeID)),
+    sdk.NewAttribute("code_id", fmt.Sprintf("%d", codeID)),
     // features required by the contract (new in 0.18)
     // see https://github.com/CosmWasm/wasmd/issues/574
     sdk.NewAttribute("feature", "stargate"),
@@ -166,7 +165,7 @@ sdk.NewEvent(
 // Instantiate Contract
 sdk.NewEvent(
     "instantiate",
-    sdk.NewAttribute("_code_id", fmt.Sprintf("%d", msg.CodeID)),
+    sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
     sdk.NewAttribute("result", hex.EncodeToString(data)),
 )
@@ -182,7 +181,7 @@ sdk.NewEvent(
 sdk.NewEvent(
     "migrate",
     // Note: this is the new code id that is being migrated to
-    sdk.NewAttribute("_code_id", fmt.Sprintf("%d", msg.CodeID)),
+    sdk.NewAttribute("code_id", fmt.Sprintf("%d", msg.CodeID)),
     sdk.NewAttribute("_contract_addr", contractAddr.String()),
     sdk.NewAttribute("result", hex.EncodeToString(data)),
 )
@@ -203,13 +202,13 @@ sdk.NewEvent(
 // Pin Code
 sdk.NewEvent(
     "pin_code",
-    sdk.NewAttribute("_code_id", strconv.FormatUint(msg.CodeID, 10)),
+    sdk.NewAttribute("code_id", strconv.FormatUint(msg.CodeID, 10)),
 )
 
 // Unpin Code
 sdk.NewEvent(
     "unpin_code",
-    sdk.NewAttribute("_code_id", strconv.FormatUint(msg.CodeID, 10)),
+    sdk.NewAttribute("code_id", strconv.FormatUint(msg.CodeID, 10)),
 )
 
 // Emitted when processing a submessage reply
@@ -222,8 +221,8 @@ sdk.NewEvent(
 
 Note that every event that affects a contract (not store code, pin or unpin) will return the contract_addr as
 `_contract_addr`. The events that are related to a particular wasm code (store code, instantiate, pin, unpin, and migrate)
-will emit that as `_code_id`. All attributes prefixed with `_` are reserved and may not be emitted by a smart contract,
-so we use consistently with the underscore prefix, as they may also be present in the wasm events.
+will emit that as `code_id`. All attributes prefixed with `_` are reserved and may not be emitted by a smart contract,
+so we use the underscore prefix consistently with attributes that may be injected into custom events.
 
 ### Emitted Custom Events from a Contract
 
@@ -233,8 +232,7 @@ are emitted to the blockchain.
 
 Every contract execution, be it execute, instantiate, migrate, reply, will receive a `wasm` type event. This event will
 always be tagged with `_contract_address` by the Go module, so this is trust-worthy. The contract itself cannot overwrite
-this field. (QUESTION: do we want to emit `_code_id` as well for the code id that was just executed?) Beyond this, if the
-contract returned any `attributes`, these are appended to the same event after the standard tags.
+this field. Beyond this, if the contract returned any `attributes`, these are appended to the same event after the standard tags.
 
 A contact may also return custom `events`. These are multiple events, each with their own type as well as attributes.
 When they are received, `x/wasm` prepends `wasm-` to the event type returned by the contact to avoid them trying to fake
@@ -278,7 +276,7 @@ sdk.NewEvent(
 While the `wasm` and `wasm-*` namespacing does sandbox the smart contract events and limits malicious activity they could
 undertake, we also perform a number of further validation checks on the contracts:
 
-* No attribute key may start with `_`. This is currently used for `_contract_address` and `_code_id` and is reserved for a 
+* No attribute key may start with `_`. This is currently used for `_contract_address` and is reserved for a 
   namespace for injecting more *trusted* attributes from the `x/wasm` module as opposed to the contract itself
 * Event types are trimmed of whitespace, and must have at least two characters prior to prepending `wasm-`. If the contract returns
   "  hello\n", the event type will look like `wasm-hello`. If it emits "  a  ", this will be rejected with an error (aborting execution!)

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -230,9 +230,9 @@ When a CosmWasm contract returns a `Response` from one of the calls, it may retu
 of events (in addition to data and a list of messages to dispatch). These are then processed in `x/wasm` to create events that
 are emitted to the blockchain.
 
-Every contract execution, be it execute, instantiate, migrate, reply, will receive a `wasm` type event. This event will
+If the response contains a non-empty list of `attributes`, `x/wasm` will emit a `wasm` type event. This event will
 always be tagged with `_contract_address` by the Go module, so this is trust-worthy. The contract itself cannot overwrite
-this field. Beyond this, if the contract returned any `attributes`, these are appended to the same event after the standard tags.
+this field. Beyond this, the `attributes` returned by the contract, these are appended to the same event.
 
 A contact may also return custom `events`. These are multiple events, each with their own type as well as attributes.
 When they are received, `x/wasm` prepends `wasm-` to the event type returned by the contact to avoid them trying to fake
@@ -270,6 +270,11 @@ sdk.NewEvent(
     sdk.NewAttribute("address", "cosmos19875632"),
 )
 ```
+
+If the Response contains neither `event` nor `attributes`, not `wasm*` events will be emitted, just the standard `message`
+type as well as the action-dependent event (like `execute` or `migrate`). This is a significant change from pre-0.18 versions
+where one could count on the `wasm` event to always be emitted. Now it is recommended to search for `execute._contract_address="foo"`
+to find all transactions related to the contract.
 
 ### Validation Rules
 


### PR DESCRIPTION
This goes into great detail on both how Tendermint and the Cosmos SDK handle events, as well as how we work with them in `x/wasm` and when interfacing with smart contracts.

This documents a spec on the desired format for implementing #440

Closes #448 and remove all filtering of `message` events.

Document a solution to #552 which is a small adjustment from the current behaviour.

Documents a format for #574

We may want to raise new issues for any other changes defined here if they don't fit in the above 3 issues.