### PR TITLE
Gofumpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,15 @@ test-sim-multi-seed-short: runsim
 ###                                Linting                                  ###
 ###############################################################################
 
-lint:
-	golangci-lint run --tests=false
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*_test.go" | xargs gofmt -d -s
+gofumpt:
+	go install mvdan.cc/gofumpt@v0.3.1
 
-format:
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs gofmt -w -s
+lint: gofumpt
+	golangci-lint run --tests=false
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*_test.go" | xargs gofumpt -d -s
+
+format: gofumpt
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs gofumpt -w -s
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs misspell -w
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs goimports -w -local github.com/CosmWasm/wasmd
 

--- a/Makefile
+++ b/Makefile
@@ -148,14 +148,15 @@ test-sim-multi-seed-short: runsim
 ###                                Linting                                  ###
 ###############################################################################
 
-gofumpt:
+format-tools:
 	go install mvdan.cc/gofumpt@v0.3.1
+	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
-lint: gofumpt
+lint: format-tools
 	golangci-lint run --tests=false
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "*_test.go" | xargs gofumpt -d -s
 
-format: gofumpt
+format: format-tools
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs gofumpt -w -s
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs misspell -w
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs goimports -w -local github.com/CosmWasm/wasmd

--- a/app/ante.go
+++ b/app/ante.go
@@ -38,7 +38,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrLogic, "tx counter key is required for ante builder")
 	}
 
-	var sigGasConsumer = options.SigGasConsumer
+	sigGasConsumer := options.SigGasConsumer
 	if sigGasConsumer == nil {
 		sigGasConsumer = ante.DefaultSigVerificationGasConsumer
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -282,7 +282,6 @@ func NewWasmApp(
 	wasmOpts []wasm.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *WasmApp {
-
 	appCodec, legacyAmino := encodingConfig.Marshaler, encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
 
@@ -521,7 +520,7 @@ func NewWasmApp(
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment
 	// we prefer to be more strict in what arguments the modules expect.
-	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
+	skipGenesisInvariants := cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -165,11 +165,13 @@ func TestAppImportExport(t *testing.T) {
 
 	storeKeysPrefixes := []StoreKeysPrefixes{
 		{app.keys[authtypes.StoreKey], newApp.keys[authtypes.StoreKey], [][]byte{}},
-		{app.keys[stakingtypes.StoreKey], newApp.keys[stakingtypes.StoreKey],
+		{
+			app.keys[stakingtypes.StoreKey], newApp.keys[stakingtypes.StoreKey],
 			[][]byte{
 				stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 				stakingtypes.HistoricalInfoKey,
-			}},
+			},
+		},
 		{app.keys[slashingtypes.StoreKey], newApp.keys[slashingtypes.StoreKey], [][]byte{}},
 		{app.keys[minttypes.StoreKey], newApp.keys[minttypes.StoreKey], [][]byte{}},
 		{app.keys[distrtypes.StoreKey], newApp.keys[distrtypes.StoreKey], [][]byte{}},

--- a/app/test_access.go
+++ b/app/test_access.go
@@ -38,6 +38,7 @@ func (s TestSupport) WasmKeeper() wasm.Keeper {
 func (s TestSupport) AppCodec() codec.Codec {
 	return s.app.appCodec
 }
+
 func (s TestSupport) ScopedWasmIBCKeeper() capabilitykeeper.ScopedKeeper {
 	return s.app.scopedWasmKeeper
 }

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -293,7 +293,6 @@ func SignCheckDeliver(
 	t *testing.T, txCfg client.TxConfig, app *bam.BaseApp, header tmproto.Header, msgs []sdk.Msg,
 	chainID string, accNums, accSeqs []uint64, expSimPass, expPass bool, priv ...cryptotypes.PrivKey,
 ) (sdk.GasInfo, *sdk.Result, error) {
-
 	tx, err := helpers.GenTx(
 		txCfg,
 		msgs,
@@ -343,7 +342,6 @@ func SignAndDeliver(
 	t *testing.T, txCfg client.TxConfig, app *bam.BaseApp, header tmproto.Header, msgs []sdk.Msg,
 	chainID string, accNums, accSeqs []uint64, expSimPass, expPass bool, priv ...cryptotypes.PrivKey,
 ) (sdk.GasInfo, *sdk.Result, error) {
-
 	tx, err := helpers.GenTx(
 		txCfg,
 		msgs,

--- a/cmd/wasmd/genwasm.go
+++ b/cmd/wasmd/genwasm.go
@@ -24,5 +24,4 @@ func AddGenesisWasmMsgCmd(defaultNodeHome string) *cobra.Command {
 		wasmcli.GenesisListCodesCmd(defaultNodeHome, genesisIO),
 	)
 	return txCmd
-
 }

--- a/cmd/wasmd/root.go
+++ b/cmd/wasmd/root.go
@@ -186,7 +186,6 @@ func (ac appCreator) newApp(
 	traceStore io.Writer,
 	appOpts servertypes.AppOptions,
 ) servertypes.Application {
-
 	var cache sdk.MultiStorePersistentCache
 
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
@@ -247,7 +246,6 @@ func (ac appCreator) appExport(
 	jailAllowedAddrs []string,
 	appOpts servertypes.AppOptions,
 ) (servertypes.ExportedApp, error) {
-
 	var wasmApp *app.WasmApp
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)
 	if !ok || homePath == "" {

--- a/third_party/proto/tendermint/blockchain/types.pb.go
+++ b/third_party/proto/tendermint/blockchain/types.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -35,9 +38,11 @@ func (*BlockRequest) ProtoMessage()    {}
 func (*BlockRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{0}
 }
+
 func (m *BlockRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockRequest.Marshal(b, m, deterministic)
@@ -50,12 +55,15 @@ func (m *BlockRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *BlockRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockRequest.Merge(m, src)
 }
+
 func (m *BlockRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockRequest.DiscardUnknown(m)
 }
@@ -80,9 +88,11 @@ func (*NoBlockResponse) ProtoMessage()    {}
 func (*NoBlockResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{1}
 }
+
 func (m *NoBlockResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *NoBlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_NoBlockResponse.Marshal(b, m, deterministic)
@@ -95,12 +105,15 @@ func (m *NoBlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *NoBlockResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_NoBlockResponse.Merge(m, src)
 }
+
 func (m *NoBlockResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *NoBlockResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_NoBlockResponse.DiscardUnknown(m)
 }
@@ -125,9 +138,11 @@ func (*BlockResponse) ProtoMessage()    {}
 func (*BlockResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{2}
 }
+
 func (m *BlockResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockResponse.Marshal(b, m, deterministic)
@@ -140,12 +155,15 @@ func (m *BlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *BlockResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockResponse.Merge(m, src)
 }
+
 func (m *BlockResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockResponse.DiscardUnknown(m)
 }
@@ -160,8 +178,7 @@ func (m *BlockResponse) GetBlock() *types.Block {
 }
 
 // StatusRequest requests the status of a peer.
-type StatusRequest struct {
-}
+type StatusRequest struct{}
 
 func (m *StatusRequest) Reset()         { *m = StatusRequest{} }
 func (m *StatusRequest) String() string { return proto.CompactTextString(m) }
@@ -169,9 +186,11 @@ func (*StatusRequest) ProtoMessage()    {}
 func (*StatusRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{3}
 }
+
 func (m *StatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *StatusRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StatusRequest.Marshal(b, m, deterministic)
@@ -184,12 +203,15 @@ func (m *StatusRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *StatusRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StatusRequest.Merge(m, src)
 }
+
 func (m *StatusRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *StatusRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_StatusRequest.DiscardUnknown(m)
 }
@@ -208,9 +230,11 @@ func (*StatusResponse) ProtoMessage()    {}
 func (*StatusResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{4}
 }
+
 func (m *StatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *StatusResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StatusResponse.Marshal(b, m, deterministic)
@@ -223,12 +247,15 @@ func (m *StatusResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *StatusResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StatusResponse.Merge(m, src)
 }
+
 func (m *StatusResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *StatusResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_StatusResponse.DiscardUnknown(m)
 }
@@ -265,9 +292,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2927480384e78499, []int{5}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -280,12 +309,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -612,6 +644,7 @@ func (m *Message_BlockRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_NoBlockResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -633,6 +666,7 @@ func (m *Message_NoBlockResponse) MarshalToSizedBuffer(dAtA []byte) (int, error)
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_BlockResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -654,6 +688,7 @@ func (m *Message_BlockResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_StatusRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -675,6 +710,7 @@ func (m *Message_StatusRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_StatusResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -696,6 +732,7 @@ func (m *Message_StatusResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -707,6 +744,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *BlockRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -792,6 +830,7 @@ func (m *Message_BlockRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_NoBlockResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -804,6 +843,7 @@ func (m *Message_NoBlockResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_BlockResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -816,6 +856,7 @@ func (m *Message_BlockResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_StatusRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -828,6 +869,7 @@ func (m *Message_StatusRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_StatusResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -844,9 +886,11 @@ func (m *Message_StatusResponse) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *BlockRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -916,6 +960,7 @@ func (m *BlockRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *NoBlockResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -985,6 +1030,7 @@ func (m *NoBlockResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *BlockResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1071,6 +1117,7 @@ func (m *BlockResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *StatusRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1121,6 +1168,7 @@ func (m *StatusRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *StatusResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1209,6 +1257,7 @@ func (m *StatusResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1434,6 +1483,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/consensus/types.pb.go
+++ b/third_party/proto/tendermint/consensus/types.pb.go
@@ -17,8 +17,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*NewRoundStep) ProtoMessage()    {}
 func (*NewRoundStep) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{0}
 }
+
 func (m *NewRoundStep) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *NewRoundStep) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_NewRoundStep.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *NewRoundStep) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *NewRoundStep) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_NewRoundStep.Merge(m, src)
 }
+
 func (m *NewRoundStep) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *NewRoundStep) XXX_DiscardUnknown() {
 	xxx_messageInfo_NewRoundStep.DiscardUnknown(m)
 }
@@ -105,7 +113,7 @@ func (m *NewRoundStep) GetLastCommitRound() int32 {
 }
 
 // NewValidBlock is sent when a validator observes a valid block B in some round r,
-//i.e., there is a Proposal for block B and 2/3+ prevotes for the block B in the round r.
+// i.e., there is a Proposal for block B and 2/3+ prevotes for the block B in the round r.
 // In case the block is also committed, then IsCommit flag is set to true.
 type NewValidBlock struct {
 	Height             int64               `protobuf:"varint,1,opt,name=height,proto3" json:"height,omitempty"`
@@ -121,9 +129,11 @@ func (*NewValidBlock) ProtoMessage()    {}
 func (*NewValidBlock) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{1}
 }
+
 func (m *NewValidBlock) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *NewValidBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_NewValidBlock.Marshal(b, m, deterministic)
@@ -136,12 +146,15 @@ func (m *NewValidBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *NewValidBlock) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_NewValidBlock.Merge(m, src)
 }
+
 func (m *NewValidBlock) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *NewValidBlock) XXX_DiscardUnknown() {
 	xxx_messageInfo_NewValidBlock.DiscardUnknown(m)
 }
@@ -194,9 +207,11 @@ func (*Proposal) ProtoMessage()    {}
 func (*Proposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{2}
 }
+
 func (m *Proposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Proposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Proposal.Marshal(b, m, deterministic)
@@ -209,12 +224,15 @@ func (m *Proposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Proposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Proposal.Merge(m, src)
 }
+
 func (m *Proposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Proposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_Proposal.DiscardUnknown(m)
 }
@@ -241,9 +259,11 @@ func (*ProposalPOL) ProtoMessage()    {}
 func (*ProposalPOL) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{3}
 }
+
 func (m *ProposalPOL) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ProposalPOL) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ProposalPOL.Marshal(b, m, deterministic)
@@ -256,12 +276,15 @@ func (m *ProposalPOL) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
+
 func (m *ProposalPOL) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ProposalPOL.Merge(m, src)
 }
+
 func (m *ProposalPOL) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ProposalPOL) XXX_DiscardUnknown() {
 	xxx_messageInfo_ProposalPOL.DiscardUnknown(m)
 }
@@ -302,9 +325,11 @@ func (*BlockPart) ProtoMessage()    {}
 func (*BlockPart) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{4}
 }
+
 func (m *BlockPart) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockPart) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockPart.Marshal(b, m, deterministic)
@@ -317,12 +342,15 @@ func (m *BlockPart) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *BlockPart) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockPart.Merge(m, src)
 }
+
 func (m *BlockPart) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockPart) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockPart.DiscardUnknown(m)
 }
@@ -361,9 +389,11 @@ func (*Vote) ProtoMessage()    {}
 func (*Vote) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{5}
 }
+
 func (m *Vote) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Vote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Vote.Marshal(b, m, deterministic)
@@ -376,12 +406,15 @@ func (m *Vote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Vote) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Vote.Merge(m, src)
 }
+
 func (m *Vote) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Vote) XXX_DiscardUnknown() {
 	xxx_messageInfo_Vote.DiscardUnknown(m)
 }
@@ -409,9 +442,11 @@ func (*HasVote) ProtoMessage()    {}
 func (*HasVote) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{6}
 }
+
 func (m *HasVote) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *HasVote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_HasVote.Marshal(b, m, deterministic)
@@ -424,12 +459,15 @@ func (m *HasVote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *HasVote) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_HasVote.Merge(m, src)
 }
+
 func (m *HasVote) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *HasVote) XXX_DiscardUnknown() {
 	xxx_messageInfo_HasVote.DiscardUnknown(m)
 }
@@ -478,9 +516,11 @@ func (*VoteSetMaj23) ProtoMessage()    {}
 func (*VoteSetMaj23) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{7}
 }
+
 func (m *VoteSetMaj23) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *VoteSetMaj23) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_VoteSetMaj23.Marshal(b, m, deterministic)
@@ -493,12 +533,15 @@ func (m *VoteSetMaj23) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *VoteSetMaj23) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_VoteSetMaj23.Merge(m, src)
 }
+
 func (m *VoteSetMaj23) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *VoteSetMaj23) XXX_DiscardUnknown() {
 	xxx_messageInfo_VoteSetMaj23.DiscardUnknown(m)
 }
@@ -548,9 +591,11 @@ func (*VoteSetBits) ProtoMessage()    {}
 func (*VoteSetBits) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{8}
 }
+
 func (m *VoteSetBits) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *VoteSetBits) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_VoteSetBits.Marshal(b, m, deterministic)
@@ -563,12 +608,15 @@ func (m *VoteSetBits) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
+
 func (m *VoteSetBits) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_VoteSetBits.Merge(m, src)
 }
+
 func (m *VoteSetBits) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *VoteSetBits) XXX_DiscardUnknown() {
 	xxx_messageInfo_VoteSetBits.DiscardUnknown(m)
 }
@@ -630,9 +678,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81a22d2efc008981, []int{9}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -645,12 +695,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -1328,6 +1381,7 @@ func (m *Message_NewRoundStep) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_NewValidBlock) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1349,6 +1403,7 @@ func (m *Message_NewValidBlock) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_Proposal) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1370,6 +1425,7 @@ func (m *Message_Proposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_ProposalPol) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1391,6 +1447,7 @@ func (m *Message_ProposalPol) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_BlockPart) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1412,6 +1469,7 @@ func (m *Message_BlockPart) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_Vote) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1433,6 +1491,7 @@ func (m *Message_Vote) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_HasVote) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1454,6 +1513,7 @@ func (m *Message_HasVote) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_VoteSetMaj23) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1475,6 +1535,7 @@ func (m *Message_VoteSetMaj23) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_VoteSetBits) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1496,6 +1557,7 @@ func (m *Message_VoteSetBits) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -1507,6 +1569,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *NewRoundStep) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1700,6 +1763,7 @@ func (m *Message_NewRoundStep) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_NewValidBlock) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1712,6 +1776,7 @@ func (m *Message_NewValidBlock) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_Proposal) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1724,6 +1789,7 @@ func (m *Message_Proposal) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_ProposalPol) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1736,6 +1802,7 @@ func (m *Message_ProposalPol) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_BlockPart) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1748,6 +1815,7 @@ func (m *Message_BlockPart) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_Vote) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1760,6 +1828,7 @@ func (m *Message_Vote) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_HasVote) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1772,6 +1841,7 @@ func (m *Message_HasVote) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_VoteSetMaj23) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1784,6 +1854,7 @@ func (m *Message_VoteSetMaj23) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_VoteSetBits) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1800,9 +1871,11 @@ func (m *Message_VoteSetBits) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *NewRoundStep) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1948,6 +2021,7 @@ func (m *NewRoundStep) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *NewValidBlock) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2125,6 +2199,7 @@ func (m *NewValidBlock) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Proposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2208,6 +2283,7 @@ func (m *Proposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ProposalPOL) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2329,6 +2405,7 @@ func (m *ProposalPOL) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *BlockPart) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2450,6 +2527,7 @@ func (m *BlockPart) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Vote) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2536,6 +2614,7 @@ func (m *Vote) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *HasVote) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2662,6 +2741,7 @@ func (m *HasVote) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *VoteSetMaj23) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2802,6 +2882,7 @@ func (m *VoteSetMaj23) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *VoteSetBits) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2975,6 +3056,7 @@ func (m *VoteSetBits) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3340,6 +3422,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/consensus/wal.pb.go
+++ b/third_party/proto/tendermint/consensus/wal.pb.go
@@ -20,9 +20,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,9 +45,11 @@ func (*MsgInfo) ProtoMessage()    {}
 func (*MsgInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ed0b60c2d348ab09, []int{0}
 }
+
 func (m *MsgInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInfo.Marshal(b, m, deterministic)
@@ -57,12 +62,15 @@ func (m *MsgInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *MsgInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInfo.Merge(m, src)
 }
+
 func (m *MsgInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInfo.DiscardUnknown(m)
 }
@@ -97,9 +105,11 @@ func (*TimeoutInfo) ProtoMessage()    {}
 func (*TimeoutInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ed0b60c2d348ab09, []int{1}
 }
+
 func (m *TimeoutInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *TimeoutInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_TimeoutInfo.Marshal(b, m, deterministic)
@@ -112,12 +122,15 @@ func (m *TimeoutInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
+
 func (m *TimeoutInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_TimeoutInfo.Merge(m, src)
 }
+
 func (m *TimeoutInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *TimeoutInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_TimeoutInfo.DiscardUnknown(m)
 }
@@ -164,9 +177,11 @@ func (*EndHeight) ProtoMessage()    {}
 func (*EndHeight) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ed0b60c2d348ab09, []int{2}
 }
+
 func (m *EndHeight) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *EndHeight) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_EndHeight.Marshal(b, m, deterministic)
@@ -179,12 +194,15 @@ func (m *EndHeight) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *EndHeight) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_EndHeight.Merge(m, src)
 }
+
 func (m *EndHeight) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *EndHeight) XXX_DiscardUnknown() {
 	xxx_messageInfo_EndHeight.DiscardUnknown(m)
 }
@@ -213,9 +231,11 @@ func (*WALMessage) ProtoMessage()    {}
 func (*WALMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ed0b60c2d348ab09, []int{3}
 }
+
 func (m *WALMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *WALMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_WALMessage.Marshal(b, m, deterministic)
@@ -228,12 +248,15 @@ func (m *WALMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *WALMessage) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_WALMessage.Merge(m, src)
 }
+
 func (m *WALMessage) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *WALMessage) XXX_DiscardUnknown() {
 	xxx_messageInfo_WALMessage.DiscardUnknown(m)
 }
@@ -321,9 +344,11 @@ func (*TimedWALMessage) ProtoMessage()    {}
 func (*TimedWALMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ed0b60c2d348ab09, []int{4}
 }
+
 func (m *TimedWALMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *TimedWALMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_TimedWALMessage.Marshal(b, m, deterministic)
@@ -336,12 +361,15 @@ func (m *TimedWALMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *TimedWALMessage) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_TimedWALMessage.Merge(m, src)
 }
+
 func (m *TimedWALMessage) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *TimedWALMessage) XXX_DiscardUnknown() {
 	xxx_messageInfo_TimedWALMessage.DiscardUnknown(m)
 }
