### PR TITLE
Add module name to buf.yml file

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -4,6 +4,7 @@
 # This module represents the "proto" root found in
 # the previous configuration.
 version: v1
+name: buf.build/cosmwasm/wasmd
 breaking:
   use:
     - FILE


### PR DESCRIPTION
The module name is a required field as specified here:
https://docs.buf.build/bsr/overview