### PR TITLE
Enforce default code permissions

### DIFF
--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -330,3 +330,21 @@ func VerifyAddressLen() func(addr []byte) error {
 		return nil
 	}
 }
+
+// IsSubset will return true if the caller is the same as the superset,
+// or if the caller is more restrictive than the superset.
+func (a AccessConfig) IsSubset(superSet AccessConfig) bool {
+	switch superSet.Permission {
+	case AccessTypeEverybody:
+		// Everything is a subset of this
+		return a.Permission != AccessTypeUnspecified
+	case AccessTypeNobody:
+		// Only an exact match is a subset of this
+		return a.Permission == AccessTypeNobody
+	case AccessTypeOnlyAddress:
+		// An exact match or nobody
+		return a.Permission == AccessTypeNobody || (a.Permission == AccessTypeOnlyAddress && a.Address == superSet.Address)
+	default:
+		return false
+	}
+}

--- a/x/wasm/types/types_test.go
+++ b/x/wasm/types/types_test.go
@@ -394,6 +394,11 @@ func TestAccesConfigSubset(t *testing.T) {
 			check:    AccessConfig{Permission: AccessTypeEverybody},
 			isSubSet: false,
 		},
+		"unspecified > nobody": {
+			superSet: AccessConfig{Permission: AccessTypeNobody},
+			check:    AccessConfig{Permission: AccessTypeUnspecified},
+			isSubSet: false,
+		},
 		"nobody <= everybody": {
 			superSet: AccessConfig{Permission: AccessTypeEverybody},
 			check:    AccessConfig{Permission: AccessTypeNobody},
@@ -408,6 +413,11 @@ func TestAccesConfigSubset(t *testing.T) {
 			superSet: AccessConfig{Permission: AccessTypeEverybody},
 			check:    AccessConfig{Permission: AccessTypeEverybody},
 			isSubSet: true,
+		},
+		"unspecified > everybody": {
+			superSet: AccessConfig{Permission: AccessTypeEverybody},
+			check:    AccessConfig{Permission: AccessTypeUnspecified},
+			isSubSet: false,
 		},
 		"nobody <= only": {
 			superSet: AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
@@ -432,11 +442,6 @@ func TestAccesConfigSubset(t *testing.T) {
 		"nobody > unspecified": {
 			superSet: AccessConfig{Permission: AccessTypeUnspecified},
 			check:    AccessConfig{Permission: AccessTypeNobody},
-			isSubSet: false,
-		},
-		"unspecified > everybody": {
-			superSet: AccessConfig{Permission: AccessTypeEverybody},
-			check:    AccessConfig{Permission: AccessTypeUnspecified},
 			isSubSet: false,
 		},
 	}

--- a/x/wasm/types/types_test.go
+++ b/x/wasm/types/types_test.go
@@ -372,3 +372,79 @@ func TestVerifyAddressLen(t *testing.T) {
 		})
 	}
 }
+
+func TestAccesConfigSubset(t *testing.T) {
+	specs := map[string]struct {
+		check    AccessConfig
+		superSet AccessConfig
+		isSubSet bool
+	}{
+		"nobody <= nobody": {
+			superSet: AccessConfig{Permission: AccessTypeNobody},
+			check:    AccessConfig{Permission: AccessTypeNobody},
+			isSubSet: true,
+		},
+		"only > nobody": {
+			superSet: AccessConfig{Permission: AccessTypeNobody},
+			check:    AccessConfig{Permission: AccessTypeOnlyAddress, Address: "foobar"},
+			isSubSet: false,
+		},
+		"everybody > nobody": {
+			superSet: AccessConfig{Permission: AccessTypeNobody},
+			check:    AccessConfig{Permission: AccessTypeEverybody},
+			isSubSet: false,
+		},
+		"nobody <= everybody": {
+			superSet: AccessConfig{Permission: AccessTypeEverybody},
+			check:    AccessConfig{Permission: AccessTypeNobody},
+			isSubSet: true,
+		},
+		"only <= everybody": {
+			superSet: AccessConfig{Permission: AccessTypeEverybody},
+			check:    AccessConfig{Permission: AccessTypeOnlyAddress, Address: "foobar"},
+			isSubSet: true,
+		},
+		"everybody <= everybody": {
+			superSet: AccessConfig{Permission: AccessTypeEverybody},
+			check:    AccessConfig{Permission: AccessTypeEverybody},
+			isSubSet: true,
+		},
+		"nobody <= only": {
+			superSet: AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
+			check:    AccessConfig{Permission: AccessTypeNobody},
+			isSubSet: true,
+		},
+		"only <= only(same)": {
+			superSet: AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
+			check:    AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
+			isSubSet: true,
+		},
+		"only > only(other)": {
+			superSet: AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
+			check:    AccessConfig{Permission: AccessTypeOnlyAddress, Address: "other"},
+			isSubSet: false,
+		},
+		"everybody > only": {
+			superSet: AccessConfig{Permission: AccessTypeOnlyAddress, Address: "owner"},
+			check:    AccessConfig{Permission: AccessTypeEverybody},
+			isSubSet: false,
+		},
+		"nobody > unspecified": {
+			superSet: AccessConfig{Permission: AccessTypeUnspecified},
+			check:    AccessConfig{Permission: AccessTypeNobody},
+			isSubSet: false,
+		},
+		"unspecified > everybody": {
+			superSet: AccessConfig{Permission: AccessTypeEverybody},
+			check:    AccessConfig{Permission: AccessTypeUnspecified},
+			isSubSet: false,
+		},
+	}
+
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			subset := spec.check.IsSubset(spec.superSet)
+			require.Equal(t, spec.isSubSet, subset)
+		})
+	}
+}


### PR DESCRIPTION
Closes #840 
Closes #761

We now define the `InstantiateDefaultPermission` as a restriction on the contracts, not a "helpful default".
That means, it is used if you do not set a permission explicitly, but it also provide a "maximum bound" on how permissive you can be.

That is, if `InstantiateDefaultPermission` is `Everybody`, you can set any permission you wish (permissionless cosmwasm)
But if `InstantiateDefaultPermission` is `Nobody`, you can only set permission to Nobody on upload and must request governance to update that to allow instantiation (permissioned cosmwasm)

This minor logic change now allows us to open up code upload to everybody (which cost $$$ gas when it was a proposal) and just have a vote on updating the instantiate permissions (implemented in #796), which is much cheaper to vote on. Thus resolving the issue of very expensive votes on permssioned chains #761 while still allowing them to control what code is executed.

@jhernandezb Happy for feedback here as well