@@ -577,6 +605,7 @@ func (m *WALMessage_EventDataRoundState) MarshalToSizedBuffer(dAtA []byte) (int,
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *WALMessage_MsgInfo) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -598,6 +627,7 @@ func (m *WALMessage_MsgInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *WALMessage_TimeoutInfo) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -619,6 +649,7 @@ func (m *WALMessage_TimeoutInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *WALMessage_EndHeight) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -640,6 +671,7 @@ func (m *WALMessage_EndHeight) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *TimedWALMessage) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -694,6 +726,7 @@ func encodeVarintWal(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *MsgInfo) Size() (n int) {
 	if m == nil {
 		return 0
@@ -765,6 +798,7 @@ func (m *WALMessage_EventDataRoundState) Size() (n int) {
 	}
 	return n
 }
+
 func (m *WALMessage_MsgInfo) Size() (n int) {
 	if m == nil {
 		return 0
@@ -777,6 +811,7 @@ func (m *WALMessage_MsgInfo) Size() (n int) {
 	}
 	return n
 }
+
 func (m *WALMessage_TimeoutInfo) Size() (n int) {
 	if m == nil {
 		return 0
@@ -789,6 +824,7 @@ func (m *WALMessage_TimeoutInfo) Size() (n int) {
 	}
 	return n
 }
+
 func (m *WALMessage_EndHeight) Size() (n int) {
 	if m == nil {
 		return 0
@@ -801,6 +837,7 @@ func (m *WALMessage_EndHeight) Size() (n int) {
 	}
 	return n
 }
+
 func (m *TimedWALMessage) Size() (n int) {
 	if m == nil {
 		return 0
@@ -819,9 +856,11 @@ func (m *TimedWALMessage) Size() (n int) {
 func sovWal(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozWal(x uint64) (n int) {
 	return sovWal(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *MsgInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -937,6 +976,7 @@ func (m *MsgInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *TimeoutInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1077,6 +1117,7 @@ func (m *TimeoutInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *EndHeight) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1146,6 +1187,7 @@ func (m *EndHeight) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *WALMessage) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1336,6 +1378,7 @@ func (m *WALMessage) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *TimedWALMessage) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1455,6 +1498,7 @@ func (m *TimedWALMessage) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipWal(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/crypto/keys.pb.go
+++ b/third_party/proto/tendermint/crypto/keys.pb.go
@@ -16,8 +16,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -39,9 +42,11 @@ func (*PublicKey) ProtoMessage()    {}
 func (*PublicKey) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb048658b234868c, []int{0}
 }
+
 func (m *PublicKey) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PublicKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PublicKey.Marshal(b, m, deterministic)
@@ -54,12 +59,15 @@ func (m *PublicKey) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PublicKey) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PublicKey.Merge(m, src)
 }
+
 func (m *PublicKey) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PublicKey) XXX_DiscardUnknown() {
 	xxx_messageInfo_PublicKey.DiscardUnknown(m)
 }
@@ -198,6 +206,7 @@ func (this *PublicKey) Compare(that interface{}) int {
 	}
 	return 0
 }
+
 func (this *PublicKey_Ed25519) Compare(that interface{}) int {
 	if that == nil {
 		if this == nil {
@@ -228,6 +237,7 @@ func (this *PublicKey_Ed25519) Compare(that interface{}) int {
 	}
 	return 0
 }
+
 func (this *PublicKey_Secp256K1) Compare(that interface{}) int {
 	if that == nil {
 		if this == nil {
@@ -258,6 +268,7 @@ func (this *PublicKey_Secp256K1) Compare(that interface{}) int {
 	}
 	return 0
 }
+
 func (this *PublicKey) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -288,6 +299,7 @@ func (this *PublicKey) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *PublicKey_Ed25519) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -312,6 +324,7 @@ func (this *PublicKey_Ed25519) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *PublicKey_Secp256K1) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -336,6 +349,7 @@ func (this *PublicKey_Secp256K1) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (m *PublicKey) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -384,6 +398,7 @@ func (m *PublicKey_Ed25519) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *PublicKey_Secp256K1) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -400,6 +415,7 @@ func (m *PublicKey_Secp256K1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintKeys(dAtA []byte, offset int, v uint64) int {
 	offset -= sovKeys(v)
 	base := offset
@@ -411,6 +427,7 @@ func encodeVarintKeys(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *PublicKey) Size() (n int) {
 	if m == nil {
 		return 0
@@ -435,6 +452,7 @@ func (m *PublicKey_Ed25519) Size() (n int) {
 	}
 	return n
 }
+
 func (m *PublicKey_Secp256K1) Size() (n int) {
 	if m == nil {
 		return 0
@@ -451,9 +469,11 @@ func (m *PublicKey_Secp256K1) Size() (n int) {
 func sovKeys(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozKeys(x uint64) (n int) {
 	return sovKeys(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *PublicKey) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -570,6 +590,7 @@ func (m *PublicKey) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipKeys(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/crypto/proof.pb.go
+++ b/third_party/proto/tendermint/crypto/proof.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -37,9 +40,11 @@ func (*Proof) ProtoMessage()    {}
 func (*Proof) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6b60b6ba2ab5b856, []int{0}
 }
+
 func (m *Proof) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Proof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Proof.Marshal(b, m, deterministic)
@@ -52,12 +57,15 @@ func (m *Proof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Proof) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Proof.Merge(m, src)
 }
+
 func (m *Proof) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Proof) XXX_DiscardUnknown() {
 	xxx_messageInfo_Proof.DiscardUnknown(m)
 }
@@ -105,9 +113,11 @@ func (*ValueOp) ProtoMessage()    {}
 func (*ValueOp) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6b60b6ba2ab5b856, []int{1}
 }
+
 func (m *ValueOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ValueOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ValueOp.Marshal(b, m, deterministic)
@@ -120,12 +130,15 @@ func (m *ValueOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *ValueOp) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ValueOp.Merge(m, src)
 }
+
 func (m *ValueOp) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ValueOp) XXX_DiscardUnknown() {
 	xxx_messageInfo_ValueOp.DiscardUnknown(m)
 }
@@ -158,9 +171,11 @@ func (*DominoOp) ProtoMessage()    {}
 func (*DominoOp) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6b60b6ba2ab5b856, []int{2}
 }
+
 func (m *DominoOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *DominoOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_DominoOp.Marshal(b, m, deterministic)
@@ -173,12 +188,15 @@ func (m *DominoOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *DominoOp) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DominoOp.Merge(m, src)
 }
+
 func (m *DominoOp) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *DominoOp) XXX_DiscardUnknown() {
 	xxx_messageInfo_DominoOp.DiscardUnknown(m)
 }
@@ -221,9 +239,11 @@ func (*ProofOp) ProtoMessage()    {}
 func (*ProofOp) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6b60b6ba2ab5b856, []int{3}
 }
+
 func (m *ProofOp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ProofOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ProofOp.Marshal(b, m, deterministic)
@@ -236,12 +256,15 @@ func (m *ProofOp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *ProofOp) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ProofOp.Merge(m, src)
 }
+
 func (m *ProofOp) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ProofOp) XXX_DiscardUnknown() {
 	xxx_messageInfo_ProofOp.DiscardUnknown(m)
 }
@@ -280,9 +303,11 @@ func (*ProofOps) ProtoMessage()    {}
 func (*ProofOps) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6b60b6ba2ab5b856, []int{4}
 }
+
 func (m *ProofOps) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ProofOps) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ProofOps.Marshal(b, m, deterministic)
@@ -295,12 +320,15 @@ func (m *ProofOps) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *ProofOps) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ProofOps.Merge(m, src)
 }
+
 func (m *ProofOps) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ProofOps) XXX_DiscardUnknown() {
 	xxx_messageInfo_ProofOps.DiscardUnknown(m)
 }
@@ -577,6 +605,7 @@ func encodeVarintProof(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *Proof) Size() (n int) {
 	if m == nil {
 		return 0
@@ -679,9 +708,11 @@ func (m *ProofOps) Size() (n int) {
 func sovProof(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozProof(x uint64) (n int) {
 	return sovProof(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *Proof) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -836,6 +867,7 @@ func (m *Proof) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ValueOp) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -956,6 +988,7 @@ func (m *ValueOp) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *DominoOp) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1102,6 +1135,7 @@ func (m *DominoOp) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ProofOp) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1252,6 +1286,7 @@ func (m *ProofOp) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ProofOps) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1336,6 +1371,7 @@ func (m *ProofOps) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipProof(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/libs/bits/types.pb.go
+++ b/third_party/proto/tendermint/libs/bits/types.pb.go
@@ -14,8 +14,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -34,9 +37,11 @@ func (*BitArray) ProtoMessage()    {}
 func (*BitArray) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e91ab2672920d7d4, []int{0}
 }
+
 func (m *BitArray) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BitArray) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BitArray.Marshal(b, m, deterministic)
@@ -49,12 +54,15 @@ func (m *BitArray) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *BitArray) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BitArray.Merge(m, src)
 }
+
 func (m *BitArray) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BitArray) XXX_DiscardUnknown() {
 	xxx_messageInfo_BitArray.DiscardUnknown(m)
 }
@@ -153,6 +161,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *BitArray) Size() (n int) {
 	if m == nil {
 		return 0
@@ -175,9 +184,11 @@ func (m *BitArray) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *BitArray) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -323,6 +334,7 @@ func (m *BitArray) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/mempool/types.pb.go
+++ b/third_party/proto/tendermint/mempool/types.pb.go
@@ -14,8 +14,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -33,9 +36,11 @@ func (*Txs) ProtoMessage()    {}
 func (*Txs) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2af51926fdbcbc05, []int{0}
 }
+
 func (m *Txs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Txs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Txs.Marshal(b, m, deterministic)
@@ -48,12 +53,15 @@ func (m *Txs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Txs) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Txs.Merge(m, src)
 }
+
 func (m *Txs) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Txs) XXX_DiscardUnknown() {
 	xxx_messageInfo_Txs.DiscardUnknown(m)
 }
@@ -79,9 +87,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2af51926fdbcbc05, []int{1}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -94,12 +104,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -247,6 +260,7 @@ func (m *Message_Txs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -258,6 +272,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *Txs) Size() (n int) {
 	if m == nil {
 		return 0
@@ -301,9 +316,11 @@ func (m *Message_Txs) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *Txs) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -386,6 +403,7 @@ func (m *Txs) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -471,6 +489,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/p2p/conn.pb.go
+++ b/third_party/proto/tendermint/p2p/conn.pb.go
@@ -16,8 +16,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -25,8 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type PacketPing struct {
-}
+type PacketPing struct{}
 
 func (m *PacketPing) Reset()         { *m = PacketPing{} }
 func (m *PacketPing) String() string { return proto.CompactTextString(m) }
@@ -34,9 +36,11 @@ func (*PacketPing) ProtoMessage()    {}
 func (*PacketPing) Descriptor() ([]byte, []int) {
 	return fileDescriptor_22474b5527c8fa9f, []int{0}
 }
+
 func (m *PacketPing) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PacketPing) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PacketPing.Marshal(b, m, deterministic)
@@ -49,20 +53,22 @@ func (m *PacketPing) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PacketPing) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PacketPing.Merge(m, src)
 }
+
 func (m *PacketPing) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PacketPing) XXX_DiscardUnknown() {
 	xxx_messageInfo_PacketPing.DiscardUnknown(m)
 }
 
 var xxx_messageInfo_PacketPing proto.InternalMessageInfo
 
-type PacketPong struct {
-}
+type PacketPong struct{}
 
 func (m *PacketPong) Reset()         { *m = PacketPong{} }
 func (m *PacketPong) String() string { return proto.CompactTextString(m) }
@@ -70,9 +76,11 @@ func (*PacketPong) ProtoMessage()    {}
 func (*PacketPong) Descriptor() ([]byte, []int) {
 	return fileDescriptor_22474b5527c8fa9f, []int{1}
 }
+
 func (m *PacketPong) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PacketPong) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PacketPong.Marshal(b, m, deterministic)
@@ -85,12 +93,15 @@ func (m *PacketPong) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PacketPong) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PacketPong.Merge(m, src)
 }
+
 func (m *PacketPong) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PacketPong) XXX_DiscardUnknown() {
 	xxx_messageInfo_PacketPong.DiscardUnknown(m)
 }
@@ -109,9 +120,11 @@ func (*PacketMsg) ProtoMessage()    {}
 func (*PacketMsg) Descriptor() ([]byte, []int) {
 	return fileDescriptor_22474b5527c8fa9f, []int{2}
 }
+
 func (m *PacketMsg) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PacketMsg) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PacketMsg.Marshal(b, m, deterministic)
@@ -124,12 +137,15 @@ func (m *PacketMsg) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PacketMsg) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PacketMsg.Merge(m, src)
 }
+
 func (m *PacketMsg) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PacketMsg) XXX_DiscardUnknown() {
 	xxx_messageInfo_PacketMsg.DiscardUnknown(m)
 }
@@ -171,9 +187,11 @@ func (*Packet) ProtoMessage()    {}
 func (*Packet) Descriptor() ([]byte, []int) {
 	return fileDescriptor_22474b5527c8fa9f, []int{3}
 }
+
 func (m *Packet) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Packet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Packet.Marshal(b, m, deterministic)
@@ -186,12 +204,15 @@ func (m *Packet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Packet) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Packet.Merge(m, src)
 }
+
 func (m *Packet) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Packet) XXX_DiscardUnknown() {
 	xxx_messageInfo_Packet.DiscardUnknown(m)
 }
@@ -266,9 +287,11 @@ func (*AuthSigMessage) ProtoMessage()    {}
 func (*AuthSigMessage) Descriptor() ([]byte, []int) {
 	return fileDescriptor_22474b5527c8fa9f, []int{4}
 }
+
 func (m *AuthSigMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *AuthSigMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AuthSigMessage.Marshal(b, m, deterministic)
@@ -281,12 +304,15 @@ func (m *AuthSigMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *AuthSigMessage) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AuthSigMessage.Merge(m, src)
 }
+
 func (m *AuthSigMessage) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *AuthSigMessage) XXX_DiscardUnknown() {
 	xxx_messageInfo_AuthSigMessage.DiscardUnknown(m)
 }
@@ -490,6 +516,7 @@ func (m *Packet_PacketPing) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Packet_PacketPong) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -511,6 +538,7 @@ func (m *Packet_PacketPong) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Packet_PacketMsg) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -532,6 +560,7 @@ func (m *Packet_PacketMsg) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *AuthSigMessage) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -583,6 +612,7 @@ func encodeVarintConn(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *PacketPing) Size() (n int) {
 	if m == nil {
 		return 0
@@ -644,6 +674,7 @@ func (m *Packet_PacketPing) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Packet_PacketPong) Size() (n int) {
 	if m == nil {
 		return 0
@@ -656,6 +687,7 @@ func (m *Packet_PacketPong) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Packet_PacketMsg) Size() (n int) {
 	if m == nil {
 		return 0
@@ -668,6 +700,7 @@ func (m *Packet_PacketMsg) Size() (n int) {
 	}
 	return n
 }
+
 func (m *AuthSigMessage) Size() (n int) {
 	if m == nil {
 		return 0
@@ -686,9 +719,11 @@ func (m *AuthSigMessage) Size() (n int) {
 func sovConn(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozConn(x uint64) (n int) {
 	return sovConn(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *PacketPing) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -739,6 +774,7 @@ func (m *PacketPing) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PacketPong) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -789,6 +825,7 @@ func (m *PacketPong) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PacketMsg) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -912,6 +949,7 @@ func (m *PacketMsg) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Packet) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1067,6 +1105,7 @@ func (m *Packet) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *AuthSigMessage) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1184,6 +1223,7 @@ func (m *AuthSigMessage) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipConn(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/p2p/pex.pb.go
+++ b/third_party/proto/tendermint/p2p/pex.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -24,8 +27,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type PexRequest struct {
-}
+type PexRequest struct{}
 
 func (m *PexRequest) Reset()         { *m = PexRequest{} }
 func (m *PexRequest) String() string { return proto.CompactTextString(m) }
@@ -33,9 +35,11 @@ func (*PexRequest) ProtoMessage()    {}
 func (*PexRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81c2f011fd13be57, []int{0}
 }
+
 func (m *PexRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PexRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PexRequest.Marshal(b, m, deterministic)
@@ -48,12 +52,15 @@ func (m *PexRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PexRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PexRequest.Merge(m, src)
 }
+
 func (m *PexRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PexRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_PexRequest.DiscardUnknown(m)
 }
@@ -70,9 +77,11 @@ func (*PexAddrs) ProtoMessage()    {}
 func (*PexAddrs) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81c2f011fd13be57, []int{1}
 }
+
 func (m *PexAddrs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PexAddrs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PexAddrs.Marshal(b, m, deterministic)
@@ -85,12 +94,15 @@ func (m *PexAddrs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *PexAddrs) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PexAddrs.Merge(m, src)
 }
+
 func (m *PexAddrs) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PexAddrs) XXX_DiscardUnknown() {
 	xxx_messageInfo_PexAddrs.DiscardUnknown(m)
 }
@@ -117,9 +129,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_81c2f011fd13be57, []int{2}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -132,12 +146,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -331,6 +348,7 @@ func (m *Message_PexRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_PexAddrs) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -352,6 +370,7 @@ func (m *Message_PexAddrs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintPex(dAtA []byte, offset int, v uint64) int {
 	offset -= sovPex(v)
 	base := offset
@@ -363,6 +382,7 @@ func encodeVarintPex(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *PexRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -411,6 +431,7 @@ func (m *Message_PexRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_PexAddrs) Size() (n int) {
 	if m == nil {
 		return 0
@@ -427,9 +448,11 @@ func (m *Message_PexAddrs) Size() (n int) {
 func sovPex(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozPex(x uint64) (n int) {
 	return sovPex(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *PexRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -480,6 +503,7 @@ func (m *PexRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PexAddrs) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -564,6 +588,7 @@ func (m *PexAddrs) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -684,6 +709,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipPex(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/p2p/types.pb.go
+++ b/third_party/proto/tendermint/p2p/types.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -36,9 +39,11 @@ func (*NetAddress) ProtoMessage()    {}
 func (*NetAddress) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c8a29e659aeca578, []int{0}
 }
+
 func (m *NetAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *NetAddress) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_NetAddress.Marshal(b, m, deterministic)
@@ -51,12 +56,15 @@ func (m *NetAddress) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *NetAddress) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_NetAddress.Merge(m, src)
 }
+
 func (m *NetAddress) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *NetAddress) XXX_DiscardUnknown() {
 	xxx_messageInfo_NetAddress.DiscardUnknown(m)
 }
@@ -96,9 +104,11 @@ func (*ProtocolVersion) ProtoMessage()    {}
 func (*ProtocolVersion) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c8a29e659aeca578, []int{1}
 }
+
 func (m *ProtocolVersion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ProtocolVersion) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ProtocolVersion.Marshal(b, m, deterministic)
@@ -111,12 +121,15 @@ func (m *ProtocolVersion) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *ProtocolVersion) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ProtocolVersion.Merge(m, src)
 }
+
 func (m *ProtocolVersion) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ProtocolVersion) XXX_DiscardUnknown() {
 	xxx_messageInfo_ProtocolVersion.DiscardUnknown(m)
 }
@@ -161,9 +174,11 @@ func (*DefaultNodeInfo) ProtoMessage()    {}
 func (*DefaultNodeInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c8a29e659aeca578, []int{2}
 }
+
 func (m *DefaultNodeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *DefaultNodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_DefaultNodeInfo.Marshal(b, m, deterministic)
@@ -176,12 +191,15 @@ func (m *DefaultNodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *DefaultNodeInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DefaultNodeInfo.Merge(m, src)
 }
+
 func (m *DefaultNodeInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *DefaultNodeInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_DefaultNodeInfo.DiscardUnknown(m)
 }
@@ -255,9 +273,11 @@ func (*DefaultNodeInfoOther) ProtoMessage()    {}
 func (*DefaultNodeInfoOther) Descriptor() ([]byte, []int) {
 	return fileDescriptor_c8a29e659aeca578, []int{3}
 }
+
 func (m *DefaultNodeInfoOther) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *DefaultNodeInfoOther) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_DefaultNodeInfoOther.Marshal(b, m, deterministic)
@@ -270,12 +290,15 @@ func (m *DefaultNodeInfoOther) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *DefaultNodeInfoOther) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DefaultNodeInfoOther.Merge(m, src)
 }
+
 func (m *DefaultNodeInfoOther) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *DefaultNodeInfoOther) XXX_DiscardUnknown() {
 	xxx_messageInfo_DefaultNodeInfoOther.DiscardUnknown(m)
 }
@@ -552,6 +575,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *NetAddress) Size() (n int) {
 	if m == nil {
 		return 0
@@ -647,9 +671,11 @@ func (m *DefaultNodeInfoOther) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *NetAddress) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -783,6 +809,7 @@ func (m *NetAddress) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ProtocolVersion) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -890,6 +917,7 @@ func (m *ProtocolVersion) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *DefaultNodeInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1200,6 +1228,7 @@ func (m *DefaultNodeInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *DefaultNodeInfoOther) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1314,6 +1343,7 @@ func (m *DefaultNodeInfoOther) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/privval/types.pb.go
+++ b/third_party/proto/tendermint/privval/types.pb.go
@@ -17,8 +17,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -74,9 +77,11 @@ func (*RemoteSignerError) ProtoMessage()    {}
 func (*RemoteSignerError) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{0}
 }
+
 func (m *RemoteSignerError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *RemoteSignerError) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_RemoteSignerError.Marshal(b, m, deterministic)
@@ -89,12 +94,15 @@ func (m *RemoteSignerError) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *RemoteSignerError) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_RemoteSignerError.Merge(m, src)
 }
+
 func (m *RemoteSignerError) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *RemoteSignerError) XXX_DiscardUnknown() {
 	xxx_messageInfo_RemoteSignerError.DiscardUnknown(m)
 }
@@ -126,9 +134,11 @@ func (*PubKeyRequest) ProtoMessage()    {}
 func (*PubKeyRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{1}
 }
