### PR TITLE
Relaxed address strength restrictions for legacy 20 byte addresses

### DIFF
--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -57,7 +57,8 @@ func GetContractStorePrefix(addr sdk.AccAddress) []byte {
 func GetContractByCreatedSecondaryIndexKey(contractAddr sdk.AccAddress, c ContractCodeHistoryEntry) []byte {
 	prefix := GetContractByCodeIDSecondaryIndexPrefix(c.CodeID)
 	prefixLen := len(prefix)
-	r := make([]byte, prefixLen+AbsoluteTxPositionLen+ContractAddrLen)
+	contractAddrLen := len(contractAddr)
+	r := make([]byte, prefixLen+AbsoluteTxPositionLen+contractAddrLen)
 	copy(r[0:], prefix)
 	copy(r[prefixLen:], c.Updated.Bytes())
 	copy(r[prefixLen+AbsoluteTxPositionLen:], contractAddr)
@@ -87,7 +88,8 @@ func GetContractCodeHistoryElementKey(contractAddr sdk.AccAddress, pos uint64) [
 // GetContractCodeHistoryElementPrefix returns the key prefix for a contract code history entry: `<prefix><contractAddr>`
 func GetContractCodeHistoryElementPrefix(contractAddr sdk.AccAddress) []byte {
 	prefixLen := len(ContractCodeHistoryElementPrefix)
-	r := make([]byte, prefixLen+len(contractAddr))
+	contractAddrLen := len(contractAddr)
+	r := make([]byte, prefixLen+contractAddrLen)
 	copy(r[0:], ContractCodeHistoryElementPrefix)
 	copy(r[prefixLen:], contractAddr)
 	return r

--- a/x/wasm/types/keys.go
+++ b/x/wasm/types/keys.go
@@ -87,7 +87,7 @@ func GetContractCodeHistoryElementKey(contractAddr sdk.AccAddress, pos uint64) [
 // GetContractCodeHistoryElementPrefix returns the key prefix for a contract code history entry: `<prefix><contractAddr>`
 func GetContractCodeHistoryElementPrefix(contractAddr sdk.AccAddress) []byte {
 	prefixLen := len(ContractCodeHistoryElementPrefix)
-	r := make([]byte, prefixLen+ContractAddrLen)
+	r := make([]byte, prefixLen+len(contractAddr))
 	copy(r[0:], ContractCodeHistoryElementPrefix)
 	copy(r[prefixLen:], contractAddr)
 	return r


### PR DESCRIPTION
This PR upstreams the changes required for addressing #758 on the Provenance Blockchain.

By removing the assumption that a valid address would always be 32 bytes long per the current standard, the previous shorter 20 byte addresses can be used for accessing existing instances.  All new instances will conform to the new 32 byte form.

(PR opened by request of @ethanfrey, also CC @channa-figure )