### PR TITLE
Register any-of-address flag for gov

### DIFF
--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -87,6 +87,7 @@ func ProposalStoreCodeCmd() *cobra.Command {
 	cmd.Flags().String(flagInstantiateByEverybody, "", "Everybody can instantiate a contract from the code, optional")
 	cmd.Flags().String(flagInstantiateNobody, "", "Nobody except the governance process can instantiate a contract from the code, optional")
 	cmd.Flags().String(flagInstantiateByAddress, "", "Only this address can instantiate a contract instance from the code, optional")
+	cmd.Flags().StringSlice(flagInstantiateByAnyOfAddress, []string{}, "Any of the addresses can instantiate a contract from the code, optional")
 	cmd.Flags().Bool(flagUnpinCode, false, "Unpin code on upload, optional")
 
 	// proposal flags


### PR DESCRIPTION
Resolves #1078 
Fixes the missing flag registration for cli gov

Tested manually with a custom wasmd that has '-X github.com/CosmWasm/wasmd/app.ProposalsEnabled=true' set: 
```sh
wasmd tx gov submit-proposal wasm-store "$DIR/../../x/wasm/keeper/testdata/hackatom.wasm" \
  --title "testing" --description "Testing" --deposit "1000000000stake" \
  --run-as $(wasmd keys show -a validator) \
  --from validator --gas auto --gas-adjustment=1.5 -y  --chain-id=testing --node=http://localhost:26657 -b block -o json
```