+
 func (m *PubKeyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PubKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PubKeyRequest.Marshal(b, m, deterministic)
@@ -141,12 +151,15 @@ func (m *PubKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *PubKeyRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PubKeyRequest.Merge(m, src)
 }
+
 func (m *PubKeyRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PubKeyRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_PubKeyRequest.DiscardUnknown(m)
 }
@@ -172,9 +185,11 @@ func (*PubKeyResponse) ProtoMessage()    {}
 func (*PubKeyResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{2}
 }
+
 func (m *PubKeyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PubKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PubKeyResponse.Marshal(b, m, deterministic)
@@ -187,12 +202,15 @@ func (m *PubKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *PubKeyResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PubKeyResponse.Merge(m, src)
 }
+
 func (m *PubKeyResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PubKeyResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_PubKeyResponse.DiscardUnknown(m)
 }
@@ -225,9 +243,11 @@ func (*SignVoteRequest) ProtoMessage()    {}
 func (*SignVoteRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{3}
 }
+
 func (m *SignVoteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SignVoteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SignVoteRequest.Marshal(b, m, deterministic)
@@ -240,12 +260,15 @@ func (m *SignVoteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *SignVoteRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SignVoteRequest.Merge(m, src)
 }
+
 func (m *SignVoteRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SignVoteRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_SignVoteRequest.DiscardUnknown(m)
 }
@@ -278,9 +301,11 @@ func (*SignedVoteResponse) ProtoMessage()    {}
 func (*SignedVoteResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{4}
 }
+
 func (m *SignedVoteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SignedVoteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SignedVoteResponse.Marshal(b, m, deterministic)
@@ -293,12 +318,15 @@ func (m *SignedVoteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *SignedVoteResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SignedVoteResponse.Merge(m, src)
 }
+
 func (m *SignedVoteResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SignedVoteResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_SignedVoteResponse.DiscardUnknown(m)
 }
@@ -331,9 +359,11 @@ func (*SignProposalRequest) ProtoMessage()    {}
 func (*SignProposalRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{5}
 }
+
 func (m *SignProposalRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SignProposalRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SignProposalRequest.Marshal(b, m, deterministic)
@@ -346,12 +376,15 @@ func (m *SignProposalRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *SignProposalRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SignProposalRequest.Merge(m, src)
 }
+
 func (m *SignProposalRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SignProposalRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_SignProposalRequest.DiscardUnknown(m)
 }
@@ -384,9 +417,11 @@ func (*SignedProposalResponse) ProtoMessage()    {}
 func (*SignedProposalResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{6}
 }
+
 func (m *SignedProposalResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SignedProposalResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SignedProposalResponse.Marshal(b, m, deterministic)
@@ -399,12 +434,15 @@ func (m *SignedProposalResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *SignedProposalResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SignedProposalResponse.Merge(m, src)
 }
+
 func (m *SignedProposalResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SignedProposalResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_SignedProposalResponse.DiscardUnknown(m)
 }
@@ -426,8 +464,7 @@ func (m *SignedProposalResponse) GetError() *RemoteSignerError {
 }
 
 // PingRequest is a request to confirm that the connection is alive.
-type PingRequest struct {
-}
+type PingRequest struct{}
 
 func (m *PingRequest) Reset()         { *m = PingRequest{} }
 func (m *PingRequest) String() string { return proto.CompactTextString(m) }
@@ -435,9 +472,11 @@ func (*PingRequest) ProtoMessage()    {}
 func (*PingRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{7}
 }
+
 func (m *PingRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PingRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PingRequest.Marshal(b, m, deterministic)
@@ -450,12 +489,15 @@ func (m *PingRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
+
 func (m *PingRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PingRequest.Merge(m, src)
 }
+
 func (m *PingRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PingRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_PingRequest.DiscardUnknown(m)
 }
@@ -463,8 +505,7 @@ func (m *PingRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_PingRequest proto.InternalMessageInfo
 
 // PingResponse is a response to confirm that the connection is alive.
-type PingResponse struct {
-}
+type PingResponse struct{}
 
 func (m *PingResponse) Reset()         { *m = PingResponse{} }
 func (m *PingResponse) String() string { return proto.CompactTextString(m) }
@@ -472,9 +513,11 @@ func (*PingResponse) ProtoMessage()    {}
 func (*PingResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{8}
 }
+
 func (m *PingResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PingResponse.Marshal(b, m, deterministic)
@@ -487,12 +530,15 @@ func (m *PingResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *PingResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PingResponse.Merge(m, src)
 }
+
 func (m *PingResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PingResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_PingResponse.DiscardUnknown(m)
 }
@@ -518,9 +564,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_cb4e437a5328cf9c, []int{9}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -533,12 +581,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -1112,6 +1163,7 @@ func (m *Message_PubKeyRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_PubKeyResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1133,6 +1185,7 @@ func (m *Message_PubKeyResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_SignVoteRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1154,6 +1207,7 @@ func (m *Message_SignVoteRequest) MarshalToSizedBuffer(dAtA []byte) (int, error)
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_SignedVoteResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1175,6 +1229,7 @@ func (m *Message_SignedVoteResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_SignProposalRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1196,6 +1251,7 @@ func (m *Message_SignProposalRequest) MarshalToSizedBuffer(dAtA []byte) (int, er
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_SignedProposalResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1217,6 +1273,7 @@ func (m *Message_SignedProposalResponse) MarshalToSizedBuffer(dAtA []byte) (int,
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_PingRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1238,6 +1295,7 @@ func (m *Message_PingRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_PingResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -1259,6 +1317,7 @@ func (m *Message_PingResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTypes(v)
 	base := offset
@@ -1270,6 +1329,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *RemoteSignerError) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1420,6 +1480,7 @@ func (m *Message_PubKeyRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_PubKeyResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1432,6 +1493,7 @@ func (m *Message_PubKeyResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_SignVoteRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1444,6 +1506,7 @@ func (m *Message_SignVoteRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_SignedVoteResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1456,6 +1519,7 @@ func (m *Message_SignedVoteResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_SignProposalRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1468,6 +1532,7 @@ func (m *Message_SignProposalRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_SignedProposalResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1480,6 +1545,7 @@ func (m *Message_SignedProposalResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_PingRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1492,6 +1558,7 @@ func (m *Message_PingRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_PingResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1508,9 +1575,11 @@ func (m *Message_PingResponse) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *RemoteSignerError) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1612,6 +1681,7 @@ func (m *RemoteSignerError) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PubKeyRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1694,6 +1764,7 @@ func (m *PubKeyRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PubKeyResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1813,6 +1884,7 @@ func (m *PubKeyResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SignVoteRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1931,6 +2003,7 @@ func (m *SignVoteRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SignedVoteResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2050,6 +2123,7 @@ func (m *SignedVoteResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SignProposalRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2168,6 +2242,7 @@ func (m *SignProposalRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SignedProposalResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2287,6 +2362,7 @@ func (m *SignedProposalResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PingRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2337,6 +2413,7 @@ func (m *PingRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PingResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2387,6 +2464,7 @@ func (m *PingResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2717,6 +2795,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/state/types.pb.go
+++ b/third_party/proto/tendermint/state/types.pb.go
@@ -21,9 +21,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -46,9 +49,11 @@ func (*ABCIResponses) ProtoMessage()    {}
 func (*ABCIResponses) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ccfacf933f22bf93, []int{0}
 }
+
 func (m *ABCIResponses) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ABCIResponses) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ABCIResponses.Marshal(b, m, deterministic)
@@ -61,12 +66,15 @@ func (m *ABCIResponses) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *ABCIResponses) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ABCIResponses.Merge(m, src)
 }
+
 func (m *ABCIResponses) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ABCIResponses) XXX_DiscardUnknown() {
 	xxx_messageInfo_ABCIResponses.DiscardUnknown(m)
 }
@@ -106,9 +114,11 @@ func (*ValidatorsInfo) ProtoMessage()    {}
 func (*ValidatorsInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ccfacf933f22bf93, []int{1}
 }
+
 func (m *ValidatorsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ValidatorsInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ValidatorsInfo.Marshal(b, m, deterministic)
@@ -121,12 +131,15 @@ func (m *ValidatorsInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *ValidatorsInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ValidatorsInfo.Merge(m, src)
 }
+
 func (m *ValidatorsInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ValidatorsInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_ValidatorsInfo.DiscardUnknown(m)
 }
@@ -159,9 +172,11 @@ func (*ConsensusParamsInfo) ProtoMessage()    {}
 func (*ConsensusParamsInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ccfacf933f22bf93, []int{2}
 }
+
 func (m *ConsensusParamsInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ConsensusParamsInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ConsensusParamsInfo.Marshal(b, m, deterministic)
@@ -174,12 +189,15 @@ func (m *ConsensusParamsInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *ConsensusParamsInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ConsensusParamsInfo.Merge(m, src)
 }
+
 func (m *ConsensusParamsInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ConsensusParamsInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_ConsensusParamsInfo.DiscardUnknown(m)
 }
@@ -211,9 +229,11 @@ func (*Version) ProtoMessage()    {}
 func (*Version) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ccfacf933f22bf93, []int{3}
 }
+
 func (m *Version) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Version) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Version.Marshal(b, m, deterministic)
@@ -226,12 +246,15 @@ func (m *Version) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Version) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Version.Merge(m, src)
 }
+
 func (m *Version) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Version) XXX_DiscardUnknown() {
 	xxx_messageInfo_Version.DiscardUnknown(m)
 }
@@ -287,9 +310,11 @@ func (*State) ProtoMessage()    {}
 func (*State) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ccfacf933f22bf93, []int{4}
 }
+
 func (m *State) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *State) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_State.Marshal(b, m, deterministic)
@@ -302,12 +327,15 @@ func (m *State) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *State) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_State.Merge(m, src)
 }
+
 func (m *State) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *State) XXX_DiscardUnknown() {
 	xxx_messageInfo_State.DiscardUnknown(m)
 }
@@ -802,6 +830,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *ABCIResponses) Size() (n int) {
 	if m == nil {
 		return 0
@@ -926,9 +955,11 @@ func (m *State) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *ABCIResponses) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1085,6 +1116,7 @@ func (m *ABCIResponses) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ValidatorsInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1190,6 +1222,7 @@ func (m *ValidatorsInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ConsensusParamsInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1292,6 +1325,7 @@ func (m *ConsensusParamsInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Version) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1407,6 +1441,7 @@ func (m *Version) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *State) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1873,6 +1908,7 @@ func (m *State) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/statesync/types.pb.go
+++ b/third_party/proto/tendermint/statesync/types.pb.go
@@ -14,8 +14,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -38,9 +41,11 @@ func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1c2869546ca7914, []int{0}
 }
+
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
@@ -53,12 +58,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Message) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Message.Merge(m, src)
 }
+
 func (m *Message) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Message) XXX_DiscardUnknown() {
 	xxx_messageInfo_Message.DiscardUnknown(m)
 }
@@ -134,8 +142,7 @@ func (*Message) XXX_OneofWrappers() []interface{} {
 	}
 }
 
-type SnapshotsRequest struct {
-}
+type SnapshotsRequest struct{}
 
 func (m *SnapshotsRequest) Reset()         { *m = SnapshotsRequest{} }
 func (m *SnapshotsRequest) String() string { return proto.CompactTextString(m) }
@@ -143,9 +150,11 @@ func (*SnapshotsRequest) ProtoMessage()    {}
 func (*SnapshotsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1c2869546ca7914, []int{1}
 }
+
 func (m *SnapshotsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SnapshotsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SnapshotsRequest.Marshal(b, m, deterministic)
@@ -158,12 +167,15 @@ func (m *SnapshotsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
+
 func (m *SnapshotsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SnapshotsRequest.Merge(m, src)
 }
+
 func (m *SnapshotsRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SnapshotsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_SnapshotsRequest.DiscardUnknown(m)
 }
@@ -184,9 +196,11 @@ func (*SnapshotsResponse) ProtoMessage()    {}
 func (*SnapshotsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1c2869546ca7914, []int{2}
 }
+
 func (m *SnapshotsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SnapshotsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SnapshotsResponse.Marshal(b, m, deterministic)
@@ -199,12 +213,15 @@ func (m *SnapshotsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *SnapshotsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SnapshotsResponse.Merge(m, src)
 }
+
 func (m *SnapshotsResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SnapshotsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_SnapshotsResponse.DiscardUnknown(m)
 }
@@ -258,9 +275,11 @@ func (*ChunkRequest) ProtoMessage()    {}
 func (*ChunkRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1c2869546ca7914, []int{3}
 }
+
 func (m *ChunkRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ChunkRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ChunkRequest.Marshal(b, m, deterministic)
@@ -273,12 +292,15 @@ func (m *ChunkRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *ChunkRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ChunkRequest.Merge(m, src)
 }
+
 func (m *ChunkRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ChunkRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_ChunkRequest.DiscardUnknown(m)
 }
@@ -320,9 +342,11 @@ func (*ChunkResponse) ProtoMessage()    {}
 func (*ChunkResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_a1c2869546ca7914, []int{4}
 }
+
 func (m *ChunkResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ChunkResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ChunkResponse.Marshal(b, m, deterministic)
@@ -335,12 +359,15 @@ func (m *ChunkResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *ChunkResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ChunkResponse.Merge(m, src)
 }
+
 func (m *ChunkResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ChunkResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_ChunkResponse.DiscardUnknown(m)
 }
@@ -474,6 +501,7 @@ func (m *Message_SnapshotsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_SnapshotsResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -495,6 +523,7 @@ func (m *Message_SnapshotsResponse) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_ChunkRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -516,6 +545,7 @@ func (m *Message_ChunkRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Message_ChunkResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -537,6 +567,7 @@ func (m *Message_ChunkResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *SnapshotsRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -716,6 +747,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *Message) Size() (n int) {
 	if m == nil {
 		return 0
@@ -740,6 +772,7 @@ func (m *Message_SnapshotsRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_SnapshotsResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -752,6 +785,7 @@ func (m *Message_SnapshotsResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_ChunkRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -764,6 +798,7 @@ func (m *Message_ChunkRequest) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Message_ChunkResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -776,6 +811,7 @@ func (m *Message_ChunkResponse) Size() (n int) {
 	}
 	return n
 }
+
 func (m *SnapshotsRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -857,9 +893,11 @@ func (m *ChunkResponse) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *Message) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1050,6 +1088,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SnapshotsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1100,6 +1139,7 @@ func (m *SnapshotsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SnapshotsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1275,6 +1315,7 @@ func (m *SnapshotsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ChunkRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1382,6 +1423,7 @@ func (m *ChunkRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ChunkResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1543,6 +1585,7 @@ func (m *ChunkResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/store/types.pb.go
+++ b/third_party/proto/tendermint/store/types.pb.go
@@ -14,8 +14,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -34,9 +37,11 @@ func (*BlockStoreState) ProtoMessage()    {}
 func (*BlockStoreState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_ff9e53a0a74267f7, []int{0}
 }
+
 func (m *BlockStoreState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockStoreState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockStoreState.Marshal(b, m, deterministic)
@@ -49,12 +54,15 @@ func (m *BlockStoreState) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *BlockStoreState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockStoreState.Merge(m, src)
 }
+
 func (m *BlockStoreState) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockStoreState) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockStoreState.DiscardUnknown(m)
 }
@@ -140,6 +148,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *BlockStoreState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -158,9 +167,11 @@ func (m *BlockStoreState) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *BlockStoreState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -249,6 +260,7 @@ func (m *BlockStoreState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/block.pb.go
+++ b/third_party/proto/tendermint/types/block.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -37,9 +40,11 @@ func (*Block) ProtoMessage()    {}
 func (*Block) Descriptor() ([]byte, []int) {
 	return fileDescriptor_70840e82f4357ab1, []int{0}
 }
+
 func (m *Block) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Block) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Block.Marshal(b, m, deterministic)
@@ -52,12 +57,15 @@ func (m *Block) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Block) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Block.Merge(m, src)
 }
+
 func (m *Block) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Block) XXX_DiscardUnknown() {
 	xxx_messageInfo_Block.DiscardUnknown(m)
 }
@@ -195,6 +203,7 @@ func encodeVarintBlock(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *Block) Size() (n int) {
 	if m == nil {
 		return 0
@@ -217,9 +226,11 @@ func (m *Block) Size() (n int) {
 func sovBlock(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozBlock(x uint64) (n int) {
 	return sovBlock(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *Block) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -405,6 +416,7 @@ func (m *Block) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipBlock(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/canonical.pb.go
+++ b/third_party/proto/tendermint/types/canonical.pb.go
@@ -19,9 +19,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -40,9 +43,11 @@ func (*CanonicalBlockID) ProtoMessage()    {}
 func (*CanonicalBlockID) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8d1a1a84ff7267ed, []int{0}
 }
+
 func (m *CanonicalBlockID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CanonicalBlockID) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CanonicalBlockID.Marshal(b, m, deterministic)
@@ -55,12 +60,15 @@ func (m *CanonicalBlockID) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
+
 func (m *CanonicalBlockID) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CanonicalBlockID.Merge(m, src)
 }
+
 func (m *CanonicalBlockID) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CanonicalBlockID) XXX_DiscardUnknown() {
 	xxx_messageInfo_CanonicalBlockID.DiscardUnknown(m)
 }
@@ -92,9 +100,11 @@ func (*CanonicalPartSetHeader) ProtoMessage()    {}
 func (*CanonicalPartSetHeader) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8d1a1a84ff7267ed, []int{1}
 }
+
 func (m *CanonicalPartSetHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CanonicalPartSetHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CanonicalPartSetHeader.Marshal(b, m, deterministic)
@@ -107,12 +117,15 @@ func (m *CanonicalPartSetHeader) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *CanonicalPartSetHeader) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CanonicalPartSetHeader.Merge(m, src)
 }
+
 func (m *CanonicalPartSetHeader) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CanonicalPartSetHeader) XXX_DiscardUnknown() {
 	xxx_messageInfo_CanonicalPartSetHeader.DiscardUnknown(m)
 }
@@ -149,9 +162,11 @@ func (*CanonicalProposal) ProtoMessage()    {}
 func (*CanonicalProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8d1a1a84ff7267ed, []int{2}
 }
+
 func (m *CanonicalProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CanonicalProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CanonicalProposal.Marshal(b, m, deterministic)
@@ -164,12 +179,15 @@ func (m *CanonicalProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *CanonicalProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CanonicalProposal.Merge(m, src)
 }
+
 func (m *CanonicalProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CanonicalProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_CanonicalProposal.DiscardUnknown(m)
 }
@@ -240,9 +258,11 @@ func (*CanonicalVote) ProtoMessage()    {}
 func (*CanonicalVote) Descriptor() ([]byte, []int) {
 	return fileDescriptor_8d1a1a84ff7267ed, []int{3}
 }
+
 func (m *CanonicalVote) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CanonicalVote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CanonicalVote.Marshal(b, m, deterministic)
@@ -255,12 +275,15 @@ func (m *CanonicalVote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *CanonicalVote) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CanonicalVote.Merge(m, src)
 }
+
 func (m *CanonicalVote) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CanonicalVote) XXX_DiscardUnknown() {
 	xxx_messageInfo_CanonicalVote.DiscardUnknown(m)
 }
@@ -578,6 +601,7 @@ func encodeVarintCanonical(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *CanonicalBlockID) Size() (n int) {
 	if m == nil {
 		return 0
@@ -671,9 +695,11 @@ func (m *CanonicalVote) Size() (n int) {
 func sovCanonical(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozCanonical(x uint64) (n int) {
 	return sovCanonical(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *CanonicalBlockID) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -791,6 +817,7 @@ func (m *CanonicalBlockID) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CanonicalPartSetHeader) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -894,6 +921,7 @@ func (m *CanonicalPartSetHeader) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CanonicalProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1103,6 +1131,7 @@ func (m *CanonicalProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CanonicalVote) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1293,6 +1322,7 @@ func (m *CanonicalVote) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipCanonical(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/events.pb.go
+++ b/third_party/proto/tendermint/types/events.pb.go
@@ -14,8 +14,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -35,9 +38,11 @@ func (*EventDataRoundState) ProtoMessage()    {}
 func (*EventDataRoundState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_72cfafd446dedf7c, []int{0}
 }
+
 func (m *EventDataRoundState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *EventDataRoundState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_EventDataRoundState.Marshal(b, m, deterministic)
@@ -50,12 +55,15 @@ func (m *EventDataRoundState) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *EventDataRoundState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_EventDataRoundState.Merge(m, src)
 }
+
 func (m *EventDataRoundState) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *EventDataRoundState) XXX_DiscardUnknown() {
 	xxx_messageInfo_EventDataRoundState.DiscardUnknown(m)
 }
@@ -156,6 +164,7 @@ func encodeVarintEvents(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *EventDataRoundState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -178,9 +187,11 @@ func (m *EventDataRoundState) Size() (n int) {
 func sovEvents(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozEvents(x uint64) (n int) {
 	return sovEvents(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *EventDataRoundState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -301,6 +312,7 @@ func (m *EventDataRoundState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipEvents(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/evidence.pb.go
+++ b/third_party/proto/tendermint/types/evidence.pb.go
@@ -18,9 +18,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -41,9 +44,11 @@ func (*Evidence) ProtoMessage()    {}
 func (*Evidence) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6825fabc78e0a168, []int{0}
 }
+
 func (m *Evidence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Evidence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Evidence.Marshal(b, m, deterministic)
@@ -56,12 +61,15 @@ func (m *Evidence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Evidence) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Evidence.Merge(m, src)
 }
+
 func (m *Evidence) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Evidence) XXX_DiscardUnknown() {
 	xxx_messageInfo_Evidence.DiscardUnknown(m)
 }
@@ -128,9 +136,11 @@ func (*DuplicateVoteEvidence) ProtoMessage()    {}
 func (*DuplicateVoteEvidence) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6825fabc78e0a168, []int{1}
 }
+
 func (m *DuplicateVoteEvidence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *DuplicateVoteEvidence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_DuplicateVoteEvidence.Marshal(b, m, deterministic)
@@ -143,12 +153,15 @@ func (m *DuplicateVoteEvidence) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *DuplicateVoteEvidence) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_DuplicateVoteEvidence.Merge(m, src)
 }
+
 func (m *DuplicateVoteEvidence) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *DuplicateVoteEvidence) XXX_DiscardUnknown() {
 	xxx_messageInfo_DuplicateVoteEvidence.DiscardUnknown(m)
 }
@@ -205,9 +218,11 @@ func (*LightClientAttackEvidence) ProtoMessage()    {}
 func (*LightClientAttackEvidence) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6825fabc78e0a168, []int{2}
 }
+
 func (m *LightClientAttackEvidence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *LightClientAttackEvidence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_LightClientAttackEvidence.Marshal(b, m, deterministic)
@@ -220,12 +235,15 @@ func (m *LightClientAttackEvidence) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *LightClientAttackEvidence) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_LightClientAttackEvidence.Merge(m, src)
 }
+
 func (m *LightClientAttackEvidence) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *LightClientAttackEvidence) XXX_DiscardUnknown() {
 	xxx_messageInfo_LightClientAttackEvidence.DiscardUnknown(m)
 }
@@ -277,9 +295,11 @@ func (*EvidenceList) ProtoMessage()    {}
 func (*EvidenceList) Descriptor() ([]byte, []int) {
 	return fileDescriptor_6825fabc78e0a168, []int{3}
 }
+
 func (m *EvidenceList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *EvidenceList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_EvidenceList.Marshal(b, m, deterministic)
@@ -292,12 +312,15 @@ func (m *EvidenceList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *EvidenceList) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_EvidenceList.Merge(m, src)
 }
+
 func (m *EvidenceList) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *EvidenceList) XXX_DiscardUnknown() {
 	xxx_messageInfo_EvidenceList.DiscardUnknown(m)
 }
@@ -411,6 +434,7 @@ func (m *Evidence_DuplicateVoteEvidence) MarshalToSizedBuffer(dAtA []byte) (int,
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Evidence_LightClientAttackEvidence) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -432,6 +456,7 @@ func (m *Evidence_LightClientAttackEvidence) MarshalToSizedBuffer(dAtA []byte) (
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *DuplicateVoteEvidence) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -612,6 +637,7 @@ func encodeVarintEvidence(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *Evidence) Size() (n int) {
 	if m == nil {
 		return 0
@@ -636,6 +662,7 @@ func (m *Evidence_DuplicateVoteEvidence) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Evidence_LightClientAttackEvidence) Size() (n int) {
 	if m == nil {
 		return 0
@@ -648,6 +675,7 @@ func (m *Evidence_LightClientAttackEvidence) Size() (n int) {
 	}
 	return n
 }
+
 func (m *DuplicateVoteEvidence) Size() (n int) {
 	if m == nil {
 		return 0
@@ -718,9 +746,11 @@ func (m *EvidenceList) Size() (n int) {
 func sovEvidence(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozEvidence(x uint64) (n int) {
 	return sovEvidence(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *Evidence) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -841,6 +871,7 @@ func (m *Evidence) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *DuplicateVoteEvidence) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1034,6 +1065,7 @@ func (m *DuplicateVoteEvidence) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *LightClientAttackEvidence) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1225,6 +1257,7 @@ func (m *LightClientAttackEvidence) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *EvidenceList) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1309,6 +1342,7 @@ func (m *EvidenceList) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipEvidence(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/params.pb.go
+++ b/third_party/proto/tendermint/types/params.pb.go
@@ -18,9 +18,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -43,9 +46,11 @@ func (*ConsensusParams) ProtoMessage()    {}
 func (*ConsensusParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{0}
 }
+
 func (m *ConsensusParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ConsensusParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ConsensusParams.Marshal(b, m, deterministic)
@@ -58,12 +63,15 @@ func (m *ConsensusParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *ConsensusParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ConsensusParams.Merge(m, src)
 }
+
 func (m *ConsensusParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ConsensusParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_ConsensusParams.DiscardUnknown(m)
 }
@@ -119,9 +127,11 @@ func (*BlockParams) ProtoMessage()    {}
 func (*BlockParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{1}
 }
+
 func (m *BlockParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockParams.Marshal(b, m, deterministic)
@@ -134,12 +144,15 @@ func (m *BlockParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
+
 func (m *BlockParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockParams.Merge(m, src)
 }
+
 func (m *BlockParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockParams.DiscardUnknown(m)
 }
@@ -192,9 +205,11 @@ func (*EvidenceParams) ProtoMessage()    {}
 func (*EvidenceParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{2}
 }
+
 func (m *EvidenceParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *EvidenceParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_EvidenceParams.Marshal(b, m, deterministic)
@@ -207,12 +222,15 @@ func (m *EvidenceParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *EvidenceParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_EvidenceParams.Merge(m, src)
 }
+
 func (m *EvidenceParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *EvidenceParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_EvidenceParams.DiscardUnknown(m)
 }
@@ -252,9 +270,11 @@ func (*ValidatorParams) ProtoMessage()    {}
 func (*ValidatorParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{3}
 }
+
 func (m *ValidatorParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ValidatorParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ValidatorParams.Marshal(b, m, deterministic)
@@ -267,12 +287,15 @@ func (m *ValidatorParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *ValidatorParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ValidatorParams.Merge(m, src)
 }
+
 func (m *ValidatorParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ValidatorParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_ValidatorParams.DiscardUnknown(m)
 }
@@ -297,9 +320,11 @@ func (*VersionParams) ProtoMessage()    {}
 func (*VersionParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{4}
 }
+
 func (m *VersionParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *VersionParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_VersionParams.Marshal(b, m, deterministic)
@@ -312,12 +337,15 @@ func (m *VersionParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *VersionParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_VersionParams.Merge(m, src)
 }
+
 func (m *VersionParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *VersionParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_VersionParams.DiscardUnknown(m)
 }
@@ -345,9 +373,11 @@ func (*HashedParams) ProtoMessage()    {}
 func (*HashedParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e12598271a686f57, []int{5}
 }
+
 func (m *HashedParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *HashedParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_HashedParams.Marshal(b, m, deterministic)
@@ -360,12 +390,15 @@ func (m *HashedParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *HashedParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_HashedParams.Merge(m, src)
 }
+
 func (m *HashedParams) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *HashedParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_HashedParams.DiscardUnknown(m)
 }
@@ -468,6 +501,7 @@ func (this *ConsensusParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *BlockParams) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -498,6 +532,7 @@ func (this *BlockParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *EvidenceParams) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -528,6 +563,7 @@ func (this *EvidenceParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ValidatorParams) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -557,6 +593,7 @@ func (this *ValidatorParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *VersionParams) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -581,6 +618,7 @@ func (this *VersionParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *HashedParams) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -608,6 +646,7 @@ func (this *HashedParams) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (m *ConsensusParams) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -854,6 +893,7 @@ func encodeVarintParams(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func NewPopulatedValidatorParams(r randyParams, easy bool) *ValidatorParams {
 	this := &ValidatorParams{}
 	v1 := r.Intn(10)
@@ -892,6 +932,7 @@ func randUTF8RuneParams(r randyParams) rune {
 	}
 	return rune(ru + 61)
 }
+
 func randStringParams(r randyParams) string {
 	v2 := r.Intn(100)
 	tmps := make([]rune, v2)
@@ -900,6 +941,7 @@ func randStringParams(r randyParams) string {
 	}
 	return string(tmps)
 }
+
 func randUnrecognizedParams(r randyParams, maxFieldNumber int) (dAtA []byte) {
 	l := r.Intn(5)
 	for i := 0; i < l; i++ {
@@ -912,6 +954,7 @@ func randUnrecognizedParams(r randyParams, maxFieldNumber int) (dAtA []byte) {
 	}
 	return dAtA
 }
+
 func randFieldParams(dAtA []byte, r randyParams, fieldNumber int, wire int) []byte {
 	key := uint32(fieldNumber)<<3 | uint32(wire)
 	switch wire {
@@ -938,6 +981,7 @@ func randFieldParams(dAtA []byte, r randyParams, fieldNumber int, wire int) []by
 	}
 	return dAtA
 }
+
 func encodeVarintPopulateParams(dAtA []byte, v uint64) []byte {
 	for v >= 1<<7 {
 		dAtA = append(dAtA, uint8(uint64(v)&0x7f|0x80))
@@ -946,6 +990,7 @@ func encodeVarintPopulateParams(dAtA []byte, v uint64) []byte {
 	dAtA = append(dAtA, uint8(v))
 	return dAtA
 }
+
 func (m *ConsensusParams) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1043,9 +1088,11 @@ func (m *HashedParams) Size() (n int) {
 func sovParams(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozParams(x uint64) (n int) {
 	return sovParams(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *ConsensusParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1228,6 +1275,7 @@ func (m *ConsensusParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *BlockParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1335,6 +1383,7 @@ func (m *BlockParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *EvidenceParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1456,6 +1505,7 @@ func (m *EvidenceParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ValidatorParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1538,6 +1588,7 @@ func (m *ValidatorParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *VersionParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1607,6 +1658,7 @@ func (m *VersionParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *HashedParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1695,6 +1747,7 @@ func (m *HashedParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipParams(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/types.pb.go
+++ b/third_party/proto/tendermint/types/types.pb.go
@@ -20,9 +20,12 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
-var _ = time.Kitchen
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+	_ = time.Kitchen
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -108,9 +111,11 @@ func (*PartSetHeader) ProtoMessage()    {}
 func (*PartSetHeader) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{0}
 }
+
 func (m *PartSetHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PartSetHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PartSetHeader.Marshal(b, m, deterministic)
@@ -123,12 +128,15 @@ func (m *PartSetHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *PartSetHeader) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PartSetHeader.Merge(m, src)
 }
+
 func (m *PartSetHeader) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PartSetHeader) XXX_DiscardUnknown() {
 	xxx_messageInfo_PartSetHeader.DiscardUnknown(m)
 }
@@ -161,9 +169,11 @@ func (*Part) ProtoMessage()    {}
 func (*Part) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{1}
 }
+
 func (m *Part) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Part) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Part.Marshal(b, m, deterministic)
@@ -176,12 +186,15 @@ func (m *Part) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Part) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Part.Merge(m, src)
 }
+
 func (m *Part) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Part) XXX_DiscardUnknown() {
 	xxx_messageInfo_Part.DiscardUnknown(m)
 }
@@ -221,9 +234,11 @@ func (*BlockID) ProtoMessage()    {}
 func (*BlockID) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{2}
 }
+
 func (m *BlockID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockID) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockID.Marshal(b, m, deterministic)
@@ -236,12 +251,15 @@ func (m *BlockID) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *BlockID) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockID.Merge(m, src)
 }
+
 func (m *BlockID) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockID) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockID.DiscardUnknown(m)
 }
@@ -291,9 +309,11 @@ func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{3}
 }
+
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Header) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Header.Marshal(b, m, deterministic)
@@ -306,12 +326,15 @@ func (m *Header) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Header) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Header.Merge(m, src)
 }
+
 func (m *Header) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Header) XXX_DiscardUnknown() {
 	xxx_messageInfo_Header.DiscardUnknown(m)
 }
@@ -430,9 +453,11 @@ func (*Data) ProtoMessage()    {}
 func (*Data) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{4}
 }
+
 func (m *Data) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Data) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Data.Marshal(b, m, deterministic)
@@ -445,12 +470,15 @@ func (m *Data) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Data) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Data.Merge(m, src)
 }
+
 func (m *Data) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Data) XXX_DiscardUnknown() {
 	xxx_messageInfo_Data.DiscardUnknown(m)
 }
@@ -483,9 +511,11 @@ func (*Vote) ProtoMessage()    {}
 func (*Vote) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{5}
 }
+
 func (m *Vote) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Vote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Vote.Marshal(b, m, deterministic)
@@ -498,12 +528,15 @@ func (m *Vote) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Vote) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Vote.Merge(m, src)
 }
+
 func (m *Vote) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Vote) XXX_DiscardUnknown() {
 	xxx_messageInfo_Vote.DiscardUnknown(m)
 }
@@ -580,9 +613,11 @@ func (*Commit) ProtoMessage()    {}
 func (*Commit) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{6}
 }
+
 func (m *Commit) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Commit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Commit.Marshal(b, m, deterministic)
@@ -595,12 +630,15 @@ func (m *Commit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Commit) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Commit.Merge(m, src)
 }
+
 func (m *Commit) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Commit) XXX_DiscardUnknown() {
 	xxx_messageInfo_Commit.DiscardUnknown(m)
 }
@@ -649,9 +687,11 @@ func (*CommitSig) ProtoMessage()    {}
 func (*CommitSig) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{7}
 }
+
 func (m *CommitSig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CommitSig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CommitSig.Marshal(b, m, deterministic)
@@ -664,12 +704,15 @@ func (m *CommitSig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *CommitSig) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CommitSig.Merge(m, src)
 }
+
 func (m *CommitSig) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CommitSig) XXX_DiscardUnknown() {
 	xxx_messageInfo_CommitSig.DiscardUnknown(m)
 }
@@ -720,9 +763,11 @@ func (*Proposal) ProtoMessage()    {}
 func (*Proposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{8}
 }
+
 func (m *Proposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Proposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Proposal.Marshal(b, m, deterministic)
@@ -735,12 +780,15 @@ func (m *Proposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Proposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Proposal.Merge(m, src)
 }
+
 func (m *Proposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Proposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_Proposal.DiscardUnknown(m)
 }
@@ -807,9 +855,11 @@ func (*SignedHeader) ProtoMessage()    {}
 func (*SignedHeader) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{9}
 }
+
 func (m *SignedHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SignedHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SignedHeader.Marshal(b, m, deterministic)
@@ -822,12 +872,15 @@ func (m *SignedHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *SignedHeader) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SignedHeader.Merge(m, src)
 }
+
 func (m *SignedHeader) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SignedHeader) XXX_DiscardUnknown() {
 	xxx_messageInfo_SignedHeader.DiscardUnknown(m)
 }
@@ -859,9 +912,11 @@ func (*LightBlock) ProtoMessage()    {}
 func (*LightBlock) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{10}
 }
+
 func (m *LightBlock) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *LightBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_LightBlock.Marshal(b, m, deterministic)
@@ -874,12 +929,15 @@ func (m *LightBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *LightBlock) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_LightBlock.Merge(m, src)
 }
+
 func (m *LightBlock) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *LightBlock) XXX_DiscardUnknown() {
 	xxx_messageInfo_LightBlock.DiscardUnknown(m)
 }
@@ -913,9 +971,11 @@ func (*BlockMeta) ProtoMessage()    {}
 func (*BlockMeta) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{11}
 }
+
 func (m *BlockMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *BlockMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_BlockMeta.Marshal(b, m, deterministic)
@@ -928,12 +988,15 @@ func (m *BlockMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *BlockMeta) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_BlockMeta.Merge(m, src)
 }
+
 func (m *BlockMeta) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *BlockMeta) XXX_DiscardUnknown() {
 	xxx_messageInfo_BlockMeta.DiscardUnknown(m)
 }
@@ -981,9 +1044,11 @@ func (*TxProof) ProtoMessage()    {}
 func (*TxProof) Descriptor() ([]byte, []int) {
 	return fileDescriptor_d3a6e55e2345de56, []int{12}
 }
+
 func (m *TxProof) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *TxProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_TxProof.Marshal(b, m, deterministic)
@@ -996,12 +1061,15 @@ func (m *TxProof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *TxProof) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_TxProof.Merge(m, src)
 }
+
 func (m *TxProof) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *TxProof) XXX_DiscardUnknown() {
 	xxx_messageInfo_TxProof.DiscardUnknown(m)
 }
@@ -1871,6 +1939,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *PartSetHeader) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2177,9 +2246,11 @@ func (m *TxProof) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *PartSetHeader) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2283,6 +2354,7 @@ func (m *PartSetHeader) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Part) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2419,6 +2491,7 @@ func (m *Part) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *BlockID) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2536,6 +2609,7 @@ func (m *BlockID) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Header) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3042,6 +3116,7 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Data) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3124,6 +3199,7 @@ func (m *Data) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Vote) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3384,6 +3460,7 @@ func (m *Vote) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Commit) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3539,6 +3616,7 @@ func (m *Commit) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CommitSig) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3709,6 +3787,7 @@ func (m *CommitSig) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Proposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3935,6 +4014,7 @@ func (m *Proposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SignedHeader) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4057,6 +4137,7 @@ func (m *SignedHeader) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *LightBlock) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4179,6 +4260,7 @@ func (m *LightBlock) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *BlockMeta) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4333,6 +4415,7 @@ func (m *BlockMeta) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *TxProof) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4487,6 +4570,7 @@ func (m *TxProof) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/types/validator.pb.go
+++ b/third_party/proto/tendermint/types/validator.pb.go
@@ -16,8 +16,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -37,9 +40,11 @@ func (*ValidatorSet) ProtoMessage()    {}
 func (*ValidatorSet) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e92274df03d3088, []int{0}
 }
