### PR TITLE
More realistic benchmarks

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -35,8 +35,8 @@ import (
 // WasmApp testing.
 var DefaultConsensusParams = &abci.ConsensusParams{
 	Block: &abci.BlockParams{
-		MaxBytes: 2000000,
-		MaxGas:   20000000,
+		MaxBytes: 8000000,
+		MaxGas:   80000000,
 	},
 	Evidence: &tmproto.EvidenceParams{
 		MaxAgeNumBlocks: 302400,

--- a/benchmarks/app_test.go
+++ b/benchmarks/app_test.go
@@ -77,6 +77,8 @@ type AppInfo struct {
 	MinterAddr   sdk.AccAddress
 	ContractAddr string
 	Denom        string
+	AccNum       uint64
+	SeqNum       uint64
 	TxConfig     client.TxConfig
 }
 
@@ -152,6 +154,8 @@ func InitializeWasmApp(b testing.TB, db dbm.DB, numAccounts int) AppInfo {
 		MinterAddr:   addr,
 		ContractAddr: contractAddr,
 		Denom:        denom,
+		AccNum:       0,
+		SeqNum:       2,
 		TxConfig:     simappparams.MakeTestEncodingConfig().TxConfig,
 	}
 }

--- a/benchmarks/app_test.go
+++ b/benchmarks/app_test.go
@@ -88,14 +88,29 @@ func InitializeWasmApp(b testing.TB, db dbm.DB, numAccounts int) AppInfo {
 	addr := sdk.AccAddress(minter.PubKey().Address())
 	denom := "uatom"
 
-	// genesis setup
-	genAccs := []authtypes.GenesisAccount{&authtypes.BaseAccount{
+	// genesis setup (with a bunch of random accounts)
+	genAccs := make([]authtypes.GenesisAccount, numAccounts+1)
+	bals := make([]banktypes.Balance, numAccounts+1)
+	genAccs[0] = &authtypes.BaseAccount{
 		Address: addr.String(),
-	}}
-	bals := []banktypes.Balance{{
+	}
+	bals[0] = banktypes.Balance{
 		Address: addr.String(),
 		Coins:   sdk.NewCoins(sdk.NewInt64Coin(denom, 100000000000)),
-	}}
+	}
+	for i := 0; i <= numAccounts; i++ {
+		acct := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		if i == 0 {
+			acct = addr.String()
+		}
+		genAccs[i] = &authtypes.BaseAccount{
+			Address: acct,
+		}
+		bals[i] = banktypes.Balance{
+			Address: acct,
+			Coins:   sdk.NewCoins(sdk.NewInt64Coin(denom, 100000000000)),
+		}
+	}
 	wasmApp := SetupWithGenesisAccounts(db, genAccs, bals...)
 
 	// add wasm contract

--- a/benchmarks/app_test.go
+++ b/benchmarks/app_test.go
@@ -174,3 +174,27 @@ func InitializeWasmApp(b testing.TB, db dbm.DB, numAccounts int) AppInfo {
 		TxConfig:     simappparams.MakeTestEncodingConfig().TxConfig,
 	}
 }
+
+func GenSequenceOfTxs(b testing.TB, info *AppInfo, msgGen func(*AppInfo) ([]sdk.Msg, error), numToGenerate int) []sdk.Tx {
+	fees := sdk.Coins{sdk.NewInt64Coin(info.Denom, 0)}
+	txs := make([]sdk.Tx, numToGenerate)
+
+	for i := 0; i < numToGenerate; i++ {
+		msgs, err := msgGen(info)
+		require.NoError(b, err)
+		txs[i], err = helpers.GenTx(
+			info.TxConfig,
+			msgs,
+			fees,
+			1234567,
+			"",
+			[]uint64{info.AccNum},
+			[]uint64{info.SeqNum},
+			info.MinterKey,
+		)
+		require.NoError(b, err)
+		info.SeqNum += 1
+	}
+
+	return txs
+}

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -86,6 +86,18 @@ func BenchmarkTxSending(b *testing.B) {
 			blockSize: 20,
 			txBuilder: cw20TransferTxs,
 		},
+		"basic send - leveldb - 10k accounts": {
+			db:        buildLevelDB,
+			blockSize: 20,
+			txBuilder: bankSendTxs,
+			numAccounts: 10000,
+		},
+		"cw20 transfer - leveldb - 10k accounts": {
+			db:        buildLevelDB,
+			blockSize: 20,
+			txBuilder: cw20TransferTxs,
+			numAccounts: 10000,
+		},
 	}
 
 	for name, tc := range cases {

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -73,33 +73,37 @@ func BenchmarkTxSending(b *testing.B) {
 			db:        buildMemDB,
 			blockSize: 20,
 			txBuilder: buildTxFromMsg(bankSendMsg),
+			numAccounts: 50,
 		},
 		"cw20 transfer - memdb": {
 			db:        buildMemDB,
 			blockSize: 20,
 			txBuilder: buildTxFromMsg(cw20TransferMsg),
+			numAccounts: 50,
 		},
 		"basic send - leveldb": {
 			db:        buildLevelDB,
 			blockSize: 20,
 			txBuilder: buildTxFromMsg(bankSendMsg),
+			numAccounts: 50,
 		},
 		"cw20 transfer - leveldb": {
 			db:        buildLevelDB,
 			blockSize: 20,
 			txBuilder: buildTxFromMsg(cw20TransferMsg),
+			numAccounts: 50,
 		},
-		"basic send - leveldb - 10k accounts": {
+		"basic send - leveldb - 8k accounts": {
 			db:          buildLevelDB,
 			blockSize:   20,
 			txBuilder:   buildTxFromMsg(bankSendMsg),
-			numAccounts: 10000,
+			numAccounts: 8000,
 		},
-		"cw20 transfer - leveldb - 10k accounts": {
+		"cw20 transfer - leveldb - 8k accounts": {
 			db:          buildLevelDB,
 			blockSize:   20,
 			txBuilder:   buildTxFromMsg(cw20TransferMsg),
-			numAccounts: 10000,
+			numAccounts: 8000,
 		},
 	}
 

--- a/benchmarks/cw20_test.go
+++ b/benchmarks/cw20_test.go
@@ -1,0 +1,22 @@
+package benchmarks
+
+type cw20InitMsg struct {
+	Name            string    `json:"name"`
+	Symbol          string    `json:"symbol"`
+	Decimals        uint8     `json:"decimals"`
+	InitialBalances []balance `json:"initial_balances"`
+}
+
+type balance struct {
+	Address string `json:"address"`
+	Amount  uint64 `json:"amount,string"`
+}
+
+type cw20ExecMsg struct {
+	Transfer *transferMsg `json:"transfer,omitempty"`
+}
+
+type transferMsg struct {
+	Recipient string `json:"recipient"`
+	Amount    uint64 `json:"amount,string"`
+}


### PR DESCRIPTION
More work on #635 

- Unify setup (exact same chain config for bank and cw20 sends)
- Parameterize DB (memdb / leveldb)
- Parameterize Initial Accounts (how many inactive accounts fill up space before benchmarking)
- Send tokens to different accounts each time (still one sender)