### PR TITLE
Run docker build only for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,10 +186,10 @@ workflows:
       - docker-image:
           requires:
             - setup-dependencies
-#          filters:
-#            branches:
-#              only:
-#                - master
+          filters:
+            branches:
+              only:
+                - master
       - docker-tagged:
           filters:
             tags:


### PR DESCRIPTION
Enable filters to run docker build only on master branch.
(Disabled in #733)