### PR TITLE
Follow up on duplicate event emition

### DIFF
--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -104,7 +104,7 @@ func TestDispatchSubmessages(t *testing.T) {
 				sdk.NewEvent("wasm-reply"),
 			},
 		},
-		"with context events - released on commit": {
+		"with context events - discarded on commit": {
 			msgs: []wasmvmtypes.SubMsg{{
 				ReplyOn: wasmvmtypes.ReplyNever,
 			}},
@@ -117,10 +117,6 @@ func TestDispatchSubmessages(t *testing.T) {
 				},
 			},
 			expCommits: []bool{true},
-			expEvents: []sdk.Event{{
-				Type:       "myEvent",
-				Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}},
-			}},
 		},
 		"with context events - discarded on failure": {
 			msgs: []wasmvmtypes.SubMsg{{
@@ -352,10 +348,9 @@ func TestDispatchSubmessages(t *testing.T) {
 				require.Error(t, gotErr)
 				assert.Empty(t, em.Events())
 				return
-			} else {
-				require.NoError(t, gotErr)
-				assert.Equal(t, spec.expData, gotData)
 			}
+			require.NoError(t, gotErr)
+			assert.Equal(t, spec.expData, gotData)
 			assert.Equal(t, spec.expCommits, mockStore.Committed)
 			if len(spec.expEvents) == 0 {
 				assert.Empty(t, em.Events())


### PR DESCRIPTION
Follow up on #440

Events were returned as value of the message processing call but also emitted via context event manager when talking directly to sdk keepers. With this PR context events are captured and returned for our handler plugins.

An open question for is what to do with custom handlers that are not updated?
Before we appended context events to the returned ones. With this PR they are **silently discarded** (see https://github.com/CosmWasm/wasmd/compare/polish_event_emitting?expand=1#diff-171d7d96b1521ea0c90ca4c1d112065104dab4d6c1219f84f60a5c2dc3d28d6dR85). 
Another option would be to be strict and fail the TX. 