### PR TITLE
Remove unused NegotiateAppVersion ibc callback

### DIFF
--- a/x/wasm/ibc.go
+++ b/x/wasm/ibc.go
@@ -299,17 +299,6 @@ func (i IBCHandler) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet,
 	return nil
 }
 
-func (i IBCHandler) NegotiateAppVersion(
-	ctx sdk.Context,
-	order channeltypes.Order,
-	connectionID string,
-	portID string,
-	counterparty channeltypes.Counterparty,
-	proposedVersion string,
-) (version string, err error) {
-	return proposedVersion, nil // accept all
-}
-
 func newIBCPacket(packet channeltypes.Packet) wasmvmtypes.IBCPacket {
 	timeout := wasmvmtypes.IBCTimeout{
 		Timestamp: packet.TimeoutTimestamp,


### PR DESCRIPTION
> Now applications will perform this version negotiation during the channel handshake, thus removing the need for NegotiateAppVersion.

https://github.com/cosmos/ibc-go/blob/main/docs/migrations/v2-to-v3.md#negotiateappversion-removed-from-ibcmodule-interface