### PR TITLE
Remove breaking changes checks step from GH Action

### DIFF
--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -20,11 +20,12 @@ jobs:
         with:
           input: 'proto'
 
+      # TODO: Add this when project is more stable.
       # backward compatibility breaking checks
-      - uses: bufbuild/buf-breaking-action@v1
-        with:
-          input: 'proto'
-          against: 'https://github.com/CosmWasm/wasmd.git#branch=master'
+      #- uses: bufbuild/buf-breaking-action@v1
+      #  with:
+      #    input: 'proto'
+      #    against: 'https://github.com/CosmWasm/wasmd.git#branch=master'
 
       # publish proto files
       - uses: bufbuild/buf-push-action@v1


### PR DESCRIPTION
It will be added later when project is more stable, since it fails
the PR if there are backward compatibility breaking changes.