### PR TITLE
Add libwasm-version query command

### DIFF
--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -36,18 +36,19 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdGetContractHistory(),
 		GetCmdGetContractState(),
 		GetCmdListPinnedCode(),
-		GetCmdVMVersion(),
+		GetCmdLibVersion(),
 	)
 	return queryCmd
 }
 
-// GetCmdVMVersion gets current libwasmvm version.
-func GetCmdVMVersion() *cobra.Command {
+// GetCmdLibVersion gets current libwasmvm version.
+func GetCmdLibVersion() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "vm-version",
-		Short: "Get libwasmvm version",
-		Long:  "Get libwasmvm version",
-		Args:  cobra.ExactArgs(0),
+		Use:     "libwasmvm-version",
+		Short:   "Get libwasmvm version",
+		Long:    "Get libwasmvm version",
+		Aliases: []string{"lib-version"},
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			version, err := wasmvmapi.LibwasmvmVersion()
 			if err != nil {

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -17,6 +17,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
+	wasmvmapi "github.com/CosmWasm/wasmvm/api"
 )
 
 func GetQueryCmd() *cobra.Command {
@@ -35,8 +36,28 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdGetContractHistory(),
 		GetCmdGetContractState(),
 		GetCmdListPinnedCode(),
+		GetCmdVMVersion(),
 	)
 	return queryCmd
+}
+
+// GetCmdVMVersion gets current libwasmvm version.
+func GetCmdVMVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vm-version",
+		Short: "Get libwasmvm version",
+		Long:  "Get libwasmvm version",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			version, err := wasmvmapi.LibwasmvmVersion()
+			if err != nil {
+				return fmt.Errorf("error retrieving libwasmvm version: %w", err)
+			}
+			fmt.Println(version)
+			return nil
+		},
+	}
+	return cmd
 }
 
 // GetCmdListCode lists all wasm code uploaded


### PR DESCRIPTION
New wasmvm introduces `LibwasmvmVersion`  api method that can help to get the version of the library that is being resolved specially for dynamic linked binaries. 

I'm adding it as a query because it will be automatically wired to apps using wasmd but can be just a helper command and requires manual wiring.
