### PR TITLE
Handle error on Address not found

### DIFF
--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -57,6 +57,9 @@ func StoreCodeCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
 			msg, err := parseStoreCodeArgs(args[0], clientCtx.GetFromAddress(), cmd.Flags())
 			if err != nil {
 				return err


### PR DESCRIPTION
If we use a wallet address which does not exist, it gives the following error: 
```
Error: empty address string is not allowed
```
which is coming from the SDK and confusing to the user. 
The reason is because one error is not handled properly, in the new proposal, the error is handled which returns the following error if the address does not exist:

```
Error: The specified item could not be found in the keyring
```