### PR TITLE
Revert module version to 1 as there is no migration anymore

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -773,7 +773,17 @@ func NewWasmApp(
 // Name returns the name of the App
 func (app *WasmApp) Name() string { return app.BaseApp.Name() }
 
-// application updates every begin block
+// ModuleManager returns instance
+func (app *WasmApp) ModuleManager() module.Manager {
+	return *app.mm
+}
+
+// ModuleConfigurator returns instance
+func (app *WasmApp) ModuleConfigurator() module.Configurator {
+	return app.configurator
+}
+
+// BeginBlocker application updates every begin block
 func (app *WasmApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)
 }

--- a/x/wasm/module.go
+++ b/x/wasm/module.go
@@ -111,7 +111,7 @@ type AppModule struct {
 // module. It should be incremented on each consensus-breaking change
 // introduced by the module. To avoid wrong/empty versions, the initial version
 // should be set to 1.
-func (AppModule) ConsensusVersion() uint64 { return 2 }
+func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // NewAppModule creates a new AppModule object
 func NewAppModule(

--- a/x/wasm/module_integration_test.go
+++ b/x/wasm/module_integration_test.go
@@ -1,0 +1,31 @@
+package wasm_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
+	"github.com/CosmWasm/wasmd/app"
+	"github.com/CosmWasm/wasmd/x/wasm"
+)
+
+func TestModuleMigrations(t *testing.T) {
+	wasmApp := app.Setup(false)
+	ctx := wasmApp.BaseApp.NewContext(false, tmproto.Header{})
+	upgradeHandler := func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return wasmApp.ModuleManager().RunMigrations(ctx, wasmApp.ModuleConfigurator(), fromVM)
+	}
+	fromVM := wasmApp.UpgradeKeeper.GetModuleVersionMap(ctx)
+	fromVM[wasm.ModuleName] = 1 // start with initial version
+	upgradeHandler(ctx, upgradetypes.Plan{Name: "testing"}, fromVM)
+	// when
+	gotVM, err := wasmApp.ModuleManager().RunMigrations(ctx, wasmApp.ModuleConfigurator(), fromVM)
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), gotVM[wasm.ModuleName])
+}


### PR DESCRIPTION
> In RC0, the wasmd module was bumped to version '2' with a migration. In RC1 the migration was dropped as we restored the "classic" contract address generation process. Though I kept the module version at '2' for testnets running RC0 (Juno). 

This PR reverts the module version to `1`