### PR TITLE
Fixed wrong error message when lastCodeID value is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/CosmWasm/wasmd/tree/HEAD)
 
+**Implemented Enhancements:**
+
+- Updated error log statements in initGenesis to easy debugging: [\#643](https://github.com/CosmWasm/wasmd/issues/643)
+
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.20.0...HEAD)
 
 ## [v0.20.0](https://github.com/CosmWasm/wasmd/tree/v0.20.0) (2021-10-08)

--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -55,11 +56,13 @@ func InitGenesis(ctx sdk.Context, keeper *Keeper, data types.GenesisState, staki
 	}
 
 	// sanity check seq values
-	if keeper.peekAutoIncrementID(ctx, types.KeyLastCodeID) <= maxCodeID {
-		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s must be greater %d ", string(types.KeyLastCodeID), maxCodeID)
+	seqVal := keeper.peekAutoIncrementID(ctx, types.KeyLastCodeID)
+	if seqVal <= maxCodeID {
+		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be less than or equal to maxCodeID: %d ", string(types.KeyLastCodeID), seqVal, maxCodeID)
 	}
-	if keeper.peekAutoIncrementID(ctx, types.KeyLastInstanceID) <= uint64(maxContractID) {
-		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s must be greater %d ", string(types.KeyLastInstanceID), maxContractID)
+	seqVal = keeper.peekAutoIncrementID(ctx, types.KeyLastInstanceID)
+	if seqVal <= uint64(maxContractID) {
+		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be less than or equal to maxContractID: %d ", string(types.KeyLastInstanceID), seqVal, maxContractID)
 	}
 
 	if len(data.GenMsgs) == 0 {


### PR DESCRIPTION
The current error message gives an incorrect log statement in the initGenesis function if the lastCodeID is incorrect and fails to print out the current but incorrect value. I updated the log statement as well as added all the fields to make debugging around this error easier in the future.

#643 