### PR TITLE
TX counter spike

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// NewAnteHandler returns an AnteHandler that checks and increments sequence
+// numbers, checks signatures & account numbers, and deducts fees from the first
+// signer.
+func NewAnteHandler(
+	ak ante.AccountKeeper, bankKeeper types.BankKeeper,
+	sigGasConsumer ante.SignatureVerificationGasConsumer,
+	signModeHandler signing.SignModeHandler,
+	txCounterStoreKey sdk.StoreKey,
+) sdk.AnteHandler {
+	// copied sdk https://github.com/cosmos/cosmos-sdk/blob/v0.42.9/x/auth/ante/ante.go
+	return sdk.ChainAnteDecorators(
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		ante.NewRejectExtensionOptionsDecorator(),
+		ante.NewMempoolFeeDecorator(),
+		ante.NewValidateBasicDecorator(),
+		ante.TxTimeoutHeightDecorator{},
+		ante.NewValidateMemoDecorator(ak),
+		ante.NewConsumeGasForTxSizeDecorator(ak),
+		ante.NewRejectFeeGranterDecorator(),
+		ante.NewSetPubKeyDecorator(ak), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewValidateSigCountDecorator(ak),
+		ante.NewDeductFeeDecorator(ak, bankKeeper),
+		ante.NewSigGasConsumeDecorator(ak, sigGasConsumer),
+		ante.NewSigVerificationDecorator(ak, signModeHandler),
+		ante.NewIncrementSequenceDecorator(ak),
+		wasmkeeper.NewCountTXDecorator(txCounterStoreKey),
+	)
+}

