### PR TITLE
`ContractInfo` query: return `NoSuchContract` system error instead of sdk error

### DIFF
--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -487,7 +487,7 @@ func WasmQuerier(k wasmQueryKeeper) func(ctx sdk.Context, request *wasmvmtypes.W
 			}
 			info := k.GetContractInfo(ctx, addr)
 			if info == nil {
-				return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownAddress, request.ContractInfo.ContractAddr)
+				return nil, wasmvmtypes.NoSuchContract{Addr: request.ContractInfo.ContractAddr}
 			}
 
 			res := wasmvmtypes.ContractInfoResponse{


### PR DESCRIPTION
Closes #687.