### PR TITLE
fix: close iterators

### DIFF
--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -119,6 +119,8 @@ func ExportGenesis(ctx sdk.Context, keeper *Keeper) *types.GenesisState {
 			ContractState:   state,
 		})
 
+		contractStateIterator.Close()
+
 		return false
 	})
 

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -113,7 +113,9 @@ func TestGenesisExportImport(t *testing.T) {
 	wasmKeeper.IterateContractInfo(srcCtx, func(address sdk.AccAddress, info wasmTypes.ContractInfo) bool {
 		wasmKeeper.removeFromContractCodeSecondaryIndex(srcCtx, address, wasmKeeper.getLastContractHistoryEntry(srcCtx, address))
 		prefixStore := prefix.NewStore(srcCtx.KVStore(wasmKeeper.storeKey), types.GetContractCodeHistoryElementPrefix(address))
-		for iter := prefixStore.Iterator(nil, nil); iter.Valid(); iter.Next() {
+		iter := prefixStore.Iterator(nil, nil)
+
+		for ; iter.Valid(); iter.Next() {
 			prefixStore.Delete(iter.Key())
 		}
 		x := &info
@@ -121,6 +123,7 @@ func TestGenesisExportImport(t *testing.T) {
 		wasmKeeper.storeContractInfo(srcCtx, address, x)
 		wasmKeeper.addToContractCodeSecondaryIndex(srcCtx, address, newHistory)
 		wasmKeeper.appendToContractHistory(srcCtx, address, newHistory)
+		iter.Close()
 		return false
 	})
 
@@ -145,6 +148,8 @@ func TestGenesisExportImport(t *testing.T) {
 		if !assert.False(t, dstIT.Valid()) {
 			t.Fatalf("dest Iterator still has key :%X", dstIT.Key())
 		}
+		srcIT.Close()
+		dstIT.Close()
 	}
 }
 

--- a/x/wasm/keeper/legacy_querier.go
+++ b/x/wasm/keeper/legacy_querier.go
@@ -93,7 +93,10 @@ func queryContractState(ctx sdk.Context, bech, queryMethod string, data []byte, 
 	case QueryMethodContractStateAll:
 		resultData := make([]types.Model, 0)
 		// this returns a serialized json object (which internally encoded binary fields properly)
-		for iter := keeper.GetContractState(ctx, contractAddr); iter.Valid(); iter.Next() {
+		iter := keeper.GetContractState(ctx, contractAddr)
+		defer iter.Close()
+
+		for ; iter.Valid(); iter.Next() {
 			resultData = append(resultData, types.Model{
 				Key:   iter.Key(),
 				Value: iter.Value(),

--- a/x/wasm/types/iavl_range_test.go
+++ b/x/wasm/types/iavl_range_test.go
@@ -63,6 +63,7 @@ func TestIavlRangeBounds(t *testing.T) {
 			}
 			items := consume(iter)
 			require.Equal(t, tc.expected, items)
+			iter.Close()
 		})
 	}
 }
@@ -73,8 +74,6 @@ type KV struct {
 }
 
 func consume(itr store.Iterator) []KV {
-	defer itr.Close()
-
 	var res []KV
 	for ; itr.Valid(); itr.Next() {
 		k, v := itr.Key(), itr.Value()


### PR DESCRIPTION
Iterators should be closed after use. 

I'd also potentially recommend renaming `GetContractState(ctx sdk.Context, contractAddress sdk.AccAddress) sdk.Iterator` to `GetContractStateIterator(ctx sdk.Context, contractAddress sdk.AccAddress) sdk.Iterator` so it's clear that clients should close the iterator themselves or simply change the function signature to take a callback so the usage pattern is standardized. 