### PR TITLE
Fix flickering benchmark tests

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -91,6 +91,7 @@ func BenchmarkTxSending(b *testing.B) {
 	for name, tc := range cases {
 		b.Run(name, func(b *testing.B) {
 			db := tc.db(b)
+			defer db.Close()
 			appInfo := InitializeWasmApp(b, db, tc.numAccounts)
 			txs := tc.txBuilder(b, &appInfo)
 


### PR DESCRIPTION
Resolves #659 
The DB was blocking with a file handler some times.
