### PR TITLE
Add normalized init msg to address generation

### DIFF
--- a/x/wasm/client/cli/genesis_msg.go
+++ b/x/wasm/client/cli/genesis_msg.go
@@ -334,7 +334,7 @@ func GetAllContracts(state *types.GenesisState) ([]ContractMeta, error) {
 				return nil, types.ErrNotFound.Wrapf("hash for code-id: %d", msg.CodeID)
 			}
 			all = append(all, ContractMeta{
-				ContractAddress: keeper.BuildContractAddress(codeHash, senderAddr, msg.Label).String(),
+				ContractAddress: keeper.BuildContractAddress(codeHash, senderAddr, msg.Label, msg.Msg).String(),
 				Info: types.ContractInfo{
 					CodeID:  msg.CodeID,
 					Creator: msg.Sender,
@@ -381,7 +381,7 @@ func hasContract(state *types.GenesisState, contractAddr string) bool {
 			if hash == nil {
 				panic(fmt.Sprintf("unknown code id: %d", msg.CodeID))
 			}
-			if keeper.BuildContractAddress(hash, senderAddr, msg.Label).String() == contractAddr {
+			if keeper.BuildContractAddress(hash, senderAddr, msg.Label, msg.Msg).String() == contractAddr {
 				return true
 			}
 		}

--- a/x/wasm/client/cli/genesis_msg_test.go
+++ b/x/wasm/client/cli/genesis_msg_test.go
@@ -367,7 +367,7 @@ func TestInstantiateContractCmd(t *testing.T) {
 
 func TestExecuteContractCmd(t *testing.T) {
 	mySenderAddr := sdk.AccAddress(bytes.Repeat([]byte{1}, address.Len))
-	myFirstContractAddress := keeper.BuildContractAddress([]byte("myCodeHash"), mySenderAddr, "my").String()
+	myFirstContractAddress := keeper.BuildContractAddress([]byte("myCodeHash"), mySenderAddr, "my", []byte(`{}`)).String()
 	minimalWasmGenesis := types.GenesisState{
 		Params: types.DefaultParams(),
 	}
@@ -585,17 +585,17 @@ func TestGetAllContracts(t *testing.T) {
 			src: types.GenesisState{
 				Codes: []types.Code{{CodeID: 1, CodeInfo: types.CodeInfo{CodeHash: []byte("firstCodeHash")}}},
 				GenMsgs: []types.GenesisState_GenMsgs{
-					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr1.String(), Label: "first", CodeID: 1}}},
-					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr2.String(), Label: "second", CodeID: 1}}},
+					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr1.String(), Label: "first", CodeID: 1, Msg: []byte(`{}`)}}},
+					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr2.String(), Label: "second", CodeID: 1, Msg: []byte(`{}`)}}},
 				},
 			},
 			exp: []ContractMeta{
 				{
-					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first").String(),
+					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first", []byte(`{}`)).String(),
 					Info:            types.ContractInfo{Creator: creatorAddr1.String(), Label: "first", CodeID: 1},
 				},
 				{
-					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr2, "second").String(),
+					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr2, "second", []byte(`{}`)).String(),
 					Info:            types.ContractInfo{Creator: creatorAddr2.String(), Label: "second", CodeID: 1},
 				},
 			},
@@ -608,21 +608,21 @@ func TestGetAllContracts(t *testing.T) {
 				},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first").String(),
+						ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first", []byte(`{}`)).String(),
 						ContractInfo:    types.ContractInfo{Label: "first", CodeID: 1},
 					},
 				},
 				GenMsgs: []types.GenesisState_GenMsgs{
-					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr1.String(), Label: "hundred", CodeID: 100}}},
+					{Sum: &types.GenesisState_GenMsgs_InstantiateContract{InstantiateContract: &types.MsgInstantiateContract{Sender: creatorAddr1.String(), Label: "hundred", CodeID: 100, Msg: []byte(`{"foo":"bar"}`)}}},
 				},
 			},
 			exp: []ContractMeta{
 				{
-					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first").String(),
+					ContractAddress: keeper.BuildContractAddress([]byte("firstCodeHash"), creatorAddr1, "first", []byte(`{}`)).String(),
 					Info:            types.ContractInfo{Label: "first", CodeID: 1},
 				},
 				{
-					ContractAddress: keeper.BuildContractAddress([]byte("otherCodeHash"), creatorAddr1, "hundred").String(),
+					ContractAddress: keeper.BuildContractAddress([]byte("otherCodeHash"), creatorAddr1, "hundred", []byte(`{"foo":"bar"}`)).String(),
 					Info:            types.ContractInfo{Creator: creatorAddr1.String(), Label: "hundred", CodeID: 100},
 				},
 			},

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -84,7 +84,7 @@ func TestGenesisExportImport(t *testing.T) {
 		}
 
 		contract.CodeID = codeID