+
 func (m *ValidatorSet) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ValidatorSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ValidatorSet.Marshal(b, m, deterministic)
@@ -52,12 +57,15 @@ func (m *ValidatorSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *ValidatorSet) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ValidatorSet.Merge(m, src)
 }
+
 func (m *ValidatorSet) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ValidatorSet) XXX_DiscardUnknown() {
 	xxx_messageInfo_ValidatorSet.DiscardUnknown(m)
 }
@@ -98,9 +106,11 @@ func (*Validator) ProtoMessage()    {}
 func (*Validator) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e92274df03d3088, []int{1}
 }
+
 func (m *Validator) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Validator) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Validator.Marshal(b, m, deterministic)
@@ -113,12 +123,15 @@ func (m *Validator) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Validator) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Validator.Merge(m, src)
 }
+
 func (m *Validator) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Validator) XXX_DiscardUnknown() {
 	xxx_messageInfo_Validator.DiscardUnknown(m)
 }
@@ -164,9 +177,11 @@ func (*SimpleValidator) ProtoMessage()    {}
 func (*SimpleValidator) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4e92274df03d3088, []int{2}
 }
+
 func (m *SimpleValidator) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SimpleValidator) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SimpleValidator.Marshal(b, m, deterministic)
@@ -179,12 +194,15 @@ func (m *SimpleValidator) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *SimpleValidator) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SimpleValidator.Merge(m, src)
 }
+
 func (m *SimpleValidator) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SimpleValidator) XXX_DiscardUnknown() {
 	xxx_messageInfo_SimpleValidator.DiscardUnknown(m)
 }
@@ -395,6 +413,7 @@ func encodeVarintValidator(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *ValidatorSet) Size() (n int) {
 	if m == nil {
 		return 0
@@ -457,9 +476,11 @@ func (m *SimpleValidator) Size() (n int) {
 func sovValidator(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozValidator(x uint64) (n int) {
 	return sovValidator(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *ValidatorSet) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -599,6 +620,7 @@ func (m *ValidatorSet) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Validator) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -754,6 +776,7 @@ func (m *Validator) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SimpleValidator) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -859,6 +882,7 @@ func (m *SimpleValidator) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipValidator(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/third_party/proto/tendermint/version/types.pb.go
+++ b/third_party/proto/tendermint/version/types.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -38,9 +41,11 @@ func (*App) ProtoMessage()    {}
 func (*App) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f9b42966edc5edad, []int{0}
 }
+
 func (m *App) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *App) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_App.Marshal(b, m, deterministic)
@@ -53,12 +58,15 @@ func (m *App) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *App) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_App.Merge(m, src)
 }
+
 func (m *App) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *App) XXX_DiscardUnknown() {
 	xxx_messageInfo_App.DiscardUnknown(m)
 }
@@ -93,9 +101,11 @@ func (*Consensus) ProtoMessage()    {}
 func (*Consensus) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f9b42966edc5edad, []int{1}
 }
+
 func (m *Consensus) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Consensus) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Consensus.Marshal(b, m, deterministic)
@@ -108,12 +118,15 @@ func (m *Consensus) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Consensus) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Consensus.Merge(m, src)
 }
+
 func (m *Consensus) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Consensus) XXX_DiscardUnknown() {
 	xxx_messageInfo_Consensus.DiscardUnknown(m)
 }
@@ -186,6 +199,7 @@ func (this *Consensus) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (m *App) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -265,6 +279,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *App) Size() (n int) {
 	if m == nil {
 		return 0
@@ -299,9 +314,11 @@ func (m *Consensus) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *App) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -403,6 +420,7 @@ func (m *App) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Consensus) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -491,6 +509,7 @@ func (m *Consensus) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -215,7 +215,6 @@ func GenesisListCodesCmd(defaultNodeHome string, genReader GenesisReader) *cobra
 				return err
 			}
 			return printJSONOutput(cmd, all)
-
 		},
 	}
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
@@ -405,8 +404,10 @@ func (d DefaultGenesisReader) ReadWasmGenesis(cmd *cobra.Command) (*GenesisData,
 	), nil
 }
 
-var _ GenesisReader = DefaultGenesisIO{}
-var _ GenesisMutator = DefaultGenesisIO{}
+var (
+	_ GenesisReader  = DefaultGenesisIO{}
+	_ GenesisMutator = DefaultGenesisIO{}
+)
 
 // DefaultGenesisIO implements both interfaces to read and modify the genesis state for this module.
 // This implementation uses the default data structure that is used by the module.go genesis import/ export.

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -564,6 +564,7 @@ func TestExecuteContractCmd(t *testing.T) {
 		})
 	}
 }
+
 func TestGetAllContracts(t *testing.T) {
 	specs := map[string]struct {
 		src types.GenesisState
@@ -660,14 +661,13 @@ func TestGetAllContracts(t *testing.T) {
 			assert.Equal(t, spec.exp, got)
 		})
 	}
-
 }
 
 func setupGenesis(t *testing.T, wasmGenesis types.GenesisState) string {
 	appCodec := keeper.MakeEncodingConfig(t).Marshaler
 	homeDir := t.TempDir()
 
-	require.NoError(t, os.Mkdir(path.Join(homeDir, "config"), 0700))
+	require.NoError(t, os.Mkdir(path.Join(homeDir, "config"), 0o700))
 	genFilename := path.Join(homeDir, "config", "genesis.json")
 	appState := make(map[string]json.RawMessage)
 	appState[types.ModuleName] = appCodec.MustMarshalJSON(&wasmGenesis)

--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -658,6 +658,7 @@ func parseAccessConfigUpdates(args []string) ([]types.AccessConfigUpdate, error)
 	}
 	return updates, nil
 }
+
 func ProposalUpdateInstantiateConfigCmd() *cobra.Command {
 	bech32Prefix := sdk.GetConfig().GetBech32AccountAddrPrefix()
 	cmd := &cobra.Command{

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -175,7 +175,7 @@ func GetCmdQueryCode() *cobra.Command {
 			}
 
 			fmt.Printf("Downloading wasm code to %s\n", args[1])
-			return ioutil.WriteFile(args[1], res.Data, 0600)
+			return ioutil.WriteFile(args[1], res.Data, 0o600)
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)
@@ -230,7 +230,6 @@ func GetCmdGetContractInfo() *cobra.Command {
 		Aliases: []string{"meta", "c"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
@@ -273,7 +272,6 @@ func GetCmdGetContractState() *cobra.Command {
 		GetCmdGetContractStateSmart(),
 	)
 	return cmd
-
 }
 
 func GetCmdGetContractStateAll() *cobra.Command {

--- a/x/wasm/client/rest/gov.go
+++ b/x/wasm/client/rest/gov.go
@@ -38,12 +38,15 @@ func (s StoreCodeProposalJSONReq) Content() govtypes.Content {
 		InstantiatePermission: s.InstantiatePermission,
 	}
 }
+
 func (s StoreCodeProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s StoreCodeProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s StoreCodeProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
@@ -91,12 +94,15 @@ func (s InstantiateProposalJSONReq) Content() govtypes.Content {
 		Funds:       s.Funds,
 	}
 }
+
 func (s InstantiateProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s InstantiateProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s InstantiateProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
@@ -137,15 +143,19 @@ func (s MigrateProposalJSONReq) Content() govtypes.Content {
 		Msg:         types.RawContractMessage(s.Msg),
 	}
 }
+
 func (s MigrateProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s MigrateProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s MigrateProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
+
 func MigrateProposalHandler(cliCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
 		SubRoute: "wasm_migrate",
@@ -185,15 +195,19 @@ func (s ExecuteProposalJSONReq) Content() govtypes.Content {
 		Funds:       s.Funds,
 	}
 }
+
 func (s ExecuteProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s ExecuteProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s ExecuteProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
+
 func ExecuteProposalHandler(cliCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
 		SubRoute: "wasm_execute",
@@ -228,15 +242,19 @@ func (s SudoProposalJSONReq) Content() govtypes.Content {
 		Msg:         types.RawContractMessage(s.Msg),
 	}
 }
+
 func (s SudoProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s SudoProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s SudoProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
+
 func SudoProposalHandler(cliCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
 		SubRoute: "wasm_sudo",
@@ -271,15 +289,19 @@ func (s UpdateAdminJSONReq) Content() govtypes.Content {
 		NewAdmin:    s.NewAdmin,
 	}
 }
+
 func (s UpdateAdminJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s UpdateAdminJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s UpdateAdminJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
+
 func UpdateContractAdminProposalHandler(cliCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
 		SubRoute: "wasm_update_admin",
@@ -312,15 +334,19 @@ func (s ClearAdminJSONReq) Content() govtypes.Content {
 		Contract:    s.Contract,
 	}
 }
+
 func (s ClearAdminJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s ClearAdminJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s ClearAdminJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
+
 func ClearContractAdminProposalHandler(cliCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
 		SubRoute: "wasm_clear_admin",
@@ -353,12 +379,15 @@ func (s PinCodeJSONReq) Content() govtypes.Content {
 		CodeIDs:     s.CodeIDs,
 	}
 }
+
 func (s PinCodeJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s PinCodeJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s PinCodeJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
@@ -395,12 +424,15 @@ func (s UnpinCodeJSONReq) Content() govtypes.Content {
 		CodeIDs:     s.CodeIDs,
 	}
 }
+
 func (s UnpinCodeJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s UnpinCodeJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s UnpinCodeJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }
@@ -435,12 +467,15 @@ func (s UpdateInstantiateConfigProposalJSONReq) Content() govtypes.Content {
 		AccessConfigUpdates: s.AccessConfigUpdates,
 	}
 }
+
 func (s UpdateInstantiateConfigProposalJSONReq) GetProposer() string {
 	return s.Proposer
 }
+
 func (s UpdateInstantiateConfigProposalJSONReq) GetDeposit() sdk.Coins {
 	return s.Deposit
 }
+
 func (s UpdateInstantiateConfigProposalJSONReq) GetBaseReq() rest.BaseReq {
 	return s.BaseReq
 }

--- a/x/wasm/ibctesting/chain.go
+++ b/x/wasm/ibctesting/chain.go
@@ -241,7 +241,6 @@ func (chain *TestChain) sendMsgs(msgs ...sdk.Msg) error {
 // number and updates the TestChain's headers. It returns the result and error if one
 // occurred.
 func (chain *TestChain) SendMsgs(msgs ...sdk.Msg) (*sdk.Result, error) {
-
 	// ensure the chain has the latest time
 	chain.Coordinator.UpdateTimeForChain(chain)
 
@@ -379,7 +378,6 @@ func (chain *TestChain) ConstructUpdateTMClientHeaderWithTrustedHeight(counterpa
 	header.TrustedValidators = trustedVals
 
 	return header, nil
-
 }
 
 // ExpireClient fast forwards the chain's block time by the provided amount of time which will
@@ -471,8 +469,8 @@ func MakeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) tmtypes.Bl
 // sorting of ValidatorSet.
 // The sorting is first by .VotingPower (descending), with secondary index of .Address (ascending).
 func CreateSortedSignerArray(altPrivVal, suitePrivVal tmtypes.PrivValidator,
-	altVal, suiteVal *tmtypes.Validator) []tmtypes.PrivValidator {
-
+	altVal, suiteVal *tmtypes.Validator,
+) []tmtypes.PrivValidator {
 	switch {
 	case altVal.VotingPower > suiteVal.VotingPower:
 		return []tmtypes.PrivValidator{altPrivVal, suitePrivVal}

--- a/x/wasm/ibctesting/coordinator.go
+++ b/x/wasm/ibctesting/coordinator.go
@@ -65,7 +65,6 @@ func (coord *Coordinator) IncrementTime() {
 func (coord *Coordinator) IncrementTimeBy(increment time.Duration) {
 	coord.CurrentTime = coord.CurrentTime.Add(increment).UTC()
 	coord.UpdateTime()
-
 }
 
 // UpdateTime updates all clocks for the TestChains to the current global time.
@@ -115,7 +114,6 @@ func (coord *Coordinator) SetupConnections(path *Path) {
 // are returned within a TestConnection struct. The function expects the connections to be
 // successfully opened otherwise testing will fail.
 func (coord *Coordinator) CreateConnections(path *Path) {
-
 	err := path.EndpointA.ConnOpenInit()
 	require.NoError(coord.t, err)
 

--- a/x/wasm/ibctesting/endpoint.go
+++ b/x/wasm/ibctesting/endpoint.go
@@ -133,9 +133,7 @@ func (endpoint *Endpoint) UpdateClient() (err error) {
 	// ensure counterparty has committed state
 	endpoint.Chain.Coordinator.CommitBlock(endpoint.Counterparty.Chain)
 
-	var (
-		header exported.Header
-	)
+	var header exported.Header
 
 	switch endpoint.ClientConfig.GetClientType() {
 	case exported.Tendermint:
@@ -156,7 +154,6 @@ func (endpoint *Endpoint) UpdateClient() (err error) {
 	require.NoError(endpoint.Chain.t, err)
 
 	return endpoint.Chain.sendMsgs(msg)
-
 }
 
 // ConnOpenInit will construct and execute a MsgConnectionOpenInit on the associated endpoint.

--- a/x/wasm/ioutils/utils_test.go
+++ b/x/wasm/ioutils/utils_test.go
@@ -9,7 +9,6 @@ import (
 
 func GetTestData() ([]byte, []byte, []byte, error) {
 	wasmCode, err := ioutil.ReadFile("../keeper/testdata/hackatom.wasm")
-
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -47,8 +46,10 @@ func TestIsGzip(t *testing.T) {
 
 func TestGzipIt(t *testing.T) {
 	wasmCode, someRandomStr, _, err := GetTestData()
-	originalGzipData := []byte{31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 72, 205, 201, 201, 87, 40, 207, 47, 202, 73, 1,
-		4, 0, 0, 255, 255, 133, 17, 74, 13, 11, 0, 0, 0}
+	originalGzipData := []byte{
+		31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 72, 205, 201, 201, 87, 40, 207, 47, 202, 73, 1,
+		4, 0, 0, 255, 255, 133, 17, 74, 13, 11, 0, 0, 0,
+	}
 
 	require.NoError(t, err)
 

--- a/x/wasm/keeper/ante_test.go
+++ b/x/wasm/keeper/ante_test.go
@@ -111,6 +111,7 @@ func TestCountTxDecorator(t *testing.T) {
 		})
 	}
 }
+
 func TestLimitSimulationGasDecorator(t *testing.T) {
 	var (
 		hundred sdk.Gas = 100
@@ -164,7 +165,8 @@ func TestLimitSimulationGasDecorator(t *testing.T) {
 			ctx := sdk.Context{}.
 				WithGasMeter(sdk.NewInfiniteGasMeter()).
 				WithConsensusParams(&abci.ConsensusParams{
-					Block: &abci.BlockParams{MaxGas: spec.maxBlockGas}})
+					Block: &abci.BlockParams{MaxGas: spec.maxBlockGas},
+				})
 			// when
 			if spec.expErr != nil {
 				require.PanicsWithValue(t, spec.expErr, func() {

--- a/x/wasm/keeper/authz_policy.go
+++ b/x/wasm/keeper/authz_policy.go
@@ -12,8 +12,7 @@ type AuthorizationPolicy interface {
 	CanModifyContract(admin, actor sdk.AccAddress) bool
 }
 
-type DefaultAuthorizationPolicy struct {
-}
+type DefaultAuthorizationPolicy struct{}
 
 func (p DefaultAuthorizationPolicy) CanCreateCode(config types.AccessConfig, actor sdk.AccAddress) bool {
 	return config.Allowed(actor)
@@ -27,8 +26,7 @@ func (p DefaultAuthorizationPolicy) CanModifyContract(admin, actor sdk.AccAddres
 	return admin != nil && admin.Equals(actor)
 }
 
-type GovAuthorizationPolicy struct {
-}
+type GovAuthorizationPolicy struct{}
 
 func (p GovAuthorizationPolicy) CanCreateCode(types.AccessConfig, sdk.AccAddress) bool {
 	return true

--- a/x/wasm/keeper/events_test.go
+++ b/x/wasm/keeper/events_test.go
@@ -71,8 +71,10 @@ func TestNewCustomEvents(t *testing.T) {
 		"multiple attributes": {
 			src: wasmvmtypes.Events{{
 				Type: "foo",
-				Attributes: []wasmvmtypes.EventAttribute{{Key: "myKey", Value: "myVal"},
-					{Key: "myOtherKey", Value: "myOtherVal"}},
+				Attributes: []wasmvmtypes.EventAttribute{
+					{Key: "myKey", Value: "myVal"},
+					{Key: "myOtherKey", Value: "myOtherVal"},
+				},
 			}},
 			exp: sdk.Events{sdk.NewEvent("wasm-foo",
 				sdk.NewAttribute("_contract_address", myContract.String()),
@@ -121,7 +123,8 @@ func TestNewCustomEvents(t *testing.T) {
 				Type: "wasm",
 				Attributes: []wasmvmtypes.EventAttribute{
 					{Key: "_reserved", Value: "is skipped"},
-					{Key: "normal", Value: "is used"}},
+					{Key: "normal", Value: "is used"},
+				},
 			}},
 			isError: true,
 		},
@@ -218,8 +221,10 @@ func TestNewWasmModuleEvent(t *testing.T) {
 				sdk.NewAttribute("myKey", "myVal"))},
 		},
 		"multiple attributes": {
-			src: []wasmvmtypes.EventAttribute{{Key: "myKey", Value: "myVal"},
-				{Key: "myOtherKey", Value: "myOtherVal"}},
+			src: []wasmvmtypes.EventAttribute{
+				{Key: "myKey", Value: "myVal"},
+				{Key: "myOtherKey", Value: "myOtherVal"},
+			},
 			exp: sdk.Events{sdk.NewEvent("wasm",
 				sdk.NewAttribute("_contract_address", myContract.String()),
 				sdk.NewAttribute("myKey", "myVal"),

--- a/x/wasm/keeper/gas_register_test.go
+++ b/x/wasm/keeper/gas_register_test.go
@@ -387,6 +387,7 @@ func TestToWasmVMGasConversion(t *testing.T) {
 		})
 	}
 }
+
 func TestFromWasmVMGasConversion(t *testing.T) {
 	specs := map[string]struct {
 		src       uint64

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -259,7 +259,8 @@ func TestGenesisInit(t *testing.T) {
 					},
 				},
 				Params: types.DefaultParams(),
-			}},
+			},
+		},
 		"happy path: code id in info and contract do match": {
 			src: types.GenesisState{
 				Codes: []types.Code{{
@@ -413,8 +414,10 @@ func TestGenesisInit(t *testing.T) {
 				Params: types.DefaultParams(),
 			},
 			stakingMock: StakingKeeperMock{expCalls: 1, validatorUpdate: []abci.ValidatorUpdate{
-				{PubKey: crypto.PublicKey{Sum: &crypto.PublicKey_Ed25519{
-					Ed25519: []byte("a valid key")}},
+				{
+					PubKey: crypto.PublicKey{Sum: &crypto.PublicKey_Ed25519{
+						Ed25519: []byte("a valid key"),
+					}},
 					Power: 100,
 				},
 			}},
@@ -551,11 +554,12 @@ func TestImportContractWithCodeHistoryReset(t *testing.T) {
 	}
 	assert.Equal(t, expContractInfo, *gotContractInfo)
 
-	expHistory := []types.ContractCodeHistoryEntry{{
-		Operation: types.ContractCodeHistoryOperationTypeGenesis,
-		CodeID:    firstCodeID,
-		Updated:   types.NewAbsoluteTxPosition(ctx),
-	},
+	expHistory := []types.ContractCodeHistoryEntry{
+		{
+			Operation: types.ContractCodeHistoryOperationTypeGenesis,
+			CodeID:    firstCodeID,
+			Updated:   types.NewAbsoluteTxPosition(ctx),
+		},
 	}
 	assert.Equal(t, expHistory, keeper.GetContractHistory(ctx, contractAddr))
 	assert.Equal(t, uint64(2), keeper.PeekAutoIncrementID(ctx, types.KeyLastCodeID))

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -19,13 +19,15 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
-type BankEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.BankMsg) ([]sdk.Msg, error)
-type CustomEncoder func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error)
-type DistributionEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.DistributionMsg) ([]sdk.Msg, error)
-type StakingEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.StakingMsg) ([]sdk.Msg, error)
-type StargateEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.StargateMsg) ([]sdk.Msg, error)
-type WasmEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.WasmMsg) ([]sdk.Msg, error)
-type IBCEncoder func(ctx sdk.Context, sender sdk.AccAddress, contractIBCPortID string, msg *wasmvmtypes.IBCMsg) ([]sdk.Msg, error)
+type (
+	BankEncoder         func(sender sdk.AccAddress, msg *wasmvmtypes.BankMsg) ([]sdk.Msg, error)
+	CustomEncoder       func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error)
+	DistributionEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.DistributionMsg) ([]sdk.Msg, error)
+	StakingEncoder      func(sender sdk.AccAddress, msg *wasmvmtypes.StakingMsg) ([]sdk.Msg, error)
+	StargateEncoder     func(sender sdk.AccAddress, msg *wasmvmtypes.StargateMsg) ([]sdk.Msg, error)
+	WasmEncoder         func(sender sdk.AccAddress, msg *wasmvmtypes.WasmMsg) ([]sdk.Msg, error)
+	IBCEncoder          func(ctx sdk.Context, sender sdk.AccAddress, contractIBCPortID string, msg *wasmvmtypes.IBCMsg) ([]sdk.Msg, error)
+)
 
 type MessageEncoders struct {
 	Bank         func(sender sdk.AccAddress, msg *wasmvmtypes.BankMsg) ([]sdk.Msg, error)

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -634,5 +634,4 @@ func TestConvertWasmCoinToSdkCoin(t *testing.T) {
 			assert.Equal(t, spec.expVal, gotVal)
 		})
 	}
-
 }

--- a/x/wasm/keeper/handler_plugin_test.go
+++ b/x/wasm/keeper/handler_plugin_test.go
@@ -27,13 +27,15 @@ func TestMessageHandlerChainDispatch(t *testing.T) {
 	alwaysUnknownMsgHandler := &wasmtesting.MockMessageHandler{
 		DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
 			return nil, nil, types.ErrUnknownMsg
-		}}
+		},
+	}
 
 	assertNotCalledHandler := &wasmtesting.MockMessageHandler{
 		DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
 			t.Fatal("not expected to be called")
 			return
-		}}
+		},
+	}
 
 	myMsg := wasmvmtypes.CosmosMsg{Custom: []byte(`{}`)}
 	specs := map[string]struct {
@@ -54,15 +56,18 @@ func TestMessageHandlerChainDispatch(t *testing.T) {
 			handlers: []Messenger{&wasmtesting.MockMessageHandler{
 				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
 					return nil, nil, types.ErrInvalidMsg
-				}}, assertNotCalledHandler},
+				},
+			}, assertNotCalledHandler},
 			expErr: types.ErrInvalidMsg,
 		},
 		"return events when handle": {
-			handlers: []Messenger{&wasmtesting.MockMessageHandler{
-				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
-					_, data, _ = capturingHandler.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
-					return []sdk.Event{sdk.NewEvent("myEvent", sdk.NewAttribute("foo", "bar"))}, data, nil
-				}},
+			handlers: []Messenger{
+				&wasmtesting.MockMessageHandler{
+					DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+						_, data, _ = capturingHandler.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)
+						return []sdk.Event{sdk.NewEvent("myEvent", sdk.NewAttribute("foo", "bar"))}, data, nil
+					},
+				},
 			},
 			expEvents: []sdk.Event{sdk.NewEvent("myEvent", sdk.NewAttribute("foo", "bar"))},
 		},
@@ -231,7 +236,8 @@ func TestIBCRawPacketHandler(t *testing.T) {
 				Counterparty: channeltypes.NewCounterparty(
 					"other-port",
 					"other-channel-1",
-				)}, true
+				),
+			}, true
 		},
 		SendPacketFn: func(ctx sdk.Context, channelCap *capabilitytypes.Capability, packet ibcexported.PacketI) error {
 			capturedPacket = packet
@@ -278,7 +284,8 @@ func TestIBCRawPacketHandler(t *testing.T) {
 			chanKeeper: &wasmtesting.MockChannelKeeper{
 				GetNextSequenceSendFn: func(ctx sdk.Context, portID, channelID string) (uint64, bool) {
 					return 0, false
-				}},
+				},
+			},
 			expErr: channeltypes.ErrSequenceSendNotFound,
 		},
 		"capability not found returns error": {
@@ -291,7 +298,8 @@ func TestIBCRawPacketHandler(t *testing.T) {
 			capKeeper: wasmtesting.MockCapabilityKeeper{
 				GetCapabilityFn: func(ctx sdk.Context, name string) (*capabilitytypes.Capability, bool) {
 					return nil, false
-				}},
+				},
+			},
 			expErr: channeltypes.ErrChannelCapabilityNotFound,
 		},
 	}
