### PR TITLE
feat: Starport config file

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,16 @@
+accounts:
+  - name: alice
+    coins: ["20000token", "200000000stake"]
+  - name: bob
+    coins: ["10000token", "100000000stake"]
+validator:
+  name: alice
+  staked: "100000000stake"
+client:
+  openapi:
+    path: "docs/static/openapi.yml"
+faucet:
+  name: bob
+  coins: ["5token", "100000stake"]
+build:
+  main: "cmd/wasmd"


### PR DESCRIPTION
Many Starport users are asking for CosmWasm. Cosmos SDK is notorious for how hard it is to add modules to an existing chain `app.go` (either manually or programmatically). Until Cosmos SDK becomes better at handling modules, I propose adding a simple `config.yml`, so that users can do this:

```
git clone https://github.com/cosmwasm/wasmd
cd wasmd
starport chain serve
```