-		contractAddr := BuildContractAddress(checksum, creatorAddr, "testing")
+		contractAddr := BuildContractAddress(checksum, creatorAddr, "testing", []byte(`{}`))
 		wasmKeeper.storeContractInfo(srcCtx, contractAddr, &contract)
 		wasmKeeper.appendToContractHistory(srcCtx, contractAddr, history...)
 		wasmKeeper.importContractState(srcCtx, contractAddr, stateModels)
@@ -278,7 +278,7 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 					},
 				},
@@ -298,10 +298,10 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 					}, {
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, "other-label").String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, "other-label", []byte(`{}`)).String(),
 						ContractInfo: myContractInfoFixture(func(i *wasmTypes.ContractInfo) {
 							i.Label = "other-label"
 						}),
@@ -318,7 +318,7 @@ func TestGenesisInit(t *testing.T) {
 			src: types.GenesisState{
 				Contracts: []types.Contract{
 					{
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 					},
 				},
@@ -334,10 +334,10 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 					}, {
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 					},
 				},
@@ -353,7 +353,7 @@ func TestGenesisInit(t *testing.T) {
 				}},
 				Contracts: []types.Contract{
 					{
-						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel).String(),
+						ContractAddress: BuildContractAddress(myCodeInfo.CodeHash, mySenderAddr, myLabel, []byte(`{}`)).String(),
 						ContractInfo:    myContractInfoFixture(),
 						ContractState: []types.Model{
 							{
@@ -560,7 +560,7 @@ func TestSupportedGenMsgTypes(t *testing.T) {
 		myAddress          sdk.AccAddress = bytes.Repeat([]byte{1}, types.ContractAddrLen)
 		verifierAddress    sdk.AccAddress = bytes.Repeat([]byte{2}, types.ContractAddrLen)
 		beneficiaryAddress sdk.AccAddress = bytes.Repeat([]byte{3}, types.ContractAddrLen)
-		contractAddr                      = BuildContractAddress(wasmHash[:], myAddress, "testing")
+		contractAddr                      = BuildContractAddress(wasmHash[:], myAddress, "testing", []byte(`{}`))
 	)
 	const denom = "stake"
 	importState := types.GenesisState{

--- a/x/wasm/keeper/ibc_test.go
+++ b/x/wasm/keeper/ibc_test.go
@@ -43,7 +43,7 @@ func TestBindingPortForIBCContractOnInstantiate(t *testing.T) {
 }
 
 func TestContractFromPortID(t *testing.T) {
-	contractAddr := BuildContractAddress(rand.Bytes(32), RandomAccountAddress(t), "testing")
+	contractAddr := BuildContractAddress(rand.Bytes(32), RandomAccountAddress(t), "testing", []byte(`{}`))
 	specs := map[string]struct {
 		srcPort string
 		expAddr sdk.AccAddress

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -589,7 +589,7 @@ func TestInstantiateWithUniqueContractAddress(t *testing.T) {
 				return
 			}
 			require.NoError(t, gotErr)
-			expAddr := BuildContractAddress(keepers.WasmKeeper.GetCodeInfo(ctx, spec.codeID).CodeHash, spec.sender, spec.label)
+			expAddr := BuildContractAddress(keepers.WasmKeeper.GetCodeInfo(ctx, spec.codeID).CodeHash, spec.sender, spec.label, []byte(spec.initMsg))
 			assert.Equal(t, expAddr.String(), gotAddr.String())
 			require.NotContains(t, used, gotAddr.String())
 			used[gotAddr.String()] = struct{}{}
@@ -606,7 +606,7 @@ func TestInstantiateWithAccounts(t *testing.T) {
 	senderAddr := DeterministicAccountAddress(t, 1)
 	keepers.Faucet.Fund(parentCtx, senderAddr, sdk.NewInt64Coin("denom", 100000000))
 	const myLabel = "testing"
-	contractAddr := BuildContractAddress(example.Checksum, senderAddr, myLabel)
+	contractAddr := BuildContractAddress(example.Checksum, senderAddr, myLabel, types.ExampleHackatomInitMsg())
 
 	lastAccountNumber := keepers.AccountKeeper.GetAccount(parentCtx, senderAddr).GetAccountNumber()
 
@@ -2010,6 +2010,7 @@ func TestBuildContractAddress(t *testing.T) {
 		checksum   []byte
 		label      string
 		creator    string
+		initMsg    []byte
 		expAddress string
 	}{
 		"initial account addr example": {
@@ -2073,6 +2074,7 @@ func TestBuildContractAddress(t *testing.T) {
 			creator:    "purple1nxvenxve42424242hwamhwamenxvenxvhxf2py",
 			expAddress: "purple1prkdvjmvv4s3tnppfxmlpj259v9cplf3wws4qq9qd7w3s4yqzqeqem4759",
 		},
+		// todo: add examples with init message
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
@@ -2080,7 +2082,7 @@ func TestBuildContractAddress(t *testing.T) {
 			require.NoError(t, err)
 
 			// when
-			gotAddr := BuildContractAddress(spec.checksum, creatorAddr, spec.label)
+			gotAddr := BuildContractAddress(spec.checksum, creatorAddr, spec.label, spec.initMsg)
 
 			require.Equal(t, spec.expAddress, gotAddr.String())
 			require.NoError(t, sdk.VerifyAddressFormat(gotAddr))

--- a/x/wasm/keeper/proposal_integration_test.go
+++ b/x/wasm/keeper/proposal_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -104,6 +105,7 @@ func TestInstantiateProposal(t *testing.T) {
 		p.RunAs = oneAddress.String()
 		p.Admin = otherAddress.String()
 		p.Label = "testing"
+		p.Msg = types.ExampleHackatomInitMsg()
 	})
 	em := sdk.NewEventManager()
 
@@ -118,7 +120,7 @@ func TestInstantiateProposal(t *testing.T) {
 
 	// then
 	codeHash := keepers.WasmKeeper.GetCodeInfo(ctx, 1).CodeHash
-	contractAddr := BuildContractAddress(codeHash, oneAddress, "testing")
+	contractAddr := BuildContractAddress(codeHash, oneAddress, "testing", types.ExampleHackatomInitMsg())
 	cInfo := wasmKeeper.GetContractInfo(ctx, contractAddr)
 	require.NotNil(t, cInfo)
 	assert.Equal(t, uint64(1), cInfo.CodeID)
@@ -165,6 +167,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 		p.RunAs = oneAddress.String()
 		p.Admin = "invalid"
 		p.Label = "testing"
+		p.Msg = types.ExampleHackatomInitMsg()
 	})
 	_, err = govKeeper.SubmitProposal(ctx, src)
 	require.Error(t, err)
@@ -175,6 +178,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 		p.RunAs = oneAddress.String()
 		p.Admin = ""
 		p.Label = "testing"
+		p.Msg = types.ExampleHackatomInitMsg()
 	})
 	em := sdk.NewEventManager()
 
@@ -189,7 +193,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 
 	// then
 	codeHash := keepers.WasmKeeper.GetCodeInfo(ctx, 1).CodeHash
-	contractAddr := BuildContractAddress(codeHash, oneAddress, "testing")
+	contractAddr := BuildContractAddress(codeHash, oneAddress, "testing", types.ExampleHackatomInitMsg())
 	cInfo := wasmKeeper.GetContractInfo(ctx, contractAddr)
 	require.NotNil(t, cInfo)
 	assert.Equal(t, uint64(1), cInfo.CodeID)
@@ -230,7 +234,7 @@ func TestMigrateProposal(t *testing.T) {
 	var (
 		anyAddress   = DeterministicAccountAddress(t, 1)
 		otherAddress = DeterministicAccountAddress(t, 2)
-		contractAddr = BuildContractAddress(codeInfoFixture.CodeHash, RandomAccountAddress(t), "")
+		contractAddr = BuildContractAddress(codeInfoFixture.CodeHash, RandomAccountAddress(t), "", []byte(fmt.Sprintf(`{"verifier":"%s","beneficiary":"%s"}`, DeterministicAccountAddress(t, 1).String(), DeterministicAccountAddress(t, 1).String())))
 	)
 
 	contractInfoFixture := types.ContractInfoFixture(func(c *types.ContractInfo) {
@@ -412,7 +416,7 @@ func TestAdminProposals(t *testing.T) {
 	var (
 		otherAddress = DeterministicAccountAddress(t, 2)
 		codeHash     = sha256.Sum256(wasmCode)
-		contractAddr = BuildContractAddress(codeHash[:], RandomAccountAddress(t), "")
+		contractAddr = BuildContractAddress(codeHash[:], RandomAccountAddress(t), "", types.ExampleHackatomInitMsg())
 	)
 
 	specs := map[string]struct {

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -159,7 +159,7 @@ func TestQuerySmartContractState(t *testing.T) {
 func TestQuerySmartContractPanics(t *testing.T) {
 	ctx, keepers := CreateTestInput(t, false, AvailableCapabilities)
 	creator := RandomAccountAddress(t)
-	contractAddr := BuildContractAddress([]byte("myCodeHash"), creator, "testing")
+	contractAddr := BuildContractAddress([]byte("myCodeHash"), creator, "testing", []byte(`{}`))
 	keepers.WasmKeeper.storeCodeInfo(ctx, 1, types.CodeInfo{CodeHash: []byte("myCodeHash")})
 	keepers.WasmKeeper.storeContractInfo(ctx, contractAddr, &types.ContractInfo{
 		CodeID:  1,

--- a/x/wasm/types/test_fixtures.go
+++ b/x/wasm/types/test_fixtures.go
@@ -191,24 +191,25 @@ func StoreCodeProposalFixture(mutators ...func(*StoreCodeProposal)) *StoreCodePr
 	return p
 }
 
-func InstantiateContractProposalFixture(mutators ...func(p *InstantiateContractProposal)) *InstantiateContractProposal {
-	var (
-		anyValidAddress sdk.AccAddress = bytes.Repeat([]byte{0x1}, ContractAddrLen)
-
-		initMsg = struct {
-			Verifier    sdk.AccAddress `json:"verifier"`
-			Beneficiary sdk.AccAddress `json:"beneficiary"`
-		}{
-			Verifier:    anyValidAddress,
-			Beneficiary: anyValidAddress,
-		}
-	)
-	const anyAddress = "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs2m6sx4"
-
-	initMsgBz, err := json.Marshal(initMsg)
+// ExampleHackatomInitMsg deterministic init message to be used for tests only
+func ExampleHackatomInitMsg() []byte {
+	var anyValidAddress sdk.AccAddress = bytes.Repeat([]byte{0x1}, ContractAddrLen)
+	r, err := json.Marshal(struct {
+		Verifier    sdk.AccAddress `json:"verifier"`
+		Beneficiary sdk.AccAddress `json:"beneficiary"`
+	}{
+		Verifier:    anyValidAddress,
+		Beneficiary: anyValidAddress,
+	})
 	if err != nil {
 		panic(err)
 	}
+	return r
+}
+
+func InstantiateContractProposalFixture(mutators ...func(p *InstantiateContractProposal)) *InstantiateContractProposal {
+	const anyAddress = "cosmos1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs2m6sx4"
+
 	p := &InstantiateContractProposal{
 		Title:       "Foo",
 		Description: "Bar",
@@ -216,7 +217,7 @@ func InstantiateContractProposalFixture(mutators ...func(p *InstantiateContractP
 		Admin:       anyAddress,
 		CodeID:      1,
 		Label:       "testing",
-		Msg:         initMsgBz,
+		Msg:         ExampleHackatomInitMsg(),
 		Funds:       nil,
 	}
 


### PR DESCRIPTION
🚧 Early version - tests need to be fixed

See changes in [`keeper.go`](https://github.com/CosmWasm/wasmd/pull/1008/files#diff-4e16010ab332946722b789b22962fb5a0814d529cd8de443b925d20ccd13705f)

Resolves part of #1000 