@@ -372,9 +380,10 @@ func TestBurnCoinMessageHandlerIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ = parentCtx.CacheContext()
 			k.wasmVM = &wasmtesting.MockWasmer{ExecuteFn: func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, executeMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error) {
-				return &wasmvmtypes.Response{Messages: []wasmvmtypes.SubMsg{
-					{Msg: wasmvmtypes.CosmosMsg{Bank: &wasmvmtypes.BankMsg{Burn: &spec.msg}}, ReplyOn: wasmvmtypes.ReplyNever},
-				},
+				return &wasmvmtypes.Response{
+					Messages: []wasmvmtypes.SubMsg{
+						{Msg: wasmvmtypes.CosmosMsg{Bank: &wasmvmtypes.BankMsg{Burn: &spec.msg}}, ReplyOn: wasmvmtypes.ReplyNever},
+					},
 				}, 0, nil
 			}}
 

--- a/x/wasm/keeper/ibc_test.go
+++ b/x/wasm/keeper/ibc_test.go
@@ -79,5 +79,4 @@ func TestContractFromPortID(t *testing.T) {
 			assert.Equal(t, spec.expAddr, gotAddr)
 		})
 	}
-
 }

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -241,7 +241,6 @@ func (k Keeper) instantiate(ctx sdk.Context, codeID uint64, creator, admin sdk.A
 		if err := k.bank.TransferCoins(ctx, creator, contractAddress, deposit); err != nil {
 			return nil, nil, err
 		}
-
 	} else {
 		// create an empty account (so we don't have issues later)
 		// TODO: can we remove this?

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -258,7 +258,7 @@ func TestIsSimulationMode(t *testing.T) {
 	}
 	for msg := range specs {
 		t.Run(msg, func(t *testing.T) {
-			//assert.Equal(t, spec.exp, isSimulationMode(spec.ctx))
+			// assert.Equal(t, spec.exp, isSimulationMode(spec.ctx))
 		})
 	}
 }
@@ -742,7 +742,6 @@ func TestExecuteWithCpuLoop(t *testing.T) {
 	// this should throw out of gas exception (panic)
 	_, err = keepers.ContractKeeper.Execute(ctx, addr, fred, []byte(`{"cpu_loop":{}}`), nil)
 	require.True(t, false, "We must panic before this line")
-
 }
 
 func TestExecuteWithStorageLoop(t *testing.T) {
@@ -1230,7 +1229,6 @@ func TestSudo(t *testing.T) {
 	expEvt := sdk.NewEvent("sudo",
 		sdk.NewAttribute("_contract_address", addr.String()))
 	assert.Equal(t, expEvt, em.Events()[0])
-
 }
 
 func prettyEvents(t *testing.T, events sdk.Events) string {
@@ -1428,7 +1426,8 @@ func TestUnpinCode(t *testing.T) {
 		UnpinFn: func(checksum wasmvm.Checksum) error {
 			capturedChecksums = append(capturedChecksums, checksum)
 			return nil
-		}}
+		},
+	}
 	wasmtesting.MakeInstantiable(&mock)
 	myCodeID := StoreRandomContract(t, ctx, keepers, &mock).CodeID
 	require.Equal(t, uint64(1), myCodeID)
@@ -1523,7 +1522,6 @@ func TestPinnedContractLoops(t *testing.T) {
 	})
 	assert.True(t, ctx.GasMeter().IsOutOfGas())
 	assert.Greater(t, loops, 2)
-
 }
 
 func TestNewDefaultWasmVMContractResponseHandler(t *testing.T) {
@@ -1587,9 +1585,7 @@ func TestNewDefaultWasmVMContractResponseHandler(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			var (
-				msgs []wasmvmtypes.SubMsg
-			)
+			var msgs []wasmvmtypes.SubMsg
 			var mock wasmtesting.MockMsgDispatcher
 			spec.setup(&mock)
 			d := NewDefaultWasmVMContractResponseHandler(&mock)

--- a/x/wasm/keeper/legacy_querier_test.go
+++ b/x/wasm/keeper/legacy_querier_test.go
@@ -221,9 +221,7 @@ func TestLegacyQueryContractHistory(t *testing.T) {
 	ctx, keepers := CreateTestInput(t, false, SupportedFeatures)
 	keeper := keepers.WasmKeeper
 
-	var (
-		otherAddr sdk.AccAddress = bytes.Repeat([]byte{0x2}, types.ContractAddrLen)
-	)
+	var otherAddr sdk.AccAddress = bytes.Repeat([]byte{0x2}, types.ContractAddrLen)
 
 	specs := map[string]struct {
 		srcQueryAddr sdk.AccAddress

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -101,10 +101,11 @@ func TestDispatchSubmessages(t *testing.T) {
 			},
 			expData:    []byte("myReplyData"),
 			expCommits: []bool{true},
-			expEvents: []sdk.Event{{
-				Type:       "myEvent",
-				Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}},
-			},
+			expEvents: []sdk.Event{
+				{
+					Type:       "myEvent",
+					Attributes: []abci.EventAttribute{{Key: []byte("foo"), Value: []byte("bar")}},
+				},
 				sdk.NewEvent("wasm-reply"),
 			},
 		},

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -82,7 +82,6 @@ func TestConstructorOptions(t *testing.T) {
 			spec.verify(t, k)
 		})
 	}
-
 }
 
 func setApiDefaults() {

--- a/x/wasm/keeper/proposal_integration_test.go
+++ b/x/wasm/keeper/proposal_integration_test.go
@@ -139,9 +139,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 		wasmCode),
 	)
 
