### PR TITLE
Publish protobufs on release tags

### DIFF
--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -4,9 +4,13 @@ name: Proto Buf Publishing - Action
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'proto/**'
+
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   push:

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -10,7 +10,7 @@ on:
 
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v[0-9]+.[0-9]+.[0-9]+.*" # Push events to matching v*, //i.e. v20.15.10, v0.27.0-rc1
 
 jobs:
   push:


### PR DESCRIPTION
Publish protobufs when:
- A new commit is pushed into main (only if files in proto folder are modified)
- A new release tag event is triggered