### PR TITLE
Open read access to sequences

### DIFF
--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -56,11 +56,11 @@ func InitGenesis(ctx sdk.Context, keeper *Keeper, data types.GenesisState, staki
 	}
 
 	// sanity check seq values
-	seqVal := keeper.peekAutoIncrementID(ctx, types.KeyLastCodeID)
+	seqVal := keeper.PeekAutoIncrementID(ctx, types.KeyLastCodeID)
 	if seqVal <= maxCodeID {
 		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be greater than: %d ", string(types.KeyLastCodeID), seqVal, maxCodeID)
 	}
-	seqVal = keeper.peekAutoIncrementID(ctx, types.KeyLastInstanceID)
+	seqVal = keeper.PeekAutoIncrementID(ctx, types.KeyLastInstanceID)
 	if seqVal <= uint64(maxContractID) {
 		return nil, sdkerrors.Wrapf(types.ErrInvalid, "seq %s with value: %d must be greater than: %d ", string(types.KeyLastInstanceID), seqVal, maxContractID)
 	}
@@ -125,7 +125,7 @@ func ExportGenesis(ctx sdk.Context, keeper *Keeper) *types.GenesisState {
 	for _, k := range [][]byte{types.KeyLastCodeID, types.KeyLastInstanceID} {
 		genState.Sequences = append(genState.Sequences, types.Sequence{
 			IDKey: k,
-			Value: keeper.peekAutoIncrementID(ctx, k),
+			Value: keeper.PeekAutoIncrementID(ctx, k),
 		})
 	}
 

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -911,18 +911,6 @@ func assertNil(err error) {
 	}
 }
 
-// GetNextCodeID reads the next sequence id used for storing wasm code.
-// Read only operation.
-func (k Keeper) GetNextCodeID(ctx sdk.Context) uint64 {
-	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.KeyLastCodeID)
-	id := uint64(1)
-	if bz != nil {
-		id = binary.BigEndian.Uint64(bz)
-	}
-	return id
-}
-
 func (k Keeper) autoIncrementID(ctx sdk.Context, lastIDKey []byte) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(lastIDKey)
@@ -935,8 +923,8 @@ func (k Keeper) autoIncrementID(ctx sdk.Context, lastIDKey []byte) uint64 {
 	return id
 }
 
-// peekAutoIncrementID reads the current value without incrementing it.
-func (k Keeper) peekAutoIncrementID(ctx sdk.Context, lastIDKey []byte) uint64 {
+// PeekAutoIncrementID reads the current value without incrementing it.
+func (k Keeper) PeekAutoIncrementID(ctx sdk.Context, lastIDKey []byte) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(lastIDKey)
 	id := uint64(1)


### PR DESCRIPTION
We provided the next code id  but not the next contract instance. 