### PR TITLE
Disable false positive linter alert

### DIFF
--- a/x/wasm/handler.go
+++ b/x/wasm/handler.go
@@ -25,7 +25,7 @@ func NewHandler(k types.ContractOpsKeeper) sdk.Handler {
 			err error
 		)
 		switch msg := msg.(type) {
-		case *MsgStoreCode:
+		case *MsgStoreCode: //nolint:typecheck
 			res, err = msgServer.StoreCode(sdk.WrapSDKContext(ctx), msg)
 		case *MsgInstantiateContract:
 			res, err = msgServer.InstantiateContract(sdk.WrapSDKContext(ctx), msg)


### PR DESCRIPTION
Works on my box but fails on CI 🤷 
```
golangci-lint has version v1.42.1 built from 54f4301d on 2021-09-06T17:23:27Z
x/wasm/handler.go:28:8: previous case (typecheck)
		case *MsgStoreCode:
		     ^

Exited with code exit status 1
```
https://app.circleci.com/pipelines/github/CosmWasm/wasmd/1558/workflows/6513fc0d-b56e-4ed8-894d-83c80f529d9b/jobs/4881?invite=true#step-102-6