--- a/app/app.go
+++ b/app/app.go
@@ -486,9 +486,9 @@ func NewWasmApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetAnteHandler(
-		ante.NewAnteHandler(
+		NewAnteHandler(
 			app.accountKeeper, app.bankKeeper, ante.DefaultSigVerificationGasConsumer,
-			encodingConfig.TxConfig.SignModeHandler(),
+			encodingConfig.TxConfig.SignModeHandler(), keys[wasm.StoreKey],
 		),
 	)
 	app.SetEndBlocker(app.EndBlocker)

--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -74,6 +74,7 @@ var (
 	NewQuerier                = keeper.Querier
 	ContractFromPortID        = keeper.ContractFromPortID
 	WithWasmEngine            = keeper.WithWasmEngine
+	NewCountTXDecorator       = keeper.NewCountTXDecorator
 
 	// variable aliases
 	ModuleCdc            = types.ModuleCdc

--- a/x/wasm/keeper/ante.go
+++ b/x/wasm/keeper/ante.go
@@ -1,0 +1,40 @@
+package keeper
+
+import (
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type CountTXDecorator struct {
+	storeKey sdk.StoreKey
+}
+
+func NewCountTXDecorator(storeKey sdk.StoreKey) *CountTXDecorator {
+	return &CountTXDecorator{storeKey: storeKey}
+}
+
+func (a CountTXDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if simulate {
+		return next(types.WithTXCounter(ctx, 0), tx, simulate)
+	}
+	currentHeight := ctx.BlockHeight()
+	store := ctx.KVStore(a.storeKey)
+	var txCounter uint64 = 0
+	if bz := store.Get(types.TXCounterPrefix); bz != nil {
+		lastHeight, val := decodeHeightCounter(bz)
+		if currentHeight == lastHeight {
+			txCounter = val
+		}
+	}
+	store.Set(types.TXCounterPrefix, encodeHeightCounter(currentHeight, txCounter+1))
+
+	return next(types.WithTXCounter(ctx, txCounter), tx, simulate)
+}
+
+func encodeHeightCounter(height int64, counter uint64) []byte {
+	return append(sdk.Uint64ToBigEndian(uint64(height)), sdk.Uint64ToBigEndian(counter)...)
+}
+
+func decodeHeightCounter(bz []byte) (int64, uint64) {
+	return int64(sdk.BigEndianToUint64(bz[0:8])), sdk.BigEndianToUint64(bz[8:])
+}

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -191,6 +191,8 @@ func createTestInput(
 		Height: 1234567,
 		Time:   time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
 	}, isCheckTx, log.NewNopLogger())
+	ctx = types.WithTXCounter(ctx, 0)
+
 	encodingConfig := MakeEncodingConfig(t)
 	appCodec, legacyAmino := encodingConfig.Marshaler, encodingConfig.Amino
 

--- a/x/wasm/types/ante.go
+++ b/x/wasm/types/ante.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type contextKey int
+
+const (
+	// private type creates an interface key for Context that cannot be accessed by any other package
+	contextKeyTXCount contextKey = iota
+)
+
+func WithTXCounter(ctx sdk.Context, counter uint64) sdk.Context {
+	return ctx.WithValue(contextKeyTXCount, counter)
+}
+
+// TXCounter return tx counter value
+// Will default to `0` when not set for example in external queries or simulations
+func TXCounter(ctx sdk.Context) uint64 {
+	val, ok := ctx.Value(contextKeyTXCount).(uint64)
+	if !ok {
+		return 0
+	}
+	return val
+}

--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -30,6 +30,7 @@ var (
 	ContractCodeHistoryElementPrefix               = []byte{0x05}
 	ContractByCodeIDAndCreatedSecondaryIndexPrefix = []byte{0x06}
 	PinnedCodeIndexPrefix                          = []byte{0x07}
+	TXCounterPrefix                                = []byte{0x08}
 
 	KeyLastCodeID     = append(SequenceKeyPrefix, []byte("lastCodeId")...)
 	KeyLastInstanceID = append(SequenceKeyPrefix, []byte("lastContractId")...)

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -257,7 +257,7 @@ func NewEnv(ctx sdk.Context, contractAddr sdk.AccAddress) wasmvmtypes.Env {
 		panic("Block (unix) time must never be empty or negative ")
 	}
 	txCounter := TXCounter(ctx)
-	// todo: where to store the counter
+	// todo: where to set the counter
 	_ = txCounter
 
 	env := wasmvmtypes.Env{

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -256,6 +256,10 @@ func NewEnv(ctx sdk.Context, contractAddr sdk.AccAddress) wasmvmtypes.Env {
 	if nano < 1 {
 		panic("Block (unix) time must never be empty or negative ")
 	}
+	txCounter := TXCounter(ctx)
+	// todo: where to store the counter
+	_ = txCounter
+
 	env := wasmvmtypes.Env{
 		Block: wasmvmtypes.BlockInfo{
 			Height:  uint64(ctx.BlockHeight()),
@@ -265,6 +269,7 @@ func NewEnv(ctx sdk.Context, contractAddr sdk.AccAddress) wasmvmtypes.Env {
 		Contract: wasmvmtypes.ContractInfo{
 			Address: contractAddr.String(),
 		},
+		// tx info?
 	}
 	return env
 }

--- a/x/wasm/types/types_test.go
+++ b/x/wasm/types/types_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -296,7 +297,7 @@ func TestNewEnv(t *testing.T) {
 		exp    wasmvmtypes.Env
 	}{
 		"all good": {
-			srcCtx: sdk.Context{}.WithBlockHeight(1).WithBlockTime(myTime).WithChainID("testing"),
+			srcCtx: WithTXCounter(sdk.Context{}.WithBlockHeight(1).WithBlockTime(myTime).WithChainID("testing").WithContext(context.Background()), 0),
 			exp: wasmvmtypes.Env{
 				Block: wasmvmtypes.BlockInfo{
 					Height:  1,


### PR DESCRIPTION
🚧  SPIKE: do not merge

See #601

In this spike I have added an ante handler that counts the TX in a block and passes this down to the wasmvm Env.

* The counter is persisted in the KV store as check/deliver/simulate processes handle their DB state accordingly
* Simulations and external queries run with TX count `0`. 

Not included:
* How the TX counter is passed to the contracts
* Tests

Does this work for you @reuvenpo @assafmo ?