-	var (
-		oneAddress sdk.AccAddress = bytes.Repeat([]byte{0x1}, types.ContractAddrLen)
-	)
+	var oneAddress sdk.AccAddress = bytes.Repeat([]byte{0x1}, types.ContractAddrLen)
 
 	// test invalid admin address
 	src := types.InstantiateContractProposalFixture(func(p *types.InstantiateContractProposal) {
@@ -806,7 +804,6 @@ func TestUpdateInstantiateConfigProposal(t *testing.T) {
 	parentCtx := ctx
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {
-
 			ctx, _ := parentCtx.CacheContext()
 
 			updates := make([]types.AccessConfigUpdate, 0)

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -202,7 +202,6 @@ func (q grpcQuerier) SmartContractState(c context.Context, req *types.QuerySmart
 		return nil, types.ErrNotFound
 	}
 	return &types.QuerySmartContractStateResponse{Data: bz}, nil
-
 }
 
 func (q grpcQuerier) Code(c context.Context, req *types.QueryCodeRequest) (*types.QueryCodeResponse, error) {
@@ -300,7 +299,6 @@ func (q grpcQuerier) PinnedCodes(c context.Context, req *types.QueryPinnedCodesR
 	prefixStore := prefix.NewStore(ctx.KVStore(q.storeKey), types.PinnedCodeIndexPrefix)
 	pageRes, err := query.FilteredPaginate(prefixStore, req.Pagination, func(key []byte, _ []byte, accumulate bool) (bool, error) {
 		if accumulate {
-
 			r = append(r, sdk.BigEndianToUint64(key))
 		}
 		return true, nil
@@ -312,5 +310,4 @@ func (q grpcQuerier) PinnedCodes(c context.Context, req *types.QueryPinnedCodesR
 		CodeIDs:    r,
 		Pagination: pageRes,
 	}, nil
-
 }

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -656,7 +656,6 @@ func TestQueryPinnedCodes(t *testing.T) {
 }
 
 func TestQueryCodeInfo(t *testing.T) {
-
 	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
@@ -712,7 +711,6 @@ func TestQueryCodeInfo(t *testing.T) {
 }
 
 func TestQueryCodeInfoList(t *testing.T) {
-
 	wasmCode, err := ioutil.ReadFile("./testdata/hackatom.wasm")
 	require.NoError(t, err)
 
@@ -774,7 +772,6 @@ func TestQueryCodeInfoList(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got.CodeInfos, 3)
 	require.EqualValues(t, allCodesResponse, got.CodeInfos)
-
 }
 
 func fromBase64(s string) []byte {

--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -316,7 +316,6 @@ func TestIBCQuerier(t *testing.T) {
 			assert.JSONEq(t, spec.expJsonResult, string(gotResult), string(gotResult))
 		})
 	}
-
 }
 
 func TestBankQuerierBalance(t *testing.T) {
@@ -345,9 +344,9 @@ func TestBankQuerierBalance(t *testing.T) {
 }
 
 func TestContractInfoWasmQuerier(t *testing.T) {
-	var myValidContractAddr = RandomBech32AccountAddress(t)
-	var myCreatorAddr = RandomBech32AccountAddress(t)
-	var myAdminAddr = RandomBech32AccountAddress(t)
+	myValidContractAddr := RandomBech32AccountAddress(t)
+	myCreatorAddr := RandomBech32AccountAddress(t)
+	myAdminAddr := RandomBech32AccountAddress(t)
 	var ctx sdk.Context
 
 	specs := map[string]struct {
@@ -360,12 +359,13 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 			req: &wasmvmtypes.WasmQuery{
 				ContractInfo: &wasmvmtypes.ContractInfoQuery{ContractAddr: myValidContractAddr},
 			},
-			mock: mockWasmQueryKeeper{GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
-				val := types.ContractInfoFixture(func(i *types.ContractInfo) {
-					i.Admin, i.Creator, i.IBCPortID = myAdminAddr, myCreatorAddr, "myIBCPort"
-				})
-				return &val
-			},
+			mock: mockWasmQueryKeeper{
+				GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
+					val := types.ContractInfoFixture(func(i *types.ContractInfo) {
+						i.Admin, i.Creator, i.IBCPortID = myAdminAddr, myCreatorAddr, "myIBCPort"
+					})
+					return &val
+				},
 				IsPinnedCodeFn: func(ctx sdk.Context, codeID uint64) bool { return true },
 			},
 			expRes: wasmvmtypes.ContractInfoResponse{
@@ -395,12 +395,13 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 			req: &wasmvmtypes.WasmQuery{
 				ContractInfo: &wasmvmtypes.ContractInfoQuery{ContractAddr: myValidContractAddr},
 			},
-			mock: mockWasmQueryKeeper{GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
-				val := types.ContractInfoFixture(func(i *types.ContractInfo) {
-					i.Admin, i.Creator = myAdminAddr, myCreatorAddr
-				})
-				return &val
-			},
+			mock: mockWasmQueryKeeper{
+				GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
+					val := types.ContractInfoFixture(func(i *types.ContractInfo) {
+						i.Admin, i.Creator = myAdminAddr, myCreatorAddr
+					})
+					return &val
+				},
 				IsPinnedCodeFn: func(ctx sdk.Context, codeID uint64) bool { return false },
 			},
 			expRes: wasmvmtypes.ContractInfoResponse{
@@ -414,12 +415,13 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 			req: &wasmvmtypes.WasmQuery{
 				ContractInfo: &wasmvmtypes.ContractInfoQuery{ContractAddr: myValidContractAddr},
 			},
-			mock: mockWasmQueryKeeper{GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
-				val := types.ContractInfoFixture(func(i *types.ContractInfo) {
-					i.Creator = myCreatorAddr
-				})
-				return &val
-			},
+			mock: mockWasmQueryKeeper{
+				GetContractInfoFn: func(ctx sdk.Context, contractAddress sdk.AccAddress) *types.ContractInfo {
+					val := types.ContractInfoFixture(func(i *types.ContractInfo) {
+						i.Creator = myCreatorAddr
+					})
+					return &val
+				},
 				IsPinnedCodeFn: func(ctx sdk.Context, codeID uint64) bool { return true },
 			},
 			expRes: wasmvmtypes.ContractInfoResponse{

--- a/x/wasm/keeper/reflect_test.go
+++ b/x/wasm/keeper/reflect_test.go
@@ -164,7 +164,6 @@ func TestReflectContractSend(t *testing.T) {
 	checkAccount(t, ctx, accKeeper, bankKeeper, reflectAddr, sdk.NewCoins(sdk.NewInt64Coin("denom", 26000))) // 40k - 14k (from send)
 	checkAccount(t, ctx, accKeeper, bankKeeper, escrowAddr, sdk.Coins{})                                     // emptied reserved
 	checkAccount(t, ctx, accKeeper, bankKeeper, bob, sdk.NewCoins(sdk.NewInt64Coin("denom", 39000)))         // all escrow of 25k + 14k
-
 }
 
 func TestReflectCustomMsg(t *testing.T) {

--- a/x/wasm/keeper/relay_test.go
+++ b/x/wasm/keeper/relay_test.go
@@ -20,7 +20,7 @@ func TestOnOpenChannel(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40
@@ -91,7 +91,7 @@ func TestOnConnectChannel(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40
@@ -203,7 +203,7 @@ func TestOnCloseChannel(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40
@@ -314,7 +314,7 @@ func TestOnRecvPacket(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40
@@ -477,7 +477,7 @@ func TestOnAckPacket(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40
@@ -539,7 +539,6 @@ func TestOnAckPacket(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-
 			myAck := wasmvmtypes.IBCPacketAckMsg{Acknowledgement: wasmvmtypes.IBCAcknowledgement{Data: []byte("myAck")}}
 			m.IBCPacketAckFn = func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketAckMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
 				assert.Equal(t, myAck, msg)
@@ -584,7 +583,7 @@ func TestOnTimeoutPacket(t *testing.T) {
 	SkipIfM1(t)
 	var m wasmtesting.MockWasmer
 	wasmtesting.MakeIBCInstantiable(&m)
-	var messenger = &wasmtesting.MockMessageHandler{}
+	messenger := &wasmtesting.MockMessageHandler{}
 	parentCtx, keepers := CreateTestInput(t, false, SupportedFeatures, WithMessageHandler(messenger))
 	example := SeedNewContractInstance(t, parentCtx, keepers, &m)
 	const myContractGas = 40

--- a/x/wasm/keeper/snapshotter_integration_test.go
+++ b/x/wasm/keeper/snapshotter_integration_test.go
@@ -104,7 +104,7 @@ func TestSnapshotter(t *testing.T) {
 }
 
 func newWasmExampleApp(t *testing.T) (*app.WasmApp, sdk.AccAddress) {
-	var senderPrivKey = ed25519.GenPrivKey()
+	senderPrivKey := ed25519.GenPrivKey()
 	pubKey, err := cryptocodec.ToTmPubKeyInterface(senderPrivKey.PubKey())
 	require.NoError(t, err)
 

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -242,7 +242,8 @@ func createTestInput(
 		keys[paramstypes.StoreKey],
 		tkeys[paramstypes.TStoreKey],
 	)
-	for _, m := range []string{authtypes.ModuleName,
+	for _, m := range []string{
+		authtypes.ModuleName,
 		banktypes.ModuleName,
 		stakingtypes.ModuleName,
 		minttypes.ModuleName,
@@ -253,7 +254,8 @@ func createTestInput(
 		capabilitytypes.ModuleName,
 		ibchost.ModuleName,
 		govtypes.ModuleName,
-		types.ModuleName} {
+		types.ModuleName,
+	} {
 		paramsKeeper.Subspace(m)
 	}
 	subspace := func(m string) paramstypes.Subspace {
@@ -593,7 +595,8 @@ func StoreRandomContractWithAccessConfig(
 	t testing.TB, ctx sdk.Context,
 	keepers TestKeepers,
 	mock types.WasmerEngine,
-	cfg *types.AccessConfig) ExampleContract {
+	cfg *types.AccessConfig,
+) ExampleContract {
 	t.Helper()
 	anyAmount := sdk.NewCoins(sdk.NewInt64Coin("denom", 1000))
 	creator, _, creatorAddr := keyPubAddr()
@@ -604,7 +607,6 @@ func StoreRandomContractWithAccessConfig(
 	require.NoError(t, err)
 	exampleContract := ExampleContract{InitialAmount: anyAmount, Creator: creator, CreatorAddr: creatorAddr, CodeID: codeID}
 	return exampleContract
-
 }
 
 type HackatomExampleInstance struct {

--- a/x/wasm/keeper/test_fuzz.go
+++ b/x/wasm/keeper/test_fuzz.go
@@ -16,6 +16,7 @@ func FuzzAddr(m *sdk.AccAddress, c fuzz.Continue) {
 	*m = make([]byte, 20)
 	c.Read(*m)
 }
+
 func FuzzAddrString(m *string, c fuzz.Continue) {
 	var x sdk.AccAddress
 	FuzzAddr(&x, c)
@@ -66,6 +67,7 @@ func FuzzAccessType(m *types.AccessType, c fuzz.Continue) {
 		pos--
 	}
 }
+
 func FuzzAccessConfig(m *types.AccessConfig, c fuzz.Continue) {
 	FuzzAccessType(&m.Permission, c)
 	var add sdk.AccAddress

--- a/x/wasm/keeper/wasmtesting/mock_engine.go
+++ b/x/wasm/keeper/wasmtesting/mock_engine.go
@@ -127,7 +127,6 @@ func (m *MockWasmer) Sudo(codeID wasmvm.Checksum, env wasmvmtypes.Env, sudoMsg [
 		panic("not supposed to be called!")
 	}
 	return m.SudoFn(codeID, env, sudoMsg, store, goapi, querier, gasMeter, gasLimit, deserCost)
-
 }
 
 func (m *MockWasmer) Reply(codeID wasmvm.Checksum, env wasmvmtypes.Env, reply wasmvmtypes.Reply, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error) {
@@ -177,7 +176,6 @@ var AlwaysPanicMockWasmer = &MockWasmer{}
 // SelfCallingInstMockWasmer prepares a Wasmer mock that calls itself on instantiation.
 func SelfCallingInstMockWasmer(executeCalled *bool) *MockWasmer {
 	return &MockWasmer{
-
 		CreateFn: func(code wasmvm.WasmCode) (wasmvm.Checksum, error) {
 			anyCodeID := bytes.Repeat([]byte{0x1}, 32)
 			return anyCodeID, nil

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -540,7 +540,7 @@ func assertContractList(t *testing.T, q sdk.Querier, ctx sdk.Context, codeID uin
 	err := json.Unmarshal(bz, &res)
 	require.NoError(t, err)
 
-	var hasAddrs = make([]string, len(res))
+	hasAddrs := make([]string, len(res))
 	for i, r := range res {
 		hasAddrs[i] = r
 	}

--- a/x/wasm/relay_pingpong_test.go
+++ b/x/wasm/relay_pingpong_test.go
@@ -41,8 +41,9 @@ func TestPinPong(t *testing.T) {
 	pongContract := &player{t: t, actor: pong}
 
 	var (
-		chainAOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(pingContract)),
+		chainAOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(pingContract)),
 		}
 		chainBOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
 			wasmtesting.NewIBCContractMockWasmer(pongContract),
@@ -159,18 +160,19 @@ func (p *player) Execute(code wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmt
 	store.Set(lastBallSentKey, sdk.Uint64ToBigEndian(start.Value))
 	return &wasmvmtypes.Response{
 		Messages: []wasmvmtypes.SubMsg{
-			{Msg: wasmvmtypes.CosmosMsg{
-				IBC: &wasmvmtypes.IBCMsg{
-					SendPacket: &wasmvmtypes.SendPacketMsg{
-						ChannelID: start.ChannelID,
-						Data:      service.GetBytes(),
-						Timeout: wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{
-							Revision: doNotTimeout.RevisionNumber,
-							Height:   doNotTimeout.RevisionHeight,
-						}},
+			{
+				Msg: wasmvmtypes.CosmosMsg{
+					IBC: &wasmvmtypes.IBCMsg{
+						SendPacket: &wasmvmtypes.SendPacketMsg{
+							ChannelID: start.ChannelID,
+							Data:      service.GetBytes(),
+							Timeout: wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{
+								Revision: doNotTimeout.RevisionNumber,
+								Height:   doNotTimeout.RevisionHeight,
+							}},
+						},
 					},
 				},
-			},
 				ReplyOn: wasmvmtypes.ReplyNever,
 			},
 		},
@@ -245,10 +247,11 @@ func (p player) IBCPacketReceive(codeID wasmvm.Checksum, env wasmvmtypes.Env, ms
 	packet := msg.Packet
 	var receivedBall hit
 	if err := json.Unmarshal(packet.Data, &receivedBall); err != nil {
-		return &wasmvmtypes.IBCReceiveResult{Ok: &wasmvmtypes.IBCReceiveResponse{
-			Acknowledgement: hitAcknowledgement{Error: err.Error()}.GetBytes(),
-		},
-		// no hit msg, we stop the game
+		return &wasmvmtypes.IBCReceiveResult{
+			Ok: &wasmvmtypes.IBCReceiveResponse{
+				Acknowledgement: hitAcknowledgement{Error: err.Error()}.GetBytes(),
+			},
+			// no hit msg, we stop the game
 		}, 0, nil
 	}
 	p.incrementCounter(receivedBallsCountKey, store)
@@ -276,9 +279,11 @@ func (p player) IBCPacketReceive(codeID wasmvm.Checksum, env wasmvmtypes.Env, ms
 	p.incrementCounter(sentBallsCountKey, store)
 	p.t.Logf("[%s] received %d, returning %d: %v\n", p.actor, otherCount, nextValue, newHit)
 
-	return &wasmvmtypes.IBCReceiveResult{Ok: &wasmvmtypes.IBCReceiveResponse{
-		Acknowledgement: receivedBall.BuildAck().GetBytes(),
-		Messages:        []wasmvmtypes.SubMsg{{Msg: wasmvmtypes.CosmosMsg{IBC: respHit}, ReplyOn: wasmvmtypes.ReplyNever}}},
+	return &wasmvmtypes.IBCReceiveResult{
+		Ok: &wasmvmtypes.IBCReceiveResponse{
+			Acknowledgement: receivedBall.BuildAck().GetBytes(),
+			Messages:        []wasmvmtypes.SubMsg{{Msg: wasmvmtypes.CosmosMsg{IBC: respHit}, ReplyOn: wasmvmtypes.ReplyNever}},
+		},
 	}, 0, nil
 }
 
@@ -299,7 +304,6 @@ func (p player) IBCPacketAck(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wa
 		p.t.Logf("[%s] acknowledged %d: %v\n", p.actor, confirmedCount, sentBall)
 	} else {
 		p.t.Logf("[%s] received app layer error: %s\n", p.actor, ack.Error)
-
 	}
 
 	p.incrementCounter(confirmedBallsCountKey, store)
@@ -345,6 +349,7 @@ func NewHit(player string, count uint64) hit {
 		player: count,
 	}
 }
+
 func (h hit) GetBytes() []byte {
 	b, err := json.Marshal(h)
 	if err != nil {
@@ -352,6 +357,7 @@ func (h hit) GetBytes() []byte {
 	}
 	return b
 }
+
 func (h hit) String() string {
 	return fmt.Sprintf("Ball %s", string(h.GetBytes()))
 }

--- a/x/wasm/relay_test.go
+++ b/x/wasm/relay_test.go
@@ -138,8 +138,9 @@ func TestContractCanInitiateIBCTransferMsg(t *testing.T) {
 
 	myContract := &sendViaIBCTransferContract{t: t}
 	var (
-		chainAOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(myContract)),
+		chainAOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(myContract)),
 		}
 		coordinator = wasmibctesting.NewCoordinator(t, 2, chainAOpts)
 		chainA      = coordinator.GetChain(wasmibctesting.GetChainID(0))
@@ -207,8 +208,9 @@ func TestContractCanEmulateIBCTransferMessage(t *testing.T) {
 	myContract := &sendEmulatedIBCTransferContract{t: t}
 
 	var (
-		chainAOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(myContract)),
+		chainAOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(myContract)),
 		}
 		coordinator = wasmibctesting.NewCoordinator(t, 2, chainAOpts)
 
@@ -281,8 +283,9 @@ func TestContractCanEmulateIBCTransferMessageWithTimeout(t *testing.T) {
 	myContract := &sendEmulatedIBCTransferContract{t: t}
 
 	var (
-		chainAOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(myContract)),
+		chainAOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(myContract)),
 		}
 		coordinator = wasmibctesting.NewCoordinator(t, 2, chainAOpts)
 
@@ -360,11 +363,13 @@ func TestContractHandlesChannelClose(t *testing.T) {
 	myContractB := &captureCloseContract{}
 
 	var (
-		chainAOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(myContractA)),
+		chainAOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(myContractA)),
 		}
-		chainBOpts = []wasmkeeper.Option{wasmkeeper.WithWasmEngine(
-			wasmtesting.NewIBCContractMockWasmer(myContractB)),
+		chainBOpts = []wasmkeeper.Option{
+			wasmkeeper.WithWasmEngine(
+				wasmtesting.NewIBCContractMockWasmer(myContractB)),
 		}
 		coordinator = wasmibctesting.NewCoordinator(t, 2, chainAOpts, chainBOpts)
 
@@ -479,7 +484,6 @@ func (c *sendEmulatedIBCTransferContract) IBCPacketTimeout(codeID wasmvm.Checksu
 	}
 	if err := data.ValidateBasic(); err != nil {
 		return nil, 0, err
-
 	}
 	amount, _ := sdk.NewIntFromString(data.Amount)
 
@@ -487,7 +491,8 @@ func (c *sendEmulatedIBCTransferContract) IBCPacketTimeout(codeID wasmvm.Checksu
 		Send: &wasmvmtypes.SendMsg{
 			ToAddress: data.Sender,
 			Amount:    wasmvmtypes.Coins{wasmvmtypes.NewCoin(amount.Uint64(), data.Denom)},
-		}}
+		},
+	}
 
 	return &wasmvmtypes.IBCBasicResponse{Messages: []wasmvmtypes.SubMsg{{ReplyOn: wasmvmtypes.ReplyNever, Msg: wasmvmtypes.CosmosMsg{Bank: returnTokens}}}}, 0, nil
 }

--- a/x/wasm/types/genesis.pb.go
+++ b/x/wasm/types/genesis.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -39,9 +42,11 @@ func (*GenesisState) ProtoMessage()    {}
 func (*GenesisState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{0}
 }
+
 func (m *GenesisState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_GenesisState.Marshal(b, m, deterministic)
@@ -54,12 +59,15 @@ func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *GenesisState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_GenesisState.Merge(m, src)
 }
+
 func (m *GenesisState) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *GenesisState) XXX_DiscardUnknown() {
 	xxx_messageInfo_GenesisState.DiscardUnknown(m)
 }
@@ -119,9 +127,11 @@ func (*GenesisState_GenMsgs) ProtoMessage()    {}
 func (*GenesisState_GenMsgs) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{0, 0}
 }
+
 func (m *GenesisState_GenMsgs) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *GenesisState_GenMsgs) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_GenesisState_GenMsgs.Marshal(b, m, deterministic)
@@ -134,12 +144,15 @@ func (m *GenesisState_GenMsgs) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *GenesisState_GenMsgs) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_GenesisState_GenMsgs.Merge(m, src)
 }
+
 func (m *GenesisState_GenMsgs) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *GenesisState_GenMsgs) XXX_DiscardUnknown() {
 	xxx_messageInfo_GenesisState_GenMsgs.DiscardUnknown(m)
 }
@@ -218,9 +231,11 @@ func (*Code) ProtoMessage()    {}
 func (*Code) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{1}
 }
+
 func (m *Code) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Code) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Code.Marshal(b, m, deterministic)
@@ -233,12 +248,15 @@ func (m *Code) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Code) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Code.Merge(m, src)
 }
+
 func (m *Code) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Code) XXX_DiscardUnknown() {
 	xxx_messageInfo_Code.DiscardUnknown(m)
 }
@@ -286,9 +304,11 @@ func (*Contract) ProtoMessage()    {}
 func (*Contract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{2}
 }
+
 func (m *Contract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Contract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Contract.Marshal(b, m, deterministic)
@@ -301,12 +321,15 @@ func (m *Contract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Contract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Contract.Merge(m, src)
 }
+
 func (m *Contract) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Contract) XXX_DiscardUnknown() {
 	xxx_messageInfo_Contract.DiscardUnknown(m)
 }
@@ -346,9 +369,11 @@ func (*Sequence) ProtoMessage()    {}
 func (*Sequence) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{3}
 }
+
 func (m *Sequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Sequence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Sequence.Marshal(b, m, deterministic)
@@ -361,12 +386,15 @@ func (m *Sequence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Sequence) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Sequence.Merge(m, src)
 }
+
 func (m *Sequence) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Sequence) XXX_DiscardUnknown() {
 	xxx_messageInfo_Sequence.DiscardUnknown(m)
 }
@@ -584,6 +612,7 @@ func (m *GenesisState_GenMsgs_StoreCode) MarshalToSizedBuffer(dAtA []byte) (int,
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *GenesisState_GenMsgs_InstantiateContract) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -605,6 +634,7 @@ func (m *GenesisState_GenMsgs_InstantiateContract) MarshalToSizedBuffer(dAtA []b
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *GenesisState_GenMsgs_ExecuteContract) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
@@ -626,6 +656,7 @@ func (m *GenesisState_GenMsgs_ExecuteContract) MarshalToSizedBuffer(dAtA []byte)
 	}
 	return len(dAtA) - i, nil
 }
+
 func (m *Code) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -781,6 +812,7 @@ func encodeVarintGenesis(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *GenesisState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -840,6 +872,7 @@ func (m *GenesisState_GenMsgs_StoreCode) Size() (n int) {
 	}
 	return n
 }
+
 func (m *GenesisState_GenMsgs_InstantiateContract) Size() (n int) {
 	if m == nil {
 		return 0
@@ -852,6 +885,7 @@ func (m *GenesisState_GenMsgs_InstantiateContract) Size() (n int) {
 	}
 	return n
 }
+
 func (m *GenesisState_GenMsgs_ExecuteContract) Size() (n int) {
 	if m == nil {
 		return 0
@@ -864,6 +898,7 @@ func (m *GenesisState_GenMsgs_ExecuteContract) Size() (n int) {
 	}
 	return n
 }
+
 func (m *Code) Size() (n int) {
 	if m == nil {
 		return 0
@@ -925,9 +960,11 @@ func (m *Sequence) Size() (n int) {
 func sovGenesis(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozGenesis(x uint64) (n int) {
 	return sovGenesis(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1147,6 +1184,7 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *GenesisState_GenMsgs) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1302,6 +1340,7 @@ func (m *GenesisState_GenMsgs) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Code) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1458,6 +1497,7 @@ func (m *Code) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Contract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1607,6 +1647,7 @@ func (m *Contract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Sequence) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1710,6 +1751,7 @@ func (m *Sequence) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipGenesis(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/genesis_test.go
+++ b/x/wasm/types/genesis_test.go
@@ -182,7 +182,7 @@ func TestContractValidateBasic(t *testing.T) {
 func TestGenesisContractInfoMarshalUnmarshal(t *testing.T) {
 	var myAddr sdk.AccAddress = rand.Bytes(ContractAddrLen)
 	var myOtherAddr sdk.AccAddress = rand.Bytes(ContractAddrLen)
-	var anyPos = AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2}
+	anyPos := AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2}
 
 	anyTime := time.Now().UTC()
 	// using gov proposal here as a random protobuf types as it contains an Any type inside for nested unpacking

--- a/x/wasm/types/ibc.pb.go
+++ b/x/wasm/types/ibc.pb.go
@@ -15,8 +15,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -45,9 +48,11 @@ func (*MsgIBCSend) ProtoMessage()    {}
 func (*MsgIBCSend) Descriptor() ([]byte, []int) {
 	return fileDescriptor_af0d1c43ea53c4b9, []int{0}
 }
+
 func (m *MsgIBCSend) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgIBCSend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgIBCSend.Marshal(b, m, deterministic)
@@ -60,12 +65,15 @@ func (m *MsgIBCSend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *MsgIBCSend) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgIBCSend.Merge(m, src)
 }
+
 func (m *MsgIBCSend) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgIBCSend) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgIBCSend.DiscardUnknown(m)
 }
@@ -83,9 +91,11 @@ func (*MsgIBCCloseChannel) ProtoMessage()    {}
 func (*MsgIBCCloseChannel) Descriptor() ([]byte, []int) {
 	return fileDescriptor_af0d1c43ea53c4b9, []int{1}
 }
+
 func (m *MsgIBCCloseChannel) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgIBCCloseChannel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgIBCCloseChannel.Marshal(b, m, deterministic)
@@ -98,12 +108,15 @@ func (m *MsgIBCCloseChannel) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *MsgIBCCloseChannel) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgIBCCloseChannel.Merge(m, src)
 }
+
 func (m *MsgIBCCloseChannel) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgIBCCloseChannel) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgIBCCloseChannel.DiscardUnknown(m)
 }
@@ -228,6 +241,7 @@ func encodeVarintIbc(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *MsgIBCSend) Size() (n int) {
 	if m == nil {
 		return 0
@@ -267,9 +281,11 @@ func (m *MsgIBCCloseChannel) Size() (n int) {
 func sovIbc(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozIbc(x uint64) (n int) {
 	return sovIbc(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *MsgIBCSend) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -424,6 +440,7 @@ func (m *MsgIBCSend) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgIBCCloseChannel) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -506,6 +523,7 @@ func (m *MsgIBCCloseChannel) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipIbc(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/keys_test.go
+++ b/x/wasm/types/keys_test.go
@@ -12,10 +12,12 @@ func TestGetContractByCodeIDSecondaryIndexPrefix(t *testing.T) {
 		src uint64
 		exp []byte
 	}{
-		"small number": {src: 1,
+		"small number": {
+			src: 1,
 			exp: []byte{6, 0, 0, 0, 0, 0, 0, 0, 1},
 		},
-		"big number": {src: 1 << (8 * 7),
+		"big number": {
+			src: 1 << (8 * 7),
 			exp: []byte{6, 1, 0, 0, 0, 0, 0, 0, 0},
 		},
 	}
@@ -28,11 +30,11 @@ func TestGetContractByCodeIDSecondaryIndexPrefix(t *testing.T) {
 }
 
 func TestGetContractCodeHistoryElementPrefix(t *testing.T) {
-
 	// test that contract addresses of 20 length are still supported
 	addr := bytes.Repeat([]byte{4}, 20)
 	got := GetContractCodeHistoryElementPrefix(addr)
-	exp := []byte{5, // prefix
+	exp := []byte{
+		5,                            // prefix
 		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // address 20 bytes
 		4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
 	}
@@ -40,7 +42,8 @@ func TestGetContractCodeHistoryElementPrefix(t *testing.T) {
 
 	addr = bytes.Repeat([]byte{4}, ContractAddrLen)
 	got = GetContractCodeHistoryElementPrefix(addr)
-	exp = []byte{5, // prefix
+	exp = []byte{
+		5,                            // prefix
 		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // address 32 bytes
 		4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
 		4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
@@ -58,7 +61,8 @@ func TestGetContractByCreatedSecondaryIndexKey(t *testing.T) {
 	// test that contract addresses of 20 length are still supported
 	addr := bytes.Repeat([]byte{4}, 20)
 	got := GetContractByCreatedSecondaryIndexKey(addr, e)
-	exp := []byte{6, // prefix
+	exp := []byte{
+		6,                      // prefix
 		0, 0, 0, 0, 0, 0, 0, 1, // codeID
 		1, 0, 0, 0, 0, 0, 0, 2, // height
 		1, 0, 0, 0, 0, 0, 0, 3, // index
@@ -69,7 +73,8 @@ func TestGetContractByCreatedSecondaryIndexKey(t *testing.T) {
 
 	addr = bytes.Repeat([]byte{4}, ContractAddrLen)
 	got = GetContractByCreatedSecondaryIndexKey(addr, e)
-	exp = []byte{6, // prefix
+	exp = []byte{
+		6,                      // prefix
 		0, 0, 0, 0, 0, 0, 0, 1, // codeID
 		1, 0, 0, 0, 0, 0, 0, 2, // height
 		1, 0, 0, 0, 0, 0, 0, 3, // index

--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -12,8 +12,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var ParamStoreKeyUploadAccess = []byte("uploadAccess")
-var ParamStoreKeyInstantiateAccess = []byte("instantiateAccess")
+var (
+	ParamStoreKeyUploadAccess      = []byte("uploadAccess")
+	ParamStoreKeyInstantiateAccess = []byte("instantiateAccess")
+)
 
 var AllAccessTypes = []AccessType{
 	AccessTypeNobody,
@@ -58,6 +60,7 @@ func (a *AccessType) UnmarshalText(text []byte) error {
 	*a = AccessTypeUnspecified
 	return nil
 }
+
 func (a AccessType) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }

--- a/x/wasm/types/params_test.go
+++ b/x/wasm/types/params_test.go
@@ -142,12 +142,12 @@ func TestAccessTypeUnmarshalJson(t *testing.T) {
 		})
 	}
 }
+
 func TestParamsUnmarshalJson(t *testing.T) {
 	specs := map[string]struct {
 		src string
 		exp Params
 	}{
-
 		"defaults": {
 			src: `{"code_upload_access": {"permission": "Everybody"},
 				"instantiate_default_permission": "Everybody"}`,

--- a/x/wasm/types/proposal.pb.go
+++ b/x/wasm/types/proposal.pb.go
@@ -18,8 +18,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -46,9 +49,11 @@ func (*StoreCodeProposal) ProtoMessage() {}
 func (*StoreCodeProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{0}
 }
+
 func (m *StoreCodeProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *StoreCodeProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StoreCodeProposal.Marshal(b, m, deterministic)
@@ -61,12 +66,15 @@ func (m *StoreCodeProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *StoreCodeProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StoreCodeProposal.Merge(m, src)
 }
+
 func (m *StoreCodeProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *StoreCodeProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_StoreCodeProposal.DiscardUnknown(m)
 }
@@ -99,9 +107,11 @@ func (*InstantiateContractProposal) ProtoMessage() {}
 func (*InstantiateContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{1}
 }
+
 func (m *InstantiateContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *InstantiateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_InstantiateContractProposal.Marshal(b, m, deterministic)
@@ -114,12 +124,15 @@ func (m *InstantiateContractProposal) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
+
 func (m *InstantiateContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_InstantiateContractProposal.Merge(m, src)
 }
+
 func (m *InstantiateContractProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *InstantiateContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_InstantiateContractProposal.DiscardUnknown(m)
 }
@@ -145,9 +158,11 @@ func (*MigrateContractProposal) ProtoMessage() {}
 func (*MigrateContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{2}
 }
+
 func (m *MigrateContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MigrateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MigrateContractProposal.Marshal(b, m, deterministic)
@@ -160,12 +175,15 @@ func (m *MigrateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
+
 func (m *MigrateContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MigrateContractProposal.Merge(m, src)
 }
+
 func (m *MigrateContractProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MigrateContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_MigrateContractProposal.DiscardUnknown(m)
 }
@@ -189,9 +207,11 @@ func (*SudoContractProposal) ProtoMessage() {}
 func (*SudoContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{3}
 }
+
 func (m *SudoContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *SudoContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SudoContractProposal.Marshal(b, m, deterministic)
@@ -204,12 +224,15 @@ func (m *SudoContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *SudoContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SudoContractProposal.Merge(m, src)
 }
+
 func (m *SudoContractProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *SudoContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_SudoContractProposal.DiscardUnknown(m)
 }
@@ -238,9 +261,11 @@ func (*ExecuteContractProposal) ProtoMessage() {}
 func (*ExecuteContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{4}
 }
+
 func (m *ExecuteContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ExecuteContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ExecuteContractProposal.Marshal(b, m, deterministic)
@@ -253,12 +278,15 @@ func (m *ExecuteContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
+
 func (m *ExecuteContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ExecuteContractProposal.Merge(m, src)
 }
+
 func (m *ExecuteContractProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ExecuteContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_ExecuteContractProposal.DiscardUnknown(m)
 }
@@ -282,9 +310,11 @@ func (*UpdateAdminProposal) ProtoMessage() {}
 func (*UpdateAdminProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{5}
 }
+
 func (m *UpdateAdminProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *UpdateAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UpdateAdminProposal.Marshal(b, m, deterministic)
@@ -297,12 +327,15 @@ func (m *UpdateAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
+
 func (m *UpdateAdminProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UpdateAdminProposal.Merge(m, src)
 }
+
 func (m *UpdateAdminProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *UpdateAdminProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UpdateAdminProposal.DiscardUnknown(m)
 }
@@ -325,9 +358,11 @@ func (*ClearAdminProposal) ProtoMessage() {}
 func (*ClearAdminProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{6}
 }
+
 func (m *ClearAdminProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ClearAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ClearAdminProposal.Marshal(b, m, deterministic)
@@ -340,12 +375,15 @@ func (m *ClearAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *ClearAdminProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ClearAdminProposal.Merge(m, src)
 }
+
 func (m *ClearAdminProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ClearAdminProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_ClearAdminProposal.DiscardUnknown(m)
 }
@@ -368,9 +406,11 @@ func (*PinCodesProposal) ProtoMessage() {}
 func (*PinCodesProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{7}
 }
+
 func (m *PinCodesProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *PinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PinCodesProposal.Marshal(b, m, deterministic)
@@ -383,12 +423,15 @@ func (m *PinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
+
 func (m *PinCodesProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PinCodesProposal.Merge(m, src)
 }
+
 func (m *PinCodesProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *PinCodesProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_PinCodesProposal.DiscardUnknown(m)
 }
@@ -411,9 +454,11 @@ func (*UnpinCodesProposal) ProtoMessage() {}
 func (*UnpinCodesProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{8}
 }
+
 func (m *UnpinCodesProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *UnpinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UnpinCodesProposal.Marshal(b, m, deterministic)
@@ -426,12 +471,15 @@ func (m *UnpinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *UnpinCodesProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UnpinCodesProposal.Merge(m, src)
 }
+
 func (m *UnpinCodesProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *UnpinCodesProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UnpinCodesProposal.DiscardUnknown(m)
 }
@@ -452,9 +500,11 @@ func (*AccessConfigUpdate) ProtoMessage() {}
 func (*AccessConfigUpdate) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{9}
 }
+
 func (m *AccessConfigUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *AccessConfigUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessConfigUpdate.Marshal(b, m, deterministic)
@@ -467,12 +517,15 @@ func (m *AccessConfigUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *AccessConfigUpdate) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessConfigUpdate.Merge(m, src)
 }
+
 func (m *AccessConfigUpdate) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *AccessConfigUpdate) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessConfigUpdate.DiscardUnknown(m)
 }
@@ -496,9 +549,11 @@ func (*UpdateInstantiateConfigProposal) ProtoMessage() {}
 func (*UpdateInstantiateConfigProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_be6422d717c730cb, []int{10}
 }
+
 func (m *UpdateInstantiateConfigProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *UpdateInstantiateConfigProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UpdateInstantiateConfigProposal.Marshal(b, m, deterministic)
@@ -511,12 +566,15 @@ func (m *UpdateInstantiateConfigProposal) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
+
 func (m *UpdateInstantiateConfigProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UpdateInstantiateConfigProposal.Merge(m, src)
 }
+
 func (m *UpdateInstantiateConfigProposal) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *UpdateInstantiateConfigProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UpdateInstantiateConfigProposal.DiscardUnknown(m)
 }
@@ -631,6 +689,7 @@ func (this *StoreCodeProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *InstantiateContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -681,6 +740,7 @@ func (this *InstantiateContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *MigrateContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -717,6 +777,7 @@ func (this *MigrateContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *SudoContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -750,6 +811,7 @@ func (this *SudoContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ExecuteContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -794,6 +856,7 @@ func (this *ExecuteContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *UpdateAdminProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -827,6 +890,7 @@ func (this *UpdateAdminProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ClearAdminProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -857,6 +921,7 @@ func (this *ClearAdminProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *PinCodesProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -892,6 +957,7 @@ func (this *PinCodesProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *UnpinCodesProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -927,6 +993,7 @@ func (this *UnpinCodesProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *AccessConfigUpdate) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -954,6 +1021,7 @@ func (this *AccessConfigUpdate) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *UpdateInstantiateConfigProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -989,6 +1057,7 @@ func (this *UpdateInstantiateConfigProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (m *StoreCodeProposal) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1620,6 +1689,7 @@ func encodeVarintProposal(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *StoreCodeProposal) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1913,9 +1983,11 @@ func (m *UpdateInstantiateConfigProposal) Size() (n int) {
 func sovProposal(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozProposal(x uint64) (n int) {
 	return sovProposal(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *StoreCodeProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2132,6 +2204,7 @@ func (m *StoreCodeProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *InstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2429,6 +2502,7 @@ func (m *InstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MigrateContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2628,6 +2702,7 @@ func (m *MigrateContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *SudoContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2808,6 +2883,7 @@ func (m *SudoContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ExecuteContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3054,6 +3130,7 @@ func (m *ExecuteContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *UpdateAdminProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3232,6 +3309,7 @@ func (m *UpdateAdminProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ClearAdminProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3378,6 +3456,7 @@ func (m *ClearAdminProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *PinCodesProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3568,6 +3647,7 @@ func (m *PinCodesProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *UnpinCodesProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3758,6 +3838,7 @@ func (m *UnpinCodesProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *AccessConfigUpdate) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3860,6 +3941,7 @@ func (m *AccessConfigUpdate) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *UpdateInstantiateConfigProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4008,6 +4090,7 @@ func (m *UpdateInstantiateConfigProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipProposal(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/proposal_test.go
+++ b/x/wasm/types/proposal_test.go
@@ -162,9 +162,7 @@ func TestValidateStoreCodeProposal(t *testing.T) {
 }
 
 func TestValidateInstantiateContractProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address"
-	)
+	invalidAddress := "invalid address"
 
 	specs := map[string]struct {
 		src    *InstantiateContractProposal
@@ -257,9 +255,7 @@ func TestValidateInstantiateContractProposal(t *testing.T) {
 }
 
 func TestValidateMigrateContractProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address2"
-	)
+	invalidAddress := "invalid address2"
 
 	specs := map[string]struct {
 		src    *MigrateContractProposal
@@ -318,9 +314,7 @@ func TestValidateMigrateContractProposal(t *testing.T) {
 }
 
 func TestValidateSudoContractProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address"
-	)
+	invalidAddress := "invalid address"
 
 	specs := map[string]struct {
 		src    *SudoContractProposal
@@ -373,9 +367,7 @@ func TestValidateSudoContractProposal(t *testing.T) {
 }
 
 func TestValidateExecuteContractProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address"
-	)
+	invalidAddress := "invalid address"
 
 	specs := map[string]struct {
 		src    *ExecuteContractProposal
@@ -434,9 +426,7 @@ func TestValidateExecuteContractProposal(t *testing.T) {
 }
 
 func TestValidateUpdateAdminProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address"
-	)
+	invalidAddress := "invalid address"
 
 	specs := map[string]struct {
 		src    *UpdateAdminProposal
@@ -489,9 +479,7 @@ func TestValidateUpdateAdminProposal(t *testing.T) {
 }
 
 func TestValidateClearAdminProposal(t *testing.T) {
-	var (
-		invalidAddress = "invalid address"
-	)
+	invalidAddress := "invalid address"
 
 	specs := map[string]struct {
 		src    *ClearAdminProposal
@@ -538,7 +526,7 @@ func TestProposalStrings(t *testing.T) {
 	}{
 		"store code": {
 			src: StoreCodeProposalFixture(func(p *StoreCodeProposal) {
-				p.WASMByteCode = []byte{01, 02, 03, 04, 05, 06, 07, 0x08, 0x09, 0x0a}
+				p.WASMByteCode = []byte{0o1, 0o2, 0o3, 0o4, 0o5, 0o6, 0o7, 0x08, 0x09, 0x0a}
 			}),
 			exp: `Store Code Proposal:
   Title:       Foo
@@ -654,7 +642,7 @@ func TestProposalYaml(t *testing.T) {
 	}{
 		"store code": {
 			src: StoreCodeProposalFixture(func(p *StoreCodeProposal) {
-				p.WASMByteCode = []byte{01, 02, 03, 04, 05, 06, 07, 0x08, 0x09, 0x0a}
+				p.WASMByteCode = []byte{0o1, 0o2, 0o3, 0o4, 0o5, 0o6, 0o7, 0x08, 0x09, 0x0a}
 			}),
 			exp: `title: Foo
 description: Bar

--- a/x/wasm/types/query.pb.go
+++ b/x/wasm/types/query.pb.go
@@ -24,8 +24,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -46,9 +49,11 @@ func (*QueryContractInfoRequest) ProtoMessage()    {}
 func (*QueryContractInfoRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{0}
 }
+
 func (m *QueryContractInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractInfoRequest.Marshal(b, m, deterministic)
@@ -61,12 +66,15 @@ func (m *QueryContractInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractInfoRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractInfoRequest.Merge(m, src)
 }
+
 func (m *QueryContractInfoRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractInfoRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractInfoRequest.DiscardUnknown(m)
 }
@@ -87,9 +95,11 @@ func (*QueryContractInfoResponse) ProtoMessage()    {}
 func (*QueryContractInfoResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{1}
 }
+
 func (m *QueryContractInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractInfoResponse.Marshal(b, m, deterministic)
@@ -102,12 +112,15 @@ func (m *QueryContractInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractInfoResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractInfoResponse.Merge(m, src)
 }
+
 func (m *QueryContractInfoResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractInfoResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractInfoResponse.DiscardUnknown(m)
 }
@@ -129,9 +142,11 @@ func (*QueryContractHistoryRequest) ProtoMessage()    {}
 func (*QueryContractHistoryRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{2}
 }
+
 func (m *QueryContractHistoryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractHistoryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractHistoryRequest.Marshal(b, m, deterministic)
@@ -144,12 +159,15 @@ func (m *QueryContractHistoryRequest) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractHistoryRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractHistoryRequest.Merge(m, src)
 }
+
 func (m *QueryContractHistoryRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractHistoryRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractHistoryRequest.DiscardUnknown(m)
 }
@@ -170,9 +188,11 @@ func (*QueryContractHistoryResponse) ProtoMessage()    {}
 func (*QueryContractHistoryResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{3}
 }
+
 func (m *QueryContractHistoryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractHistoryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractHistoryResponse.Marshal(b, m, deterministic)
@@ -185,12 +205,15 @@ func (m *QueryContractHistoryResponse) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractHistoryResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractHistoryResponse.Merge(m, src)
 }
+
 func (m *QueryContractHistoryResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractHistoryResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractHistoryResponse.DiscardUnknown(m)
 }
@@ -211,9 +234,11 @@ func (*QueryContractsByCodeRequest) ProtoMessage()    {}
 func (*QueryContractsByCodeRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{4}
 }
+
 func (m *QueryContractsByCodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractsByCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCodeRequest.Marshal(b, m, deterministic)
@@ -226,12 +251,15 @@ func (m *QueryContractsByCodeRequest) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractsByCodeRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCodeRequest.Merge(m, src)
 }
+
 func (m *QueryContractsByCodeRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractsByCodeRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCodeRequest.DiscardUnknown(m)
 }
@@ -253,9 +281,11 @@ func (*QueryContractsByCodeResponse) ProtoMessage()    {}
 func (*QueryContractsByCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{5}
 }
+
 func (m *QueryContractsByCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryContractsByCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCodeResponse.Marshal(b, m, deterministic)
@@ -268,12 +298,15 @@ func (m *QueryContractsByCodeResponse) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
+
 func (m *QueryContractsByCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCodeResponse.Merge(m, src)
 }
+
 func (m *QueryContractsByCodeResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryContractsByCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCodeResponse.DiscardUnknown(m)
 }
@@ -295,9 +328,11 @@ func (*QueryAllContractStateRequest) ProtoMessage()    {}
 func (*QueryAllContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{6}
 }
+
 func (m *QueryAllContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryAllContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAllContractStateRequest.Marshal(b, m, deterministic)
@@ -310,12 +345,15 @@ func (m *QueryAllContractStateRequest) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
+
 func (m *QueryAllContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAllContractStateRequest.Merge(m, src)
 }
+
 func (m *QueryAllContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryAllContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAllContractStateRequest.DiscardUnknown(m)
 }
@@ -336,9 +374,11 @@ func (*QueryAllContractStateResponse) ProtoMessage()    {}
 func (*QueryAllContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{7}
 }
+
 func (m *QueryAllContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryAllContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAllContractStateResponse.Marshal(b, m, deterministic)
@@ -351,12 +391,15 @@ func (m *QueryAllContractStateResponse) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryAllContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAllContractStateResponse.Merge(m, src)
 }
+
 func (m *QueryAllContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryAllContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAllContractStateResponse.DiscardUnknown(m)
 }
@@ -377,9 +420,11 @@ func (*QueryRawContractStateRequest) ProtoMessage()    {}
 func (*QueryRawContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{8}
 }
+
 func (m *QueryRawContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryRawContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryRawContractStateRequest.Marshal(b, m, deterministic)
@@ -392,12 +437,15 @@ func (m *QueryRawContractStateRequest) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
+
 func (m *QueryRawContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryRawContractStateRequest.Merge(m, src)
 }
+
 func (m *QueryRawContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryRawContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryRawContractStateRequest.DiscardUnknown(m)
 }
@@ -417,9 +465,11 @@ func (*QueryRawContractStateResponse) ProtoMessage()    {}
 func (*QueryRawContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{9}
 }
+
 func (m *QueryRawContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryRawContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryRawContractStateResponse.Marshal(b, m, deterministic)
@@ -432,12 +482,15 @@ func (m *QueryRawContractStateResponse) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
+
 func (m *QueryRawContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryRawContractStateResponse.Merge(m, src)
 }
+
 func (m *QueryRawContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryRawContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryRawContractStateResponse.DiscardUnknown(m)
 }
@@ -459,9 +512,11 @@ func (*QuerySmartContractStateRequest) ProtoMessage()    {}
 func (*QuerySmartContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{10}
 }
+
 func (m *QuerySmartContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QuerySmartContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QuerySmartContractStateRequest.Marshal(b, m, deterministic)
@@ -474,12 +529,15 @@ func (m *QuerySmartContractStateRequest) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
+
 func (m *QuerySmartContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QuerySmartContractStateRequest.Merge(m, src)
 }
+
 func (m *QuerySmartContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QuerySmartContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QuerySmartContractStateRequest.DiscardUnknown(m)
 }
@@ -499,9 +557,11 @@ func (*QuerySmartContractStateResponse) ProtoMessage()    {}
 func (*QuerySmartContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{11}
 }
+
 func (m *QuerySmartContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QuerySmartContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QuerySmartContractStateResponse.Marshal(b, m, deterministic)
@@ -514,12 +574,15 @@ func (m *QuerySmartContractStateResponse) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
+
 func (m *QuerySmartContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QuerySmartContractStateResponse.Merge(m, src)
 }
+
 func (m *QuerySmartContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QuerySmartContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QuerySmartContractStateResponse.DiscardUnknown(m)
 }
@@ -537,9 +600,11 @@ func (*QueryCodeRequest) ProtoMessage()    {}
 func (*QueryCodeRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{12}
 }
+
 func (m *QueryCodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodeRequest.Marshal(b, m, deterministic)
@@ -552,12 +617,15 @@ func (m *QueryCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
+
 func (m *QueryCodeRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodeRequest.Merge(m, src)
 }
+
 func (m *QueryCodeRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryCodeRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodeRequest.DiscardUnknown(m)
 }
@@ -578,9 +646,11 @@ func (*CodeInfoResponse) ProtoMessage()    {}
 func (*CodeInfoResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{13}
 }
+
 func (m *CodeInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CodeInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CodeInfoResponse.Marshal(b, m, deterministic)
@@ -593,12 +663,15 @@ func (m *CodeInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
+
 func (m *CodeInfoResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CodeInfoResponse.Merge(m, src)
 }
+
 func (m *CodeInfoResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CodeInfoResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_CodeInfoResponse.DiscardUnknown(m)
 }
@@ -617,9 +690,11 @@ func (*QueryCodeResponse) ProtoMessage()    {}
 func (*QueryCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{14}
 }
+
 func (m *QueryCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodeResponse.Marshal(b, m, deterministic)
@@ -632,12 +707,15 @@ func (m *QueryCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *QueryCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodeResponse.Merge(m, src)
 }
+
 func (m *QueryCodeResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodeResponse.DiscardUnknown(m)
 }
@@ -656,9 +734,11 @@ func (*QueryCodesRequest) ProtoMessage()    {}
 func (*QueryCodesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{15}
 }
+
 func (m *QueryCodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodesRequest.Marshal(b, m, deterministic)
@@ -671,12 +751,15 @@ func (m *QueryCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
+
 func (m *QueryCodesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodesRequest.Merge(m, src)
 }
+
 func (m *QueryCodesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryCodesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodesRequest.DiscardUnknown(m)
 }
@@ -696,9 +779,11 @@ func (*QueryCodesResponse) ProtoMessage()    {}
 func (*QueryCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{16}
 }
+
 func (m *QueryCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodesResponse.Marshal(b, m, deterministic)
@@ -711,12 +796,15 @@ func (m *QueryCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *QueryCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodesResponse.Merge(m, src)
 }
+
 func (m *QueryCodesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodesResponse.DiscardUnknown(m)
 }
@@ -736,9 +824,11 @@ func (*QueryPinnedCodesRequest) ProtoMessage()    {}
 func (*QueryPinnedCodesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{17}
 }
+
 func (m *QueryPinnedCodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryPinnedCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPinnedCodesRequest.Marshal(b, m, deterministic)
@@ -751,12 +841,15 @@ func (m *QueryPinnedCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
+
 func (m *QueryPinnedCodesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPinnedCodesRequest.Merge(m, src)
 }
+
 func (m *QueryPinnedCodesRequest) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryPinnedCodesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPinnedCodesRequest.DiscardUnknown(m)
 }
@@ -777,9 +870,11 @@ func (*QueryPinnedCodesResponse) ProtoMessage()    {}
 func (*QueryPinnedCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{18}
 }
+
 func (m *QueryPinnedCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *QueryPinnedCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPinnedCodesResponse.Marshal(b, m, deterministic)
@@ -792,12 +887,15 @@ func (m *QueryPinnedCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *QueryPinnedCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPinnedCodesResponse.Merge(m, src)
 }
+
 func (m *QueryPinnedCodesResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *QueryPinnedCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPinnedCodesResponse.DiscardUnknown(m)
 }
@@ -934,6 +1032,7 @@ func (this *QueryContractInfoResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *CodeInfoResponse) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -967,6 +1066,7 @@ func (this *CodeInfoResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *QueryCodeResponse) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1139,33 +1239,40 @@ type QueryServer interface {
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServer struct {
-}
+type UnimplementedQueryServer struct{}
 
 func (*UnimplementedQueryServer) ContractInfo(ctx context.Context, req *QueryContractInfoRequest) (*QueryContractInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractInfo not implemented")
 }
+
 func (*UnimplementedQueryServer) ContractHistory(ctx context.Context, req *QueryContractHistoryRequest) (*QueryContractHistoryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractHistory not implemented")
 }
+
 func (*UnimplementedQueryServer) ContractsByCode(ctx context.Context, req *QueryContractsByCodeRequest) (*QueryContractsByCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractsByCode not implemented")
 }
+
 func (*UnimplementedQueryServer) AllContractState(ctx context.Context, req *QueryAllContractStateRequest) (*QueryAllContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AllContractState not implemented")
 }
+
 func (*UnimplementedQueryServer) RawContractState(ctx context.Context, req *QueryRawContractStateRequest) (*QueryRawContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RawContractState not implemented")
 }
+
 func (*UnimplementedQueryServer) SmartContractState(ctx context.Context, req *QuerySmartContractStateRequest) (*QuerySmartContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SmartContractState not implemented")
 }
+
 func (*UnimplementedQueryServer) Code(ctx context.Context, req *QueryCodeRequest) (*QueryCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Code not implemented")
 }
+
 func (*UnimplementedQueryServer) Codes(ctx context.Context, req *QueryCodesRequest) (*QueryCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Codes not implemented")
 }
+
 func (*UnimplementedQueryServer) PinnedCodes(ctx context.Context, req *QueryPinnedCodesRequest) (*QueryPinnedCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PinnedCodes not implemented")
 }
@@ -2156,6 +2263,7 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *QueryContractInfoRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2470,9 +2578,11 @@ func (m *QueryPinnedCodesResponse) Size() (n int) {
 func sovQuery(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *QueryContractInfoRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2555,6 +2665,7 @@ func (m *QueryContractInfoRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryContractInfoResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2670,6 +2781,7 @@ func (m *QueryContractInfoResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryContractHistoryRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2788,6 +2900,7 @@ func (m *QueryContractHistoryRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryContractHistoryResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2908,6 +3021,7 @@ func (m *QueryContractHistoryResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryContractsByCodeRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3013,6 +3127,7 @@ func (m *QueryContractsByCodeRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryContractsByCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3131,6 +3246,7 @@ func (m *QueryContractsByCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryAllContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3249,6 +3365,7 @@ func (m *QueryAllContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryAllContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3369,6 +3486,7 @@ func (m *QueryAllContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryRawContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3485,6 +3603,7 @@ func (m *QueryRawContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryRawContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3569,6 +3688,7 @@ func (m *QueryRawContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QuerySmartContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3685,6 +3805,7 @@ func (m *QuerySmartContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QuerySmartContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3769,6 +3890,7 @@ func (m *QuerySmartContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryCodeRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3838,6 +3960,7 @@ func (m *QueryCodeRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CodeInfoResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4006,6 +4129,7 @@ func (m *CodeInfoResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4126,6 +4250,7 @@ func (m *QueryCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryCodesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4212,6 +4337,7 @@ func (m *QueryCodesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4332,6 +4458,7 @@ func (m *QueryCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryPinnedCodesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4418,6 +4545,7 @@ func (m *QueryPinnedCodesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *QueryPinnedCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4580,6 +4708,7 @@ func (m *QueryPinnedCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipQuery(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/query.pb.gw.go
+++ b/x/wasm/types/query.pb.gw.go
@@ -25,11 +25,14 @@ import (
 
 // Suppress "imported and not used" errors
 var _ codes.Code
-var _ io.Reader
-var _ status.Status
-var _ = runtime.String
-var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
+
+var (
+	_ io.Reader
+	_ status.Status
+	_ = runtime.String
+	_ = utilities.NewDoubleArray
+	_ = descriptor.ForMessage
+)
 
 func request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractInfoRequest
@@ -55,7 +58,6 @@ func request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.ContractInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -82,12 +84,9 @@ func local_request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.ContractInfo(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_ContractHistory_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_ContractHistory_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractHistoryRequest
@@ -120,7 +119,6 @@ func request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := client.ContractHistory(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -154,12 +152,9 @@ func local_request_Query_ContractHistory_0(ctx context.Context, marshaler runtim
 
 	msg, err := server.ContractHistory(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_ContractsByCode_0 = &utilities.DoubleArray{Encoding: map[string]int{"code_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_ContractsByCode_0 = &utilities.DoubleArray{Encoding: map[string]int{"code_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractsByCodeRequest
@@ -192,7 +187,6 @@ func request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := client.ContractsByCode(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -226,12 +220,9 @@ func local_request_Query_ContractsByCode_0(ctx context.Context, marshaler runtim
 
 	msg, err := server.ContractsByCode(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_AllContractState_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
-)
+var filter_Query_AllContractState_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryAllContractStateRequest
@@ -264,7 +255,6 @@ func request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Mar
 
 	msg, err := client.AllContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -298,7 +288,6 @@ func local_request_Query_AllContractState_0(ctx context.Context, marshaler runti
 
 	msg, err := server.AllContractState(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -336,7 +325,6 @@ func request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Mar
 
 	msg, err := client.RawContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -374,7 +362,6 @@ func local_request_Query_RawContractState_0(ctx context.Context, marshaler runti
 
 	msg, err := server.RawContractState(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -412,7 +399,6 @@ func request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := client.SmartContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -450,7 +436,6 @@ func local_request_Query_SmartContractState_0(ctx context.Context, marshaler run
 
 	msg, err := server.SmartContractState(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 func request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -477,7 +462,6 @@ func request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, clie
 
 	msg, err := client.Code(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -504,12 +488,9 @@ func local_request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler
 
 	msg, err := server.Code(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_Codes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Query_Codes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryCodesRequest
@@ -524,7 +505,6 @@ func request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, cli
 
 	msg, err := client.Codes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -540,12 +520,9 @@ func local_request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshale
 
 	msg, err := server.Codes(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
-var (
-	filter_Query_PinnedCodes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
-)
+var filter_Query_PinnedCodes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryPinnedCodesRequest
@@ -560,7 +537,6 @@ func request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshale
 
 	msg, err := client.PinnedCodes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
-
 }
 
 func local_request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -576,7 +552,6 @@ func local_request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Ma
 
 	msg, err := server.PinnedCodes(ctx, &protoReq)
 	return msg, metadata, err
-
 }
 
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
@@ -584,7 +559,6 @@ func local_request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Ma
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features (such as grpc.SendHeader, etc) to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
-
 	mux.Handle("GET", pattern_Query_ContractInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -602,7 +576,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_ContractHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -622,7 +595,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractHistory_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -642,7 +614,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractsByCode_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_AllContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -662,7 +633,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_AllContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_RawContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -682,7 +652,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_RawContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_SmartContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -702,7 +671,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_SmartContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Code_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -722,7 +690,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Code_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Codes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -742,7 +709,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Codes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_PinnedCodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -762,7 +728,6 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_PinnedCodes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil
@@ -805,7 +770,6 @@ func RegisterQueryHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "QueryClient" to call the correct interceptors.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
-
 	mux.Handle("GET", pattern_Query_ContractInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -823,7 +787,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_ContractHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -843,7 +806,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractHistory_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -863,7 +825,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractsByCode_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_AllContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -883,7 +844,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_AllContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_RawContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -903,7 +863,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_RawContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_SmartContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -923,7 +882,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_SmartContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Code_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -943,7 +901,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Code_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_Codes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -963,7 +920,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Codes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	mux.Handle("GET", pattern_Query_PinnedCodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -983,7 +939,6 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_PinnedCodes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
 	})
 
 	return nil

--- a/x/wasm/types/test_fixtures.go
+++ b/x/wasm/types/test_fixtures.go
@@ -125,7 +125,7 @@ func WithSHA256CodeHash(wasmCode []byte) func(info *CodeInfo) {
 }
 
 func MsgStoreCodeFixture(mutators ...func(*MsgStoreCode)) *MsgStoreCode {
-	var wasmIdent = []byte("\x00\x61\x73\x6D")
+	wasmIdent := []byte("\x00\x61\x73\x6D")
 	const anyAddress = "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs2m6sx4"
 	r := &MsgStoreCode{
 		Sender:                anyAddress,

--- a/x/wasm/types/tx.go
+++ b/x/wasm/types/tx.go
@@ -68,7 +68,6 @@ func (msg MsgStoreCode) ValidateBasic() error {
 
 func (msg MsgStoreCode) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgStoreCode) GetSigners() []sdk.AccAddress {
@@ -98,7 +97,6 @@ func (msg MsgInstantiateContract) ValidateBasic() error {
 
 	if err := validateLabel(msg.Label); err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "label is required")
-
 	}
 
 	if !msg.Funds.IsValid() {
@@ -118,7 +116,6 @@ func (msg MsgInstantiateContract) ValidateBasic() error {
 
 func (msg MsgInstantiateContract) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgInstantiateContract) GetSigners() []sdk.AccAddress {
@@ -156,7 +153,6 @@ func (msg MsgExecuteContract) ValidateBasic() error {
 
 func (msg MsgExecuteContract) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgExecuteContract) GetSigners() []sdk.AccAddress {
@@ -165,7 +161,6 @@ func (msg MsgExecuteContract) GetSigners() []sdk.AccAddress {
 		panic(err.Error())
 	}
 	return []sdk.AccAddress{senderAddr}
-
 }
 
 func (msg MsgMigrateContract) Route() string {
@@ -196,7 +191,6 @@ func (msg MsgMigrateContract) ValidateBasic() error {
 
 func (msg MsgMigrateContract) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgMigrateContract) GetSigners() []sdk.AccAddress {
@@ -205,7 +199,6 @@ func (msg MsgMigrateContract) GetSigners() []sdk.AccAddress {
 		panic(err.Error())
 	}
 	return []sdk.AccAddress{senderAddr}
-
 }
 
 func (msg MsgUpdateAdmin) Route() string {
@@ -234,7 +227,6 @@ func (msg MsgUpdateAdmin) ValidateBasic() error {
 
 func (msg MsgUpdateAdmin) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgUpdateAdmin) GetSigners() []sdk.AccAddress {
@@ -243,7 +235,6 @@ func (msg MsgUpdateAdmin) GetSigners() []sdk.AccAddress {
 		panic(err.Error())
 	}
 	return []sdk.AccAddress{senderAddr}
-
 }
 
 func (msg MsgClearAdmin) Route() string {
@@ -266,7 +257,6 @@ func (msg MsgClearAdmin) ValidateBasic() error {
 
 func (msg MsgClearAdmin) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
-
 }
 
 func (msg MsgClearAdmin) GetSigners() []sdk.AccAddress {
@@ -275,7 +265,6 @@ func (msg MsgClearAdmin) GetSigners() []sdk.AccAddress {
 		panic(err.Error())
 	}
 	return []sdk.AccAddress{senderAddr}
-
 }
 
 func (msg MsgIBCSend) Route() string {

--- a/x/wasm/types/tx.pb.go
+++ b/x/wasm/types/tx.pb.go
@@ -22,8 +22,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -48,9 +51,11 @@ func (*MsgStoreCode) ProtoMessage()    {}
 func (*MsgStoreCode) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{0}
 }
+
 func (m *MsgStoreCode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgStoreCode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreCode.Marshal(b, m, deterministic)
@@ -63,12 +68,15 @@ func (m *MsgStoreCode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *MsgStoreCode) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreCode.Merge(m, src)
 }
+
 func (m *MsgStoreCode) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgStoreCode) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreCode.DiscardUnknown(m)
 }
@@ -87,9 +95,11 @@ func (*MsgStoreCodeResponse) ProtoMessage()    {}
 func (*MsgStoreCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{1}
 }
+
 func (m *MsgStoreCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgStoreCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreCodeResponse.Marshal(b, m, deterministic)
@@ -102,12 +112,15 @@ func (m *MsgStoreCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
+
 func (m *MsgStoreCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreCodeResponse.Merge(m, src)
 }
+
 func (m *MsgStoreCodeResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgStoreCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreCodeResponse.DiscardUnknown(m)
 }
@@ -137,9 +150,11 @@ func (*MsgInstantiateContract) ProtoMessage()    {}
 func (*MsgInstantiateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{2}
 }
+
 func (m *MsgInstantiateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgInstantiateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContract.Marshal(b, m, deterministic)
@@ -152,12 +167,15 @@ func (m *MsgInstantiateContract) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *MsgInstantiateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContract.Merge(m, src)
 }
+
 func (m *MsgInstantiateContract) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgInstantiateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContract.DiscardUnknown(m)
 }
@@ -178,9 +196,11 @@ func (*MsgInstantiateContractResponse) ProtoMessage()    {}
 func (*MsgInstantiateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{3}
 }
+
 func (m *MsgInstantiateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgInstantiateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContractResponse.Marshal(b, m, deterministic)
@@ -193,12 +213,15 @@ func (m *MsgInstantiateContractResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
+
 func (m *MsgInstantiateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContractResponse.Merge(m, src)
 }
+
 func (m *MsgInstantiateContractResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgInstantiateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContractResponse.DiscardUnknown(m)
 }
@@ -223,9 +246,11 @@ func (*MsgExecuteContract) ProtoMessage()    {}
 func (*MsgExecuteContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{4}
 }
+
 func (m *MsgExecuteContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgExecuteContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgExecuteContract.Marshal(b, m, deterministic)
@@ -238,12 +263,15 @@ func (m *MsgExecuteContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *MsgExecuteContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgExecuteContract.Merge(m, src)
 }
+
 func (m *MsgExecuteContract) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgExecuteContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgExecuteContract.DiscardUnknown(m)
 }
@@ -262,9 +290,11 @@ func (*MsgExecuteContractResponse) ProtoMessage()    {}
 func (*MsgExecuteContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{5}
 }
+
 func (m *MsgExecuteContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgExecuteContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgExecuteContractResponse.Marshal(b, m, deterministic)
@@ -277,12 +307,15 @@ func (m *MsgExecuteContractResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
+
 func (m *MsgExecuteContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgExecuteContractResponse.Merge(m, src)
 }
+
 func (m *MsgExecuteContractResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgExecuteContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgExecuteContractResponse.DiscardUnknown(m)
 }
@@ -307,9 +340,11 @@ func (*MsgMigrateContract) ProtoMessage()    {}
 func (*MsgMigrateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{6}
 }
+
 func (m *MsgMigrateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgMigrateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgMigrateContract.Marshal(b, m, deterministic)
@@ -322,12 +357,15 @@ func (m *MsgMigrateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *MsgMigrateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgMigrateContract.Merge(m, src)
 }
+
 func (m *MsgMigrateContract) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgMigrateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgMigrateContract.DiscardUnknown(m)
 }
@@ -347,9 +385,11 @@ func (*MsgMigrateContractResponse) ProtoMessage()    {}
 func (*MsgMigrateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{7}
 }
+
 func (m *MsgMigrateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgMigrateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgMigrateContractResponse.Marshal(b, m, deterministic)
@@ -362,12 +402,15 @@ func (m *MsgMigrateContractResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
+
 func (m *MsgMigrateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgMigrateContractResponse.Merge(m, src)
 }
+
 func (m *MsgMigrateContractResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgMigrateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgMigrateContractResponse.DiscardUnknown(m)
 }
@@ -390,9 +433,11 @@ func (*MsgUpdateAdmin) ProtoMessage()    {}
 func (*MsgUpdateAdmin) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{8}
 }
+
 func (m *MsgUpdateAdmin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateAdmin.Marshal(b, m, deterministic)
@@ -405,12 +450,15 @@ func (m *MsgUpdateAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateAdmin) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateAdmin.Merge(m, src)
 }
+
 func (m *MsgUpdateAdmin) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateAdmin) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateAdmin.DiscardUnknown(m)
 }
@@ -418,8 +466,7 @@ func (m *MsgUpdateAdmin) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgUpdateAdmin proto.InternalMessageInfo
 
 // MsgUpdateAdminResponse returns empty data
-type MsgUpdateAdminResponse struct {
-}
+type MsgUpdateAdminResponse struct{}
 
 func (m *MsgUpdateAdminResponse) Reset()         { *m = MsgUpdateAdminResponse{} }
 func (m *MsgUpdateAdminResponse) String() string { return proto.CompactTextString(m) }
@@ -427,9 +474,11 @@ func (*MsgUpdateAdminResponse) ProtoMessage()    {}
 func (*MsgUpdateAdminResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{9}
 }
+
 func (m *MsgUpdateAdminResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgUpdateAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateAdminResponse.Marshal(b, m, deterministic)
@@ -442,12 +491,15 @@ func (m *MsgUpdateAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
+
 func (m *MsgUpdateAdminResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateAdminResponse.Merge(m, src)
 }
+
 func (m *MsgUpdateAdminResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgUpdateAdminResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateAdminResponse.DiscardUnknown(m)
 }
@@ -468,9 +520,11 @@ func (*MsgClearAdmin) ProtoMessage()    {}
 func (*MsgClearAdmin) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{10}
 }
+
 func (m *MsgClearAdmin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgClearAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgClearAdmin.Marshal(b, m, deterministic)
@@ -483,12 +537,15 @@ func (m *MsgClearAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
+
 func (m *MsgClearAdmin) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgClearAdmin.Merge(m, src)
 }
+
 func (m *MsgClearAdmin) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgClearAdmin) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgClearAdmin.DiscardUnknown(m)
 }
@@ -496,8 +553,7 @@ func (m *MsgClearAdmin) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgClearAdmin proto.InternalMessageInfo
 
 // MsgClearAdminResponse returns empty data
-type MsgClearAdminResponse struct {
-}
+type MsgClearAdminResponse struct{}
 
 func (m *MsgClearAdminResponse) Reset()         { *m = MsgClearAdminResponse{} }
 func (m *MsgClearAdminResponse) String() string { return proto.CompactTextString(m) }
@@ -505,9 +561,11 @@ func (*MsgClearAdminResponse) ProtoMessage()    {}
 func (*MsgClearAdminResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{11}
 }
+
 func (m *MsgClearAdminResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *MsgClearAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgClearAdminResponse.Marshal(b, m, deterministic)
@@ -520,12 +578,15 @@ func (m *MsgClearAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
+
 func (m *MsgClearAdminResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgClearAdminResponse.Merge(m, src)
 }
+
 func (m *MsgClearAdminResponse) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *MsgClearAdminResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgClearAdminResponse.DiscardUnknown(m)
 }
@@ -706,24 +767,28 @@ type MsgServer interface {
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServer struct {
-}
+type UnimplementedMsgServer struct{}
 
 func (*UnimplementedMsgServer) StoreCode(ctx context.Context, req *MsgStoreCode) (*MsgStoreCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StoreCode not implemented")
 }
+
 func (*UnimplementedMsgServer) InstantiateContract(ctx context.Context, req *MsgInstantiateContract) (*MsgInstantiateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InstantiateContract not implemented")
 }
+
 func (*UnimplementedMsgServer) ExecuteContract(ctx context.Context, req *MsgExecuteContract) (*MsgExecuteContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExecuteContract not implemented")
 }
+
 func (*UnimplementedMsgServer) MigrateContract(ctx context.Context, req *MsgMigrateContract) (*MsgMigrateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method MigrateContract not implemented")
 }
+
 func (*UnimplementedMsgServer) UpdateAdmin(ctx context.Context, req *MsgUpdateAdmin) (*MsgUpdateAdminResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateAdmin not implemented")
 }
+
 func (*UnimplementedMsgServer) ClearAdmin(ctx context.Context, req *MsgClearAdmin) (*MsgClearAdminResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ClearAdmin not implemented")
 }
@@ -1362,6 +1427,7 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *MsgStoreCode) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1582,9 +1648,11 @@ func (m *MsgClearAdminResponse) Size() (n int) {
 func sovTx(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *MsgStoreCode) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1737,6 +1805,7 @@ func (m *MsgStoreCode) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgStoreCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1806,6 +1875,7 @@ func (m *MsgStoreCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgInstantiateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2039,6 +2109,7 @@ func (m *MsgInstantiateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2155,6 +2226,7 @@ func (m *MsgInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgExecuteContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2337,6 +2409,7 @@ func (m *MsgExecuteContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgExecuteContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2421,6 +2494,7 @@ func (m *MsgExecuteContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgMigrateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2588,6 +2662,7 @@ func (m *MsgMigrateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2672,6 +2747,7 @@ func (m *MsgMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateAdmin) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2818,6 +2894,7 @@ func (m *MsgUpdateAdmin) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgUpdateAdminResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2868,6 +2945,7 @@ func (m *MsgUpdateAdminResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgClearAdmin) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2982,6 +3060,7 @@ func (m *MsgClearAdmin) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *MsgClearAdminResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3032,6 +3111,7 @@ func (m *MsgClearAdminResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTx(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/types.pb.go
+++ b/x/wasm/types/types.pb.go
@@ -19,8 +19,11 @@ import (
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+
+var (
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -107,9 +110,11 @@ func (*AccessTypeParam) ProtoMessage()    {}
 func (*AccessTypeParam) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{0}
 }
+
 func (m *AccessTypeParam) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *AccessTypeParam) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessTypeParam.Marshal(b, m, deterministic)
@@ -122,12 +127,15 @@ func (m *AccessTypeParam) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
+
 func (m *AccessTypeParam) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessTypeParam.Merge(m, src)
 }
+
 func (m *AccessTypeParam) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *AccessTypeParam) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessTypeParam.DiscardUnknown(m)
 }
@@ -146,9 +154,11 @@ func (*AccessConfig) ProtoMessage()    {}
 func (*AccessConfig) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{1}
 }
+
 func (m *AccessConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *AccessConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessConfig.Marshal(b, m, deterministic)
@@ -161,12 +171,15 @@ func (m *AccessConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *AccessConfig) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessConfig.Merge(m, src)
 }
+
 func (m *AccessConfig) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *AccessConfig) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessConfig.DiscardUnknown(m)
 }
@@ -184,9 +197,11 @@ func (*Params) ProtoMessage() {}
 func (*Params) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{2}
 }
+
 func (m *Params) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Params.Marshal(b, m, deterministic)
@@ -199,12 +214,15 @@ func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Params) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Params.Merge(m, src)
 }
+
 func (m *Params) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Params) XXX_DiscardUnknown() {
 	xxx_messageInfo_Params.DiscardUnknown(m)
 }
@@ -227,9 +245,11 @@ func (*CodeInfo) ProtoMessage()    {}
 func (*CodeInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{3}
 }
+
 func (m *CodeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *CodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CodeInfo.Marshal(b, m, deterministic)
@@ -242,12 +262,15 @@ func (m *CodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *CodeInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CodeInfo.Merge(m, src)
 }
+
 func (m *CodeInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *CodeInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_CodeInfo.DiscardUnknown(m)
 }
@@ -280,9 +303,11 @@ func (*ContractInfo) ProtoMessage()    {}
 func (*ContractInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{4}
 }
+
 func (m *ContractInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ContractInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractInfo.Marshal(b, m, deterministic)
@@ -295,12 +320,15 @@ func (m *ContractInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
+
 func (m *ContractInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractInfo.Merge(m, src)
 }
+
 func (m *ContractInfo) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ContractInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractInfo.DiscardUnknown(m)
 }
@@ -323,9 +351,11 @@ func (*ContractCodeHistoryEntry) ProtoMessage()    {}
 func (*ContractCodeHistoryEntry) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{5}
 }
+
 func (m *ContractCodeHistoryEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *ContractCodeHistoryEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractCodeHistoryEntry.Marshal(b, m, deterministic)
@@ -338,12 +368,15 @@ func (m *ContractCodeHistoryEntry) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
+
 func (m *ContractCodeHistoryEntry) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractCodeHistoryEntry.Merge(m, src)
 }
+
 func (m *ContractCodeHistoryEntry) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *ContractCodeHistoryEntry) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractCodeHistoryEntry.DiscardUnknown(m)
 }
@@ -366,9 +399,11 @@ func (*AbsoluteTxPosition) ProtoMessage()    {}
 func (*AbsoluteTxPosition) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{6}
 }
+
 func (m *AbsoluteTxPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *AbsoluteTxPosition) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AbsoluteTxPosition.Marshal(b, m, deterministic)
@@ -381,12 +416,15 @@ func (m *AbsoluteTxPosition) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
+
 func (m *AbsoluteTxPosition) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AbsoluteTxPosition.Merge(m, src)
 }
+
 func (m *AbsoluteTxPosition) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *AbsoluteTxPosition) XXX_DiscardUnknown() {
 	xxx_messageInfo_AbsoluteTxPosition.DiscardUnknown(m)
 }
@@ -407,9 +445,11 @@ func (*Model) ProtoMessage()    {}
 func (*Model) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{7}
 }
+
 func (m *Model) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
+
 func (m *Model) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Model.Marshal(b, m, deterministic)
@@ -422,12 +462,15 @@ func (m *Model) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
+
 func (m *Model) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Model.Merge(m, src)
 }
+
 func (m *Model) XXX_Size() int {
 	return m.Size()
 }
+
 func (m *Model) XXX_DiscardUnknown() {
 	xxx_messageInfo_Model.DiscardUnknown(m)
 }
@@ -548,6 +591,7 @@ func (this *AccessTypeParam) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *AccessConfig) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -575,6 +619,7 @@ func (this *AccessConfig) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *Params) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -602,6 +647,7 @@ func (this *Params) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *CodeInfo) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -632,6 +678,7 @@ func (this *CodeInfo) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ContractInfo) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -674,6 +721,7 @@ func (this *ContractInfo) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *ContractCodeHistoryEntry) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -707,6 +755,7 @@ func (this *ContractCodeHistoryEntry) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *AbsoluteTxPosition) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -734,6 +783,7 @@ func (this *AbsoluteTxPosition) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (this *Model) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -761,6 +811,7 @@ func (this *Model) Equal(that interface{}) bool {
 	}
 	return true
 }
+
 func (m *AccessTypeParam) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1122,6 +1173,7 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+
 func (m *AccessTypeParam) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1277,9 +1329,11 @@ func (m *Model) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
+
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
+
 func (m *AccessTypeParam) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1349,6 +1403,7 @@ func (m *AccessTypeParam) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *AccessConfig) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1450,6 +1505,7 @@ func (m *AccessConfig) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Params) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1552,6 +1608,7 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *CodeInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1701,6 +1758,7 @@ func (m *CodeInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1970,6 +2028,7 @@ func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *ContractCodeHistoryEntry) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2128,6 +2187,7 @@ func (m *ContractCodeHistoryEntry) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *AbsoluteTxPosition) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2216,6 +2276,7 @@ func (m *AbsoluteTxPosition) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func (m *Model) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2334,6 +2395,7 @@ func (m *Model) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/types_test.go
+++ b/x/wasm/types/types_test.go
@@ -174,7 +174,7 @@ func TestContractInfoSetExtension(t *testing.T) {
 func TestContractInfoMarshalUnmarshal(t *testing.T) {
 	var myAddr sdk.AccAddress = rand.Bytes(ContractAddrLen)
 	var myOtherAddr sdk.AccAddress = rand.Bytes(ContractAddrLen)
-	var anyPos = AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2}
+	anyPos := AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2}
 
 	anyTime := time.Now().UTC()
 	// using gov proposal here as a random protobuf types as it contains an Any type inside for nested unpacking

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -7,7 +7,6 @@ import (
 
 // WasmerEngine defines the WASM contract runtime engine.
 type WasmerEngine interface {
-
 	// Create will compile the wasm code, and store the resulting pre-compile
 	// as well as the original code. Both can be referenced later via CodeID
 	// This must be done one time for given code, after which it can be


### PR DESCRIPTION
Replaces #832 (which was a great idea, thanks @faddat )

This has 2 commits to install the proper tooling and use it with the `make format` and `make lint` commands.

The last commit actually runs the updated `make format` command, and `make lint` will help enforce this as a requirement for merging.