### PR TITLE
Make MaxLabelSize a var not const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.26.0...HEAD)
 
+**Implemented Enhancements**
+
+- Make MaxLabelSize a var not const [\#822](https://github.com/CosmWasm/wasmd/pull/822)
+
 ## [v0.26.0](https://github.com/CosmWasm/wasmd/tree/v0.26.0) (2022-04-21)
 
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.25.0...v0.26.0)

--- a/README.md
+++ b/README.md
@@ -180,10 +180,9 @@ docker run --rm -it -p 26657:26657 -p 26656:26656 -p 1317:1317 \
 
 We provide a number of variables in `app/app.go` that are intended to be set via `-ldflags -X ...`
 compile-time flags. This enables us to avoid copying a new binary directory over for each small change
-to the configuration.
+to the configuration. 
 
 Available flags:
-
  
 * `-X github.com/CosmWasm/wasmd/app.NodeDir=.corald` - set the config/data directory for the node (default `~/.wasmd`)
 * `-X github.com/CosmWasm/wasmd/app.Bech32Prefix=coral` - set the bech32 prefix for all accounts (default `wasm`)
@@ -194,6 +193,16 @@ Available flags:
 Examples:
 
 * [`wasmd`](./Makefile#L50-L55) is a generic, permissionless version using the `cosmos` bech32 prefix
+
+## Compile Time Parameters
+
+Besides those above variables (meant for custom wasmd compilation), there are a few more variables which
+we allow blockchains to customize, but at compile time. If you build your own chain and import `x/wasm`,
+you can adjust a few items via module parameters, but a few others did not fit in that, as they need to be
+used by stateless `ValidateBasic()`. Thus, we made them public `var` and these can be overridden in the `app.go`
+file of your custom chain.
+
+* `wasmtypes.MaxLabelSize = 64` to set the maximum label size on instantiation (default 128)
 
 ## Genesis Configuration
 We strongly suggest **to limit the max block gas in the genesis** and not use the default value (`-1` for infinite).

--- a/x/wasm/alias.go
+++ b/x/wasm/alias.go
@@ -18,7 +18,6 @@ const (
 	QuerierRoute                    = types.QuerierRoute
 	RouterKey                       = types.RouterKey
 	MaxWasmSize                     = types.MaxWasmSize
-	MaxLabelSize                    = types.MaxLabelSize
 	WasmModuleEventType             = types.WasmModuleEventType
 	AttributeKeyContractAddr        = types.AttributeKeyContractAddr
 	ProposalTypeStoreCode           = types.ProposalTypeStoreCode

--- a/x/wasm/types/validation.go
+++ b/x/wasm/types/validation.go
@@ -6,7 +6,9 @@ import (
 
 const (
 	MaxWasmSize = 500 * 1024
+)
 
+var (
 	// MaxLabelSize is the longest label that can be used when Instantiating a contract
 	MaxLabelSize = 128
 )


### PR DESCRIPTION
Addresses #813 along with #809

MaxLabelSize is a now var, which can be overridden compile-time by any chain that imports `x/wasm`. 
The 128 char limit, while reasonable, was an arbitrary choice by Confio developers and a blockchain may wish to customize it.

To override, set this variable to a new value in some initialisation code (either `app.go` or `cmd/../main.go`)