### PR TITLE
Update to wasmvm beta7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ WORKDIR /code
 COPY . /code/
 
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta6/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
-RUN sha256sum /lib/libwasmvm_muslc.a | grep e9cb9517585ce3477905e2d4e37553d85f6eac29bdc3b9c25c37c8f5e554045c
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0-beta7/libwasmvm_muslc.a /lib/libwasmvm_muslc.a
+RUN sha256sum /lib/libwasmvm_muslc.a | grep d0152067a5609bfdfb3f0d5d6c0f2760f79d5f2cd7fd8513cafa9932d22eb350
 
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc make build

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.17
 
 require (
-	github.com/CosmWasm/wasmvm v1.0.0-beta6
+	github.com/CosmWasm/wasmvm v1.0.0-beta7
 	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/cosmos/iavl v0.17.3
 	github.com/cosmos/ibc-go/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQ
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/CosmWasm/wasmvm v1.0.0-beta6 h1:JYh9Z7qF6h9a2sOOx9hZRwCVS4aFdd+aiwrIXznLn8k=
 github.com/CosmWasm/wasmvm v1.0.0-beta6/go.mod h1:mtwKxbmsko1zdwpaKiRkRwxijMmIAtnLaX5/UT2nPFk=
+github.com/CosmWasm/wasmvm v1.0.0-beta7 h1:hCa6P8tUTh8viabzeXfede5iPlopSav9Guh+hupXjvU=
+github.com/CosmWasm/wasmvm v1.0.0-beta7/go.mod h1:y+yd9piV8KlrB7ISRZz1sDwH4UVm4Q9rEX9501dBNog=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -672,6 +672,7 @@ func TestExecuteWithNonExistingAddress(t *testing.T) {
 }
 
 func TestExecuteWithPanic(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.ContractKeeper
 
@@ -703,6 +704,7 @@ func TestExecuteWithPanic(t *testing.T) {
 }
 
 func TestExecuteWithCpuLoop(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.ContractKeeper
 
@@ -745,6 +747,7 @@ func TestExecuteWithCpuLoop(t *testing.T) {
 }
 
 func TestExecuteWithStorageLoop(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.ContractKeeper
 
@@ -786,6 +789,7 @@ func TestExecuteWithStorageLoop(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.ContractKeeper
 
@@ -967,6 +971,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestMigrateReplacesTheSecondIndex(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	example := InstantiateHackatomExampleContract(t, ctx, keepers)
 

--- a/x/wasm/keeper/m1compat.go
+++ b/x/wasm/keeper/m1compat.go
@@ -1,0 +1,12 @@
+package keeper
+
+import (
+	"runtime"
+	"testing"
+)
+
+func SkipIfM1(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping for M1: Signal Error, Stack Dump")
+	}
+}

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -207,6 +207,8 @@ func TestGasOnExternalQuery(t *testing.T) {
 }
 
 func TestLimitRecursiveQueryGas(t *testing.T) {
+	SkipIfM1(t)
+
 	// The point of this test from https://github.com/CosmWasm/cosmwasm/issues/456
 	// Basically, if I burn 90% of gas in CPU loop, then query out (to my self)
 	// the sub-query will have all the original gas (minus the 40k instance charge)

--- a/x/wasm/keeper/reflect_test.go
+++ b/x/wasm/keeper/reflect_test.go
@@ -85,6 +85,7 @@ func mustParse(t *testing.T, data []byte, res interface{}) {
 const ReflectFeatures = "staking,mask,stargate"
 
 func TestReflectContractSend(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)))
 	accKeeper, keeper, bankKeeper := keepers.AccountKeeper, keepers.ContractKeeper, keepers.BankKeeper
@@ -167,6 +168,7 @@ func TestReflectContractSend(t *testing.T) {
 }
 
 func TestReflectCustomMsg(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	accKeeper, keeper, bankKeeper := keepers.AccountKeeper, keepers.ContractKeeper, keepers.BankKeeper
@@ -260,6 +262,7 @@ func TestReflectCustomMsg(t *testing.T) {
 }
 
 func TestMaskReflectCustomQuery(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
@@ -310,6 +313,7 @@ func TestMaskReflectCustomQuery(t *testing.T) {
 }
 
 func TestReflectStargateQuery(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
@@ -387,6 +391,7 @@ type reflectState struct {
 }
 
 func TestMaskReflectWasmQueries(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
@@ -459,6 +464,7 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 }
 
 func TestWasmRawQueryWithNil(t *testing.T) {
+	SkipIfM1(t)
 	cdc := MakeEncodingConfig(t).Marshaler
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper

--- a/x/wasm/keeper/relay_test.go
+++ b/x/wasm/keeper/relay_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestOnOpenChannel(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}
@@ -87,6 +88,7 @@ func TestOnOpenChannel(t *testing.T) {
 }
 
 func TestOnConnectChannel(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}
@@ -198,6 +200,7 @@ func TestOnConnectChannel(t *testing.T) {
 }
 
 func TestOnCloseChannel(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}
@@ -308,6 +311,7 @@ func TestOnCloseChannel(t *testing.T) {
 }
 
 func TestOnRecvPacket(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}
@@ -470,6 +474,7 @@ func TestOnRecvPacket(t *testing.T) {
 }
 
 func TestOnAckPacket(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}
@@ -576,6 +581,7 @@ func TestOnAckPacket(t *testing.T) {
 }
 
 func TestOnTimeoutPacket(t *testing.T) {
+	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
 	var messenger = &wasmtesting.MockMessageHandler{}

--- a/x/wasm/keeper/staking_test.go
+++ b/x/wasm/keeper/staking_test.go
@@ -92,6 +92,7 @@ type InvestmentResponse struct {
 }
 
 func TestInitializeStaking(t *testing.T) {
+	SkipIfM1(t)
 	ctx, k := CreateTestInput(t, false, SupportedFeatures)
 	accKeeper, stakingKeeper, keeper, bankKeeper := k.AccountKeeper, k.StakingKeeper, k.ContractKeeper, k.BankKeeper
 
@@ -226,6 +227,7 @@ func initializeStaking(t *testing.T) initInfo {
 }
 
 func TestBonding(t *testing.T) {
+	SkipIfM1(t)
 	initInfo := initializeStaking(t)
 	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr
 	keeper, stakingKeeper, accKeeper, bankKeeper := initInfo.wasmKeeper, initInfo.stakingKeeper, initInfo.accKeeper, initInfo.bankKeeper
@@ -274,6 +276,7 @@ func TestBonding(t *testing.T) {
 }
 
 func TestUnbonding(t *testing.T) {
+	SkipIfM1(t)
 	initInfo := initializeStaking(t)
 	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr
 	keeper, stakingKeeper, accKeeper, bankKeeper := initInfo.wasmKeeper, initInfo.stakingKeeper, initInfo.accKeeper, initInfo.bankKeeper
@@ -339,6 +342,7 @@ func TestUnbonding(t *testing.T) {
 }
 
 func TestReinvest(t *testing.T) {
+	SkipIfM1(t)
 	initInfo := initializeStaking(t)
 	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr
 	keeper, stakingKeeper, accKeeper, bankKeeper := initInfo.wasmKeeper, initInfo.stakingKeeper, initInfo.accKeeper, initInfo.bankKeeper
@@ -407,6 +411,7 @@ func TestReinvest(t *testing.T) {
 }
 
 func TestQueryStakingInfo(t *testing.T) {
+	SkipIfM1(t)
 	// STEP 1: take a lot of setup from TestReinvest so we have non-zero info
 	initInfo := initializeStaking(t)
 	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr
@@ -586,6 +591,7 @@ func TestQueryStakingInfo(t *testing.T) {
 }
 
 func TestQueryStakingPlugin(t *testing.T) {
+	SkipIfM1(t)
 	// STEP 1: take a lot of setup from TestReinvest so we have non-zero info
 	initInfo := initializeStaking(t)
 	ctx, valAddr, contractAddr := initInfo.ctx, initInfo.valAddr, initInfo.contractAddr

--- a/x/wasm/keeper/submsg_test.go
+++ b/x/wasm/keeper/submsg_test.go
@@ -20,6 +20,7 @@ import (
 
 // Try a simple send, no gas limit to for a sanity check before trying table tests
 func TestDispatchSubMsgSuccessCase(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures)
 	accKeeper, keeper, bankKeeper := keepers.AccountKeeper, keepers.WasmKeeper, keepers.BankKeeper
 
@@ -108,6 +109,7 @@ func TestDispatchSubMsgSuccessCase(t *testing.T) {
 }
 
 func TestDispatchSubMsgErrorHandling(t *testing.T) {
+	SkipIfM1(t)
 	fundedDenom := "funds"
 	fundedAmount := 1_000_000
 	ctxGasLimit := uint64(1_000_000)
@@ -363,6 +365,7 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 // Test an error case, where the Encoded doesn't return any sdk.Msg and we trigger(ed) a null pointer exception.
 // This occurs with the IBC encoder. Test this.
 func TestDispatchSubMsgEncodeToNoSdkMsg(t *testing.T) {
+	SkipIfM1(t)
 	// fake out the bank handle to return success with no data
 	nilEncoder := func(sender sdk.AccAddress, msg *wasmvmtypes.BankMsg) ([]sdk.Msg, error) {
 		return nil, nil
@@ -439,6 +442,7 @@ func TestDispatchSubMsgEncodeToNoSdkMsg(t *testing.T) {
 
 // Try a simple send, no gas limit to for a sanity check before trying table tests
 func TestDispatchSubMsgConditionalReplyOn(t *testing.T) {
+	SkipIfM1(t)
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures)
 	keeper := keepers.WasmKeeper
 


### PR DESCRIPTION
CI to test on amd64

On Mac M1,

`go build ./...` and `make install` pass

`go test -count=1 ./x/wasm/client/...` passes
`go test -count=1 ./x/wasm/keeper` fails:

```
signal 16 received but handler not on signal stack
fatal error: non-Go code set up signal handler without SA_ONSTACK flag

runtime stack:
runtime: unexpected return pc for runtime.sigtramp called from 0x1a96c44e4
stack: frame={sp:0x14000f9c7d0, fp:0x14000f9c8a0} stack=[0x14000f946e0,0x14000f9cae0)
0x0000014000f9c6d0:  0x0000000000000039  0x0000014000f9c748 
0x0000014000f9c6e0:  0x000000010244a6d0 <runtime.sigtrampgo+0x00000000000001a0>  0x0000000000000010 
0x0000014000f9c6f0:  0x0000014000f9c730  0x0000014000f9c748 
```

Narrowing it down:

```
$ go test -v -count=1 ./x/wasm/keeper -run TestExecuteWith

=== RUN   TestExecuteWithDeposit
=== RUN   TestExecuteWithDeposit/actor_with_funds
=== RUN   TestExecuteWithDeposit/actor_without_funds
=== RUN   TestExecuteWithDeposit/blocked_address_as_actor
=== RUN   TestExecuteWithDeposit/coin_transfer_with_all_transfers_disabled
=== RUN   TestExecuteWithDeposit/coin_transfer_with_transfer_denom_disabled
=== RUN   TestExecuteWithDeposit/blocked_address_as_beneficiary
--- PASS: TestExecuteWithDeposit (0.19s)
    --- PASS: TestExecuteWithDeposit/actor_with_funds (0.04s)
    --- PASS: TestExecuteWithDeposit/actor_without_funds (0.03s)
    --- PASS: TestExecuteWithDeposit/blocked_address_as_actor (0.03s)
    --- PASS: TestExecuteWithDeposit/coin_transfer_with_all_transfers_disabled (0.03s)
    --- PASS: TestExecuteWithDeposit/coin_transfer_with_transfer_denom_disabled (0.03s)
    --- PASS: TestExecuteWithDeposit/blocked_address_as_beneficiary (0.03s)
=== RUN   TestExecuteWithNonExistingAddress
--- PASS: TestExecuteWithNonExistingAddress (0.00s)
=== RUN   TestExecuteWithPanic
--- PASS: TestExecuteWithPanic (0.03s)
=== RUN   TestExecuteWithCpuLoop
```

Note that `go test -v -count=1 ./x/wasm/keeper -run TestExecuteWithCpu` passes about 2 of 3 runs