### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.43.0
+      - image: golangci/golangci-lint:v1.46.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This is a micro-PR that only brings the golangci-lint binary that we use in CI current with their latest release.

I think it may be helpful with:

* #882 
* #815
* #866 