### PR TITLE
Bump buf docker image to fix proto generation issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SIMAPP = ./app
 
 # for dockerized protobuf tools
 DOCKER := $(shell which docker)
-BUF_IMAGE=bufbuild/buf@sha256:9dc5d6645f8f8a2d5aaafc8957fbbb5ea64eada98a84cb09654e8f49d6f73b3e
+BUF_IMAGE=bufbuild/buf@sha256:3cb1f8a4b48bd5ad8f09168f10f607ddc318af202f5c057d52a45216793d85e5 #v1.4.0
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(BUF_IMAGE)
 HTTPS_GIT := https://github.com/CosmWasm/wasmd.git
 


### PR DESCRIPTION
There were some issues with the buf config changes and the buf docker image that we used. This PR will just bump the version to the  latest [release](https://hub.docker.com/layers/buf/bufbuild/buf/1.4.0/images/sha256-3cb1f8a4b48bd5ad8f09168f10f607ddc318af202f5c057d52a45216793d85e5?context=explore)