### PR TITLE
Add extension point for ibc app version decoding

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -564,7 +564,7 @@ func NewWasmApp(
 
 	// Create fee enabled wasm ibc Stack
 	var wasmStack porttypes.IBCModule
-	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper)
+	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.IBCKeeper.ChannelKeeper, wasm.ICS29AppVersionDecoder(app.IBCFeeKeeper))
 	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.IBCFeeKeeper)
 
 	// Create static IBC router, add app routes, then set and seal it

--- a/x/wasm/ibc_middleware_support.go
+++ b/x/wasm/ibc_middleware_support.go
@@ -1,0 +1,68 @@
+package wasm
+
+import (
+	"encoding/json"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibcfees "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/types"
+	channeltypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+var _ IBCAppVersionDecoder = AppVersionDecoderFn(nil)
+
+// AppVersionDecoderFn custom type that implements IBCAppVersionDecoder
+type AppVersionDecoderFn func(ctx sdk.Context, rawVersion, portID, channelID string) (string, error)
+
+// Decode implements IBCAppVersionDecoder.Decode
+func (a AppVersionDecoderFn) Decode(ctx sdk.Context, rawVersion, portID, channelID string) (string, error) {
+	return a(ctx, rawVersion, portID, channelID)
+}
+
+// AppVersionDecoderChain set up a chain of decoders where output of decoder n is feeded into n+1 as raw version
+// until the last one is reached
+func AppVersionDecoderChain(decoders ...IBCAppVersionDecoder) IBCAppVersionDecoder {
+	if len(decoders) == 0 {
+		panic("decoders must not be empty")
+	}
+	return AppVersionDecoderFn(func(ctx sdk.Context, rawVersion, portID, channelID string) (string, error) {
+		version := rawVersion
+		var err error
+		for _, d := range decoders {
+			version, err = d.Decode(ctx, version, portID, channelID)
+			if err != nil {
+				return "", err
+			}
+		}
+		return version, nil
+	})
+}
+
+// ICS29AppVersionDecoder decodes the ibc app version from an ics-29 fee middleware version when supported
+// fallback is raw version when it can not be determined
+func ICS29AppVersionDecoder(channelSource interface {
+	IsFeeEnabled(ctx sdk.Context, portID, channelID string) bool
+},
+) IBCAppVersionDecoder {
+	return AppVersionDecoderFn(func(ctx sdk.Context, rawVersion, portID, channelID string) (string, error) {
+		if channelSource.IsFeeEnabled(ctx, portID, channelID) {
+			var meta ibcfees.Metadata
+			if err := types.ModuleCdc.UnmarshalJSON([]byte(rawVersion), &meta); err != nil {
+				return "", channeltypes.ErrInvalidChannelVersion
+			}
+			return meta.AppVersion, nil
+		}
+		if strings.TrimSpace(rawVersion) != "" && json.Valid([]byte(rawVersion)) {
+			// check for ics-29 middleware versions
+			var versionMetadata ibcfees.Metadata
+			if err := types.ModuleCdc.UnmarshalJSON([]byte(rawVersion), &versionMetadata); err == nil {
+				if strings.HasPrefix(versionMetadata.FeeVersion, "ics29-") { // sanity check
+					return versionMetadata.AppVersion, nil
+				}
+			}
+		}
+		return rawVersion, nil
+	})
+}

--- a/x/wasm/ibc_middleware_support_test.go
+++ b/x/wasm/ibc_middleware_support_test.go
@@ -1,0 +1,103 @@
+package wasm
+
+import (
+	"errors"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppVersionDecoderChain(t *testing.T) {
+	dropLastCharDec := AppVersionDecoderFn(func(_ sdk.Context, rawVersion, _, _ string) (string, error) {
+		return rawVersion[0 : len(rawVersion)-1], nil
+	})
+	alwaysErrDec := AppVersionDecoderFn(func(_ sdk.Context, rawVersion, _, _ string) (string, error) {
+		return "", errors.New("testing")
+	})
+	specs := map[string]struct {
+		dec        IBCAppVersionDecoder
+		rawVersion string
+		expVersion string
+		expErr     bool
+	}{
+		"single decoder": {
+			dec:        AppVersionDecoderChain(ICS29AppVersionDecoder(IsFeeEnabledMock{true})),
+			rawVersion: `{"fee_version":"ics29-1", "app_version":"my version"}`,
+			expVersion: "my version",
+		},
+		"multiple decoders": {
+			dec:        AppVersionDecoderChain(ICS29AppVersionDecoder(IsFeeEnabledMock{true}), dropLastCharDec, dropLastCharDec),
+			rawVersion: `{"fee_version":"ics29-1", "app_version":"123"}`,
+			expVersion: "1",
+		},
+		"multiple decoders with err": {
+			dec:    AppVersionDecoderChain(ICS29AppVersionDecoder(IsFeeEnabledMock{true}), alwaysErrDec, dropLastCharDec),
+			expErr: true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			gotVersion, gotErr := spec.dec.Decode(sdk.Context{}, spec.rawVersion, "foo", "bar")
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+			assert.Equal(t, spec.expVersion, gotVersion)
+		})
+	}
+}
+
+func TestICS29AppVersionDecoder(t *testing.T) {
+	specs := map[string]struct {
+		rawVersion   string
+		isFeeChannel bool
+		expVersion   string
+		expErr       bool
+	}{
+		"raw version": {
+			rawVersion: "my version",
+			expVersion: "my version",
+		},
+		"ics29 version on fee channel": {
+			rawVersion:   `{"fee_version":"ics29-1", "app_version":"my version"}`,
+			isFeeChannel: true,
+			expVersion:   "my version",
+		},
+		"invalid ics29 version on fee channel": {
+			rawVersion:   `not-a-json-string`,
+			isFeeChannel: true,
+			expErr:       true,
+		},
+		"ics29 version on non fee channel": {
+			rawVersion: `{"fee_version":"ics29-1", "app_version":"my version"}`,
+			expVersion: "my version",
+		},
+		"non ics29 version on non fee channel": {
+			rawVersion: `{"fee_version":"alx29-1", "app_version":"my version"}`,
+			expVersion: `{"fee_version":"alx29-1", "app_version":"my version"}`,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			gotVersion, gotErr := ICS29AppVersionDecoder(IsFeeEnabledMock{spec.isFeeChannel}).
+				Decode(sdk.Context{}, spec.rawVersion, "foo", "bar")
+			if spec.expErr {
+				require.Error(t, gotErr)
+				return
+			}
+			require.NoError(t, gotErr)
+			assert.Equal(t, spec.expVersion, gotVersion)
+		})
+	}
+}
+
+type IsFeeEnabledMock struct {
+	result bool
+}
+
+func (f IsFeeEnabledMock) IsFeeEnabled(_ sdk.Context, _, _ string) bool {
+	return f.result
+}


### PR DESCRIPTION
After #1088 

The version string stored with the channel can be overloaded with ibc middleware data. This PR adds an extension point to add a custom decoder to return the original IBC app level version.
* ICS29AppVersionDecoder - supports the fee middleware
* AppVersionDecoderChain - util to chain decoders as you can do with middleware and cascade output