### PR TITLE
Remove MaxWasmSize restriction in ValidateBasic

### DIFF
--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -17,7 +17,6 @@ const (
 	TStoreKey                       = types.TStoreKey
 	QuerierRoute                    = types.QuerierRoute
 	RouterKey                       = types.RouterKey
-	MaxWasmSize                     = types.MaxWasmSize
 	MaxLabelSize                    = types.MaxLabelSize
 	WasmModuleEventType             = types.WasmModuleEventType
 	AttributeKeyContractAddr        = types.AttributeKeyContractAddr

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -139,12 +139,6 @@ func (k Keeper) getInstantiateAccessConfig(ctx sdk.Context) types.AccessType {
 	return a
 }
 
-func (k Keeper) GetMaxWasmCodeSize(ctx sdk.Context) uint64 {
-	var a uint64
-	k.paramSpace.Get(ctx, types.ParamStoreKeyMaxWasmCodeSize, &a)
-	return a
-}
-
 // GetParams returns the total set of wasm parameters.
 func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 	var params types.Params
@@ -164,7 +158,7 @@ func (k Keeper) create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte,
 	if !authZ.CanCreateCode(k.getUploadAccessConfig(ctx), creator) {
 		return 0, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "can not create code")
 	}
-	wasmCode, err = uncompress(wasmCode, k.GetMaxWasmCodeSize(ctx))
+	wasmCode, err = uncompress(wasmCode, types.MaxWasmSize)
 	if err != nil {
 		return 0, sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
 	}
@@ -206,7 +200,7 @@ func (k Keeper) storeCodeInfo(ctx sdk.Context, codeID uint64, codeInfo types.Cod
 }
 
 func (k Keeper) importCode(ctx sdk.Context, codeID uint64, codeInfo types.CodeInfo, wasmCode []byte) error {
-	wasmCode, err := uncompress(wasmCode, k.GetMaxWasmCodeSize(ctx))
+	wasmCode, err := uncompress(wasmCode, types.MaxWasmSize)
 	if err != nil {
 		return sdkerrors.Wrap(types.ErrCreateFailed, err.Error())
 	}

--- a/x/wasm/simulation/params.go
+++ b/x/wasm/simulation/params.go
@@ -28,11 +28,6 @@ func ParamChanges(r *rand.Rand, cdc codec.Codec) []simtypes.ParamChange {
 				return fmt.Sprintf("%q", params.CodeUploadAccess.Permission.String())
 			},
 		),
-		simulation.NewSimParamChange(types.ModuleName, string(types.ParamStoreKeyMaxWasmCodeSize),
-			func(r *rand.Rand) string {
-				return fmt.Sprintf(`"%d"`, params.MaxWasmCodeSize)
-			},
-		),
 	}
 }
 

--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -12,14 +12,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const (
-	// DefaultMaxWasmCodeSize limit max bytes read to prevent gzip bombs
-	DefaultMaxWasmCodeSize = 600 * 1024 * 2
-)
-
 var ParamStoreKeyUploadAccess = []byte("uploadAccess")
 var ParamStoreKeyInstantiateAccess = []byte("instantiateAccess")
-var ParamStoreKeyMaxWasmCodeSize = []byte("maxWasmCodeSize")
 
 var AllAccessTypes = []AccessType{
 	AccessTypeNobody,
@@ -96,7 +90,6 @@ func DefaultParams() Params {
 	return Params{
 		CodeUploadAccess:             AllowEverybody,
 		InstantiateDefaultPermission: AccessTypeEverybody,
-		MaxWasmCodeSize:              DefaultMaxWasmCodeSize,
 	}
 }
 
@@ -113,7 +106,6 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
 		paramtypes.NewParamSetPair(ParamStoreKeyUploadAccess, &p.CodeUploadAccess, validateAccessConfig),
 		paramtypes.NewParamSetPair(ParamStoreKeyInstantiateAccess, &p.InstantiateDefaultPermission, validateAccessType),
-		paramtypes.NewParamSetPair(ParamStoreKeyMaxWasmCodeSize, &p.MaxWasmCodeSize, validateMaxWasmCodeSize),
 	}
 }
 

--- a/x/wasm/types/validation.go
+++ b/x/wasm/types/validation.go
@@ -5,17 +5,18 @@ import (
 )
 
 const (
-	MaxWasmSize = 500 * 1024
-
 	// MaxLabelSize is the longest label that can be used when Instantiating a contract
 	MaxLabelSize = 128
 )
+
+// MaxWasmSize is the largest a compiled contract code can be when storing code on chain
+var MaxWasmSize uint64 = 800 * 1024
 
 func validateWasmCode(s []byte) error {
 	if len(s) == 0 {
 		return sdkerrors.Wrap(ErrEmpty, "is required")
 	}
-	if len(s) > MaxWasmSize {
+	if uint64(len(s)) > MaxWasmSize {
 		return sdkerrors.Wrapf(ErrLimit, "cannot be longer than %d bytes", MaxWasmSize)
 	}
 	return nil


### PR DESCRIPTION
Spoke with Simon @ Confio on Discord about this. In the process of developing a Cosmos chain with CosmWasm, we found that `wasmd`'s `MaxWasmSize` is constantly defined and thus, potentially at odds with the module params that a chain might provide. It seems as though we should simply rely on the param and not on this constant. 

This change simply removes the constant and corresponding check. I am definitely up to other solutions, but wanted to surface it here so it gets tracked/discussed!