### PR TITLE
Filter events before reply block

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -1072,20 +1072,12 @@ func NewDefaultWasmVMContractResponseHandler(md msgDispatcher) *DefaultWasmVMCon
 
 // Handle processes the data returned by a contract invocation.
 func (h DefaultWasmVMContractResponseHandler) Handle(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, messages []wasmvmtypes.SubMsg, origRspData []byte) ([]byte, error) {
-	em := sdk.NewEventManager()
 	result := origRspData
-	switch rsp, err := h.md.DispatchSubmessages(ctx.WithEventManager(em), contractAddr, ibcPort, messages); {
+	switch rsp, err := h.md.DispatchSubmessages(ctx, contractAddr, ibcPort, messages); {
 	case err != nil:
 		return nil, sdkerrors.Wrap(err, "submessages")
 	case rsp != nil:
 		result = rsp
-	}
-	// TODO: remove this - handled inside DispatchSubmessages
-	// emit non message type events only
-	for _, e := range em.Events() {
-		if e.Type != sdk.EventTypeMessage {
-			ctx.EventManager().EmitEvent(e)
-		}
 	}
 	return result, nil
 }

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -1080,6 +1080,7 @@ func (h DefaultWasmVMContractResponseHandler) Handle(ctx sdk.Context, contractAd
 	case rsp != nil:
 		result = rsp
 	}
+	// TODO: remove this - handled inside DispatchSubmessages
 	// emit non message type events only
 	for _, e := range em.Events() {
 		if e.Type != sdk.EventTypeMessage {

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -1563,15 +1563,6 @@ func TestNewDefaultWasmVMContractResponseHandler(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"message events filtered out": {
-			setup: func(m *wasmtesting.MockMsgDispatcher) {
-				m.DispatchSubmessagesFn = func(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.SubMsg) ([]byte, error) {
-					ctx.EventManager().EmitEvent(sdk.NewEvent(sdk.EventTypeMessage))
-					return nil, nil
-				}
-			},
-			expEvts: sdk.Events{},
-		},
 		"message emit non message events": {
 			setup: func(m *wasmtesting.MockMsgDispatcher) {
 				m.DispatchSubmessagesFn = func(ctx sdk.Context, contractAddr sdk.AccAddress, ibcPort string, msgs []wasmvmtypes.SubMsg) ([]byte, error) {

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -102,7 +102,7 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 		var filteredEvents []sdk.Event
 		if err == nil {
 			commit()
-			filteredEvents = filterEvents(em.Events(), events)
+			filteredEvents = filterEvents(append(em.Events(), events...))
 			ctx.EventManager().EmitEvents(filteredEvents)
 		} // on failure, revert state from sandbox, and ignore events (just skip doing the above)
 
@@ -154,19 +154,12 @@ func (d MessageDispatcher) DispatchSubmessages(ctx sdk.Context, contractAddr sdk
 	return rsp, nil
 }
 
-func filterEvents(events ...[]sdk.Event) []sdk.Event {
+func filterEvents(events []sdk.Event) []sdk.Event {
 	// pre-allocate space for efficiency
-	cap := 0
-	for _, evts := range events {
-		cap += len(evts)
-	}
-	res := make([]sdk.Event, 0, cap)
-
-	for _, evts := range events {
-		for _, ev := range evts {
-			if ev.Type != "message" {
-				res = append(res, ev)
-			}
+	res := make([]sdk.Event, 0, len(events))
+	for _, ev := range events {
+		if ev.Type != "message" {
+			res = append(res, ev)
 		}
 	}
 	return res

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -308,7 +308,7 @@ func TestDispatchSubmessages(t *testing.T) {
 					if res.Events[0].Type != "execute" {
 						return nil, fmt.Errorf("event0: %#v", res.Events[0])
 					}
-					if res.Events[0].Type != "wasm" {
+					if res.Events[1].Type != "wasm" {
 						return nil, fmt.Errorf("event1: %#v", res.Events[1])
 					}
 

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -85,6 +85,7 @@ func TestDispatchSubmessages(t *testing.T) {
 			}},
 			replyer: &mockReplyer{
 				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) ([]byte, error) {
+					ctx.EventManager().EmitEvent(sdk.NewEvent("wasm-reply"))
 					return []byte("myReplyData"), nil
 				},
 			},
@@ -99,7 +100,9 @@ func TestDispatchSubmessages(t *testing.T) {
 			expEvents: []sdk.Event{{
 				Type:       "myEvent",
 				Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}},
-			}},
+			},
+				sdk.NewEvent("wasm-reply"),
+			},
 		},
 		"with context events - released on commit": {
 			msgs: []wasmvmtypes.SubMsg{{
@@ -265,6 +268,53 @@ func TestDispatchSubmessages(t *testing.T) {
 			},
 			expData:    []byte{},
 			expCommits: []bool{false, false},
+		},
+		"reply gets proper events": {
+			msgs: []wasmvmtypes.SubMsg{{ID: 1, ReplyOn: wasmvmtypes.ReplyAlways}},
+			replyer: &mockReplyer{
+				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) ([]byte, error) {
+					if reply.Result.Err != "" {
+						return nil, errors.New(reply.Result.Err)
+					}
+					res := reply.Result.Ok
+
+					// ensure the input events are what we expect
+					// I didn't use require.Equal() to act more like a contract... but maybe that would be better
+					if len(res.Events) != 2 {
+						return nil, fmt.Errorf("event count: %#v", res.Events)
+					}
+					if res.Events[0].Type != "execute" {
+						return nil, fmt.Errorf("event0: %#v", res.Events[0])
+					}
+					if res.Events[0].Type != "wasm" {
+						return nil, fmt.Errorf("event1: %#v", res.Events[1])
+					}
+
+					// let's add a custom event here and see if it makes it out
+					ctx.EventManager().EmitEvent(sdk.NewEvent("wasm-reply"))
+
+					// update data from what we got in
+					return res.Data, nil
+				},
+			},
+			msgHandler: &wasmtesting.MockMessageHandler{
+				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+					events = []sdk.Event{
+						sdk.NewEvent("message", sdk.NewAttribute("_contract_address", contractAddr.String())),
+						// we don't know what the contarctAddr will be so we can't use it in the final tests
+						sdk.NewEvent("execute", sdk.NewAttribute("_contract_address", "placeholder-random-addr")),
+						sdk.NewEvent("wasm", sdk.NewAttribute("random", "data")),
+					}
+					return events, [][]byte{[]byte("subData")}, nil
+				},
+			},
+			expData:    []byte("subData"),
+			expCommits: []bool{true},
+			expEvents: []sdk.Event{
+				sdk.NewEvent("execute", sdk.NewAttribute("_contract_address", "placeholder-random-addr")),
+				sdk.NewEvent("wasm", sdk.NewAttribute("random", "data")),
+				sdk.NewEvent("wasm-reply"),
+			},
 		},
 	}
 	for name, spec := range specs {

--- a/x/wasm/keeper/submsg_test.go
+++ b/x/wasm/keeper/submsg_test.go
@@ -93,7 +93,7 @@ func TestDispatchSubMsgSuccessCase(t *testing.T) {
 	require.NotNil(t, res.Result.Ok)
 	sub := res.Result.Ok
 	assert.Empty(t, sub.Data)
-	require.Len(t, sub.Events, 3)
+	require.Len(t, sub.Events, 1)
 
 	transfer := sub.Events[0]
 	assert.Equal(t, "transfer", transfer.Type)
@@ -101,22 +101,6 @@ func TestDispatchSubMsgSuccessCase(t *testing.T) {
 		Key:   "recipient",
 		Value: fred.String(),
 	}, transfer.Attributes[0])
-
-	sender := sub.Events[1]
-	assert.Equal(t, "message", sender.Type)
-	assert.Equal(t, wasmvmtypes.EventAttribute{
-		Key:   "sender",
-		Value: contractAddr.String(),
-	}, sender.Attributes[0])
-
-	// where does this come from?
-	module := sub.Events[2]
-	assert.Equal(t, "message", module.Type)
-	assert.Equal(t, wasmvmtypes.EventAttribute{
-		Key:   "module",
-		Value: "bank",
-	}, module.Attributes[0])
-
 }
 
 func TestDispatchSubMsgErrorHandling(t *testing.T) {
@@ -262,7 +246,7 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 			submsgID: 5,
 			msg:      validBankSend,
 			// note we charge another 40k for the reply call
-			resultAssertions: []assertion{assertReturnedEvents(3), assertGasUsed(123000, 125000)},
+			resultAssertions: []assertion{assertReturnedEvents(1), assertGasUsed(116000, 121000)},
 		},
 		"not enough tokens": {
 			submsgID:    6,
@@ -282,7 +266,7 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 			msg:      validBankSend,
 			gasLimit: &subGasLimit,
 			// uses same gas as call without limit
-			resultAssertions: []assertion{assertReturnedEvents(3), assertGasUsed(123000, 125000)},
+			resultAssertions: []assertion{assertReturnedEvents(1), assertGasUsed(116000, 121000)},
 		},
 		"not enough tokens with limit": {
 			submsgID:    16,
@@ -300,7 +284,6 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 			// uses all the subGasLimit, plus the 92k or so for the main contract
 			resultAssertions: []assertion{assertGasUsed(subGasLimit+92000, subGasLimit+94000), assertErrorString("out of gas")},
 		},
-
 		"instantiate contract gets address in data and events": {
 			submsgID:         21,
 			msg:              instantiateContract,


### PR DESCRIPTION
Closes #587 

- [x] Add failing testcase showing messages make it into reply block
- [x] Ensure reply doesn't get event(message)
- [x] Ensure submessage event(message) doesn't make it out with no reply block
- [x] Remove no-longer needed event(message) filtering in DefaultWasmVMContractResponseHandler.Handle
- [x] Update other tests as needed
