### PR TITLE
Add missing colons in String of some proposals

### DIFF
--- a/x/wasm/types/proposal.go
+++ b/x/wasm/types/proposal.go
@@ -258,7 +258,7 @@ func (p MigrateContractProposal) String() string {
   Description: %s
   Contract:    %s
   Code id:     %d
-  Msg          %q
+  Msg:         %q
 `, p.Title, p.Description, p.Contract, p.CodeID, p.Msg)
 }
 
@@ -311,7 +311,7 @@ func (p SudoContractProposal) String() string {
   Title:       %s
   Description: %s
   Contract:    %s
-  Msg          %q
+  Msg:         %q
 `, p.Title, p.Description, p.Contract, p.Msg)
 }
 

--- a/x/wasm/types/proposal_test.go
+++ b/x/wasm/types/proposal_test.go
@@ -479,7 +479,7 @@ func TestProposalStrings(t *testing.T) {
   Description: Bar
   Contract:    cosmos14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr
   Code id:     1
-  Msg          "{\"verifier\":\"cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs2m6sx4\"}"
+  Msg:         "{\"verifier\":\"cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs2m6sx4\"}"
 `,
 		},
 		"update admin": {


### PR DESCRIPTION
Some proposals miss a colon after `Msg` in string yaml format.
This PR adds them.