### PR TITLE
Prune vesting accounts balances

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -1178,6 +1178,7 @@ func NewCoinBurner(bank types.BankKeeper) CoinBurner {
 
 // PruneBalances burns all coins owned by the account.
 func (b CoinBurner) PruneBalances(ctx sdk.Context, address sdk.AccAddress) error {
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	if amt := b.bank.GetAllBalances(ctx, address); !amt.IsZero() {
 		if err := b.bank.SendCoinsFromAccountToModule(ctx, address, types.ModuleName, amt); err != nil {
 			return sdkerrors.Wrap(err, "prune account balance")

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -2274,3 +2274,14 @@ func TestAppendToContractHistory(t *testing.T) {
 	gotHistory := keepers.WasmKeeper.GetContractHistory(ctx, contractAddr)
 	assert.Equal(t, orderedEntries, gotHistory)
 }
+
+func TestCoinBurnerPruneBalances(t *testing.T) {
+	// should not use users gas
+	parentCtx, keepers := CreateTestInput(t, false, AvailableCapabilities)
+	addr := keepers.Faucet.NewFundedRandomAccount(parentCtx, sdk.NewCoin("stake", sdk.NewInt(1)))
+	// when
+	ctx := parentCtx.WithGasMeter(sdk.NewGasMeter(0))
+	gotErr := NewCoinBurner(keepers.BankKeeper).PruneBalances(ctx, addr)
+	require.NoError(t, gotErr)
+	assert.Empty(t, keepers.BankKeeper.GetAllBalances(parentCtx, addr))
+}

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -2324,7 +2324,7 @@ func TestCoinBurnerPruneBalances(t *testing.T) {
 
 			// when
 			noGasCtx := ctx.WithGasMeter(sdk.NewGasMeter(0)) // should not use callers gas
-			gotHandled, gotErr := NewVestingCoinBurner(keepers.BankKeeper).PruneBalances(noGasCtx, existingAccount)
+			gotHandled, gotErr := NewVestingCoinBurner(keepers.BankKeeper).CleanupExistingAccount(noGasCtx, existingAccount)
 			// then
 			if spec.expErr != nil {
 				require.ErrorIs(t, gotErr, spec.expErr)

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -154,19 +154,6 @@ func WithAcceptedAccountTypesOnContractInstantiation(accts ...authtypes.AccountI
 	})
 }
 
-// WithPruneAccountTypesOnContractInstantiation sets the account types that should be cleared. Account types of this list
-// will be overwritten with the BaseAccount type and their balance burned, when they exist for an address on contract
-// instantiation.
-//
-// Values should be references and contain the `*vestingtypes.DelayedVestingAccount`, `*vestingtypes.ContinuousVestingAccount`
-// as post genesis account types with an open address range.
-func WithPruneAccountTypesOnContractInstantiation(accts ...authtypes.AccountI) Option {
-	m := asTypeMap(accts)
-	return optsFn(func(k *Keeper) {
-		k.pruneAccountTypes = m
-	})
-}
-
 func asTypeMap(accts []authtypes.AccountI) map[reflect.Type]struct{} {
 	m := make(map[reflect.Type]struct{}, len(accts))
 	for _, a := range accts {

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -99,14 +99,14 @@ func WithCoinTransferrer(x CoinTransferrer) Option {
 	})
 }
 
-// WithCoinPruner is an optional constructor parameter to set a custom type that handles balances
+// WithAccountPruner is an optional constructor parameter to set a custom type that handles balances and data cleanup
 // for accounts pruned on contract instantiate
-func WithCoinPruner(x CoinPruner) Option {
+func WithAccountPruner(x AccountPruner) Option {
 	if x == nil {
 		panic("must not be nil")
 	}
 	return optsFn(func(k *Keeper) {
-		k.coinPruner = x
+		k.accountPruner = x
 	})
 }
 

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -95,20 +95,10 @@ func TestConstructorOptions(t *testing.T) {
 				assert.Equal(t, exp, k.acceptedAccountTypes)
 			},
 		},
-		"prune account types": {
-			srcOpt: WithPruneAccountTypesOnContractInstantiation(&authtypes.BaseAccount{}, &vestingtypes.ContinuousVestingAccount{}),
-			verify: func(t *testing.T, k Keeper) {
-				exp := map[reflect.Type]struct{}{
-					reflect.TypeOf(&authtypes.BaseAccount{}):                 {},
-					reflect.TypeOf(&vestingtypes.ContinuousVestingAccount{}): {},
-				}
-				assert.Equal(t, exp, k.pruneAccountTypes)
-			},
-		},
 		"coin pruner": {
-			srcOpt: WithCoinPruner(CoinBurner{}),
+			srcOpt: WithCoinPruner(VestingCoinBurner{}),
 			verify: func(t *testing.T, k Keeper) {
-				assert.Equal(t, CoinBurner{}, k.coinPruner)
+				assert.Equal(t, VestingCoinBurner{}, k.coinPruner)
 			},
 		},
 	}

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -95,10 +95,10 @@ func TestConstructorOptions(t *testing.T) {
 				assert.Equal(t, exp, k.acceptedAccountTypes)
 			},
 		},
-		"coin pruner": {
-			srcOpt: WithCoinPruner(VestingCoinBurner{}),
+		"account pruner": {
+			srcOpt: WithAccountPruner(VestingCoinBurner{}),
 			verify: func(t *testing.T, k Keeper) {
-				assert.Equal(t, VestingCoinBurner{}, k.coinPruner)
+				assert.Equal(t, VestingCoinBurner{}, k.accountPruner)
 			},
 		},
 	}


### PR DESCRIPTION
Prevent an out of gas error when burning accounts balance

Update:
This PR also includes 
* pruning vesting accounts original denoms only
* drop the prune account types list. It is easier to check for the vesting account interface. This should cover future vesting types as well. Chains can still overwrite this behaviour with a custom CoinPruner via Options