### PR TITLE
Add Debian docker build to test libwasmvm.aarch64.so

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,40 @@
+# docker build -f Dockerfile.debian -t cosmwasm/wasmd:debian-test .
+# docker run --rm -it cosmwasm/wasmd:debian-test /bin/sh
+FROM golang:1.17-bullseye AS go-builder
+ARG arch=x86_64
+
+RUN apt update \
+  && apt install -y file
+
+WORKDIR /code
+COPY . /code/
+
+RUN LEDGER_ENABLED=false make build
+RUN echo "Ensuring binary is dynamically linked ..." \
+  && ls /code/build/ \
+  && which file \
+  && (file /code/build/wasmd | grep "dynamically linked") \
+  && ldd /code/build/wasmd
+
+# --------------------------------------------------------
+FROM debian:bullseye-slim
+
+COPY --from=go-builder /code/build/wasmd /usr/bin
+COPY --from=go-builder /go/pkg/mod/github.com/!cosm!wasm/wasmvm@*/api/libwasmvm.*.so /usr/lib
+
+# Test
+RUN wasmd version
+
+COPY docker/* /opt/
+RUN chmod +x /opt/*.sh
+
+WORKDIR /opt
+
+# rest server
+EXPOSE 1317
+# tendermint p2p
+EXPOSE 26656
+# tendermint rpc
+EXPOSE 26657
+
+CMD ["/usr/bin/wasmd", "version"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,6 @@
 # docker build -f Dockerfile.debian -t cosmwasm/wasmd:debian-test .
 # docker run --rm -it cosmwasm/wasmd:debian-test /bin/sh
 FROM golang:1.17-bullseye AS go-builder
-ARG arch=x86_64
 
 RUN apt update \
   && apt install -y file


### PR DESCRIPTION
wasmvm 1.0.0-rc.0 and wasmd v0.27.0-rc0 now allow running on glibc Linux on an ARM64 machine. With this Dockerfile this can be tested on an M1 dev machine.

Creating this draft for demonstration purposes. Not sure if and to what degree we want to maintain the docker file or turn it into documentation. Let's see.