### PR TITLE
Add gov proposal simulations

### DIFF
--- a/app/params/weights.go
+++ b/app/params/weights.go
@@ -28,9 +28,15 @@ const (
 	DefaultWeightMsgClearAdmin          int = 10
 	DefaultWeightMsgMigrateContract     int = 50
 
-	DefaultWeightStoreCodeProposal           int = 5
-	DefaultWeightInstantiateContractProposal int = 5
-	DefaultWeightUpdateAdminProposal         int = 5
-	DefaultWeightExecuteContractProposal     int = 5
-	DefaultWeightClearAdminProposal          int = 5
+	DefaultWeightStoreCodeProposal                   int = 5
+	DefaultWeightInstantiateContractProposal         int = 5
+	DefaultWeightUpdateAdminProposal                 int = 5
+	DefaultWeightExecuteContractProposal             int = 5
+	DefaultWeightClearAdminProposal                  int = 5
+	DefaultWeightMigrateContractProposal             int = 5
+	DefaultWeightSudoContractProposal                int = 5
+	DefaultWeightPinCodesProposal                    int = 5
+	DefaultWeightUnpinCodesProposal                  int = 5
+	DefaultWeightUpdateInstantiateConfigProposal     int = 5
+	DefaultWeightStoreAndInstantiateContractProposal int = 5
 )

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -86,6 +86,14 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulateContractSelector,
 			),
 		),
+		simulation.NewWeightedProposalContent(
+			WeightPinCodesProposal,
+			params.DefaultWeightPinCodesProposal,
+			SimulatePinContractProposal(
+				wasmKeeper,
+				DefaultSimulationCodeIDSelector,
+			),
+		),
 	}
 }
 
@@ -287,6 +295,22 @@ func SimulateSudoContractProposal(wasmKeeper WasmKeeper, contractSelector SudoCo
 			simtypes.RandStringOfLength(r, 10),
 			ctAddress.String(),
 			[]byte(`{}`),
+		)
+	}
+}
+
+// Simulate pin contract proposal
+func SimulatePinContractProposal(wasmKeeper WasmKeeper, codeSelector CodeIDSelector) simtypes.ContentSimulatorFn {
+	return func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) simtypes.Content {
+		codeID := codeSelector(ctx, wasmKeeper)
+		if codeID == 0 {
+			return nil
+		}
+
+		return types.NewPinCodesProposal(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			[]uint64{codeID},
 		)
 	}
 }

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -110,6 +110,13 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulationCodeIDSelector,
 			),
 		),
+		simulation.NewWeightedProposalContent(
+			WeightStoreAndInstantiateContractProposal,
+			params.DefaultWeightStoreAndInstantiateContractProposal,
+			SimulateStoreAndInstantiateContractProposal(
+				wasmKeeper,
+			),
+		),
 	}
 }
 
@@ -368,6 +375,32 @@ func SimulateUpdateInstantiateConfigProposal(wasmKeeper WasmKeeper, codeSelector
 			simtypes.RandStringOfLength(r, 10),
 			simtypes.RandStringOfLength(r, 10),
 			[]types.AccessConfigUpdate{configUpdate},
+		)
+	}
+}
+
+func SimulateStoreAndInstantiateContractProposal(wasmKeeper WasmKeeper) simtypes.ContentSimulatorFn {
+	return func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) simtypes.Content {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		adminAccount, _ := simtypes.RandomAcc(r, accs)
+
+		wasmBz := testdata.ReflectContractWasm()
+		permission := wasmKeeper.GetParams(ctx).InstantiateDefaultPermission.With(simAccount.Address)
+
+		return types.NewStoreAndInstantiateContractProposal(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			simAccount.Address.String(),
+			wasmBz,
+			"",
+			"",
+			[]byte{},
+			&permission,
+			false,
+			adminAccount.Address.String(),
+			simtypes.RandStringOfLength(r, 10),
+			[]byte(`{}`),
+			sdk.Coins{},
 		)
 	}
 }

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -94,6 +94,14 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulationCodeIDSelector,
 			),
 		),
+		simulation.NewWeightedProposalContent(
+			WeightUnpinCodesProposal,
+			params.DefaultWeightUnpinCodesProposal,
+			SimulateUnpinContractProposal(
+				wasmKeeper,
+				DefaultSimulationCodeIDSelector,
+			),
+		),
 	}
 }
 
@@ -308,6 +316,22 @@ func SimulatePinContractProposal(wasmKeeper WasmKeeper, codeSelector CodeIDSelec
 		}
 
 		return types.NewPinCodesProposal(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			[]uint64{codeID},
+		)
+	}
+}
+
+// Simulate unpin contract proposal
+func SimulateUnpinContractProposal(wasmKeeper WasmKeeper, codeSelector CodeIDSelector) simtypes.ContentSimulatorFn {
+	return func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) simtypes.Content {
+		codeID := codeSelector(ctx, wasmKeeper)
+		if codeID == 0 {
+			return nil
+		}
+
+		return types.NewUnpinCodesProposal(
 			simtypes.RandStringOfLength(r, 10),
 			simtypes.RandStringOfLength(r, 10),
 			[]uint64{codeID},

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -102,6 +102,14 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulationCodeIDSelector,
 			),
 		),
+		simulation.NewWeightedProposalContent(
+			WeightUpdateInstantiateConfigProposal,
+			params.DefaultWeightUpdateInstantiateConfigProposal,
+			SimulateUpdateInstantiateConfigProposal(
+				wasmKeeper,
+				DefaultSimulationCodeIDSelector,
+			),
+		),
 	}
 }
 
@@ -335,6 +343,31 @@ func SimulateUnpinContractProposal(wasmKeeper WasmKeeper, codeSelector CodeIDSel
 			simtypes.RandStringOfLength(r, 10),
 			simtypes.RandStringOfLength(r, 10),
 			[]uint64{codeID},
+		)
+	}
+}
+
+// Simulate update instantiate config proposal
+func SimulateUpdateInstantiateConfigProposal(wasmKeeper WasmKeeper, codeSelector CodeIDSelector) simtypes.ContentSimulatorFn {
+	return func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) simtypes.Content {
+		codeID := codeSelector(ctx, wasmKeeper)
+		if codeID == 0 {
+			return nil
+		}
+
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		permission := wasmKeeper.GetParams(ctx).InstantiateDefaultPermission
+		config := permission.With(simAccount.Address)
+
+		configUpdate := types.AccessConfigUpdate{
+			CodeID:                codeID,
+			InstantiatePermission: config,
+		}
+
+		return types.NewUpdateInstantiateConfigProposal(
+			simtypes.RandStringOfLength(r, 10),
+			simtypes.RandStringOfLength(r, 10),
+			[]types.AccessConfigUpdate{configUpdate},
 		)
 	}
 }

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -78,14 +78,14 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulationCodeIDSelector,
 			),
 		),
-		simulation.NewWeightedProposalContent(
-			WeightSudoContractProposal,
-			params.DefaultWeightSudoContractProposal,
-			SimulateSudoContractProposal(
-				wasmKeeper,
-				DefaultSimulateContractSelector,
-			),
-		),
+		// simulation.NewWeightedProposalContent(
+		//	WeightSudoContractProposal,
+		//	params.DefaultWeightSudoContractProposal,
+		//	SimulateSudoContractProposal(
+		//		wasmKeeper,
+		//		DefaultSimulateContractSelector,
+		//	),
+		// ),
 		simulation.NewWeightedProposalContent(
 			WeightPinCodesProposal,
 			params.DefaultWeightPinCodesProposal,
@@ -110,13 +110,13 @@ func ProposalContents(bk BankKeeper, wasmKeeper WasmKeeper) []simtypes.WeightedP
 				DefaultSimulationCodeIDSelector,
 			),
 		),
-		simulation.NewWeightedProposalContent(
-			WeightStoreAndInstantiateContractProposal,
-			params.DefaultWeightStoreAndInstantiateContractProposal,
-			SimulateStoreAndInstantiateContractProposal(
-				wasmKeeper,
-			),
-		),
+		// simulation.NewWeightedProposalContent(
+		//	WeightStoreAndInstantiateContractProposal,
+		//	params.DefaultWeightStoreAndInstantiateContractProposal,
+		//	SimulateStoreAndInstantiateContractProposal(
+		//		wasmKeeper,
+		//	),
+		// ),
 	}
 }
 

--- a/x/wasm/simulation/proposals.go
+++ b/x/wasm/simulation/proposals.go
@@ -374,7 +374,7 @@ func SimulateUpdateInstantiateConfigProposal(wasmKeeper WasmKeeper, codeSelector
 		return types.NewUpdateInstantiateConfigProposal(
 			simtypes.RandStringOfLength(r, 10),
 			simtypes.RandStringOfLength(r, 10),
-			[]types.AccessConfigUpdate{configUpdate},
+			configUpdate,
 		)
 	}
 }

--- a/x/wasm/types/proposal.go
+++ b/x/wasm/types/proposal.go
@@ -821,7 +821,7 @@ func validateProposalCommons(title, description string) error {
 func NewUpdateInstantiateConfigProposal(
 	title string,
 	description string,
-	accessConfigUpdates []AccessConfigUpdate,
+	accessConfigUpdates ...AccessConfigUpdate,
 ) *UpdateInstantiateConfigProposal {
 	return &UpdateInstantiateConfigProposal{
 		Title:               title,

--- a/x/wasm/types/proposal.go
+++ b/x/wasm/types/proposal.go
@@ -411,6 +411,22 @@ func (p StoreAndInstantiateContractProposal) MarshalYAML() (interface{}, error) 
 	}, nil
 }
 
+func NewMigrateContractProposal(
+	title string,
+	description string,
+	contract string,
+	codeID uint64,
+	msg RawContractMessage,
+) *MigrateContractProposal {
+	return &MigrateContractProposal{
+		Title:       title,
+		Description: description,
+		Contract:    contract,
+		CodeID:      codeID,
+		Msg:         msg,
+	}
+}
+
 // ProposalRoute returns the routing key of a parameter change proposal.
 func (p MigrateContractProposal) ProposalRoute() string { return RouterKey }
 
@@ -466,6 +482,20 @@ func (p MigrateContractProposal) MarshalYAML() (interface{}, error) {
 		CodeID:      p.CodeID,
 		Msg:         string(p.Msg),
 	}, nil
+}
+
+func NewSudoContractProposal(
+	title string,
+	description string,
+	contract string,
+	msg RawContractMessage,
+) *SudoContractProposal {
+	return &SudoContractProposal{
+		Title:       title,
+		Description: description,
+		Contract:    contract,
+		Msg:         msg,
+	}
 }
 
 // ProposalRoute returns the routing key of a parameter change proposal.
@@ -678,6 +708,18 @@ func (p ClearAdminProposal) String() string {
 `, p.Title, p.Description, p.Contract)
 }
 
+func NewPinCodesProposal(
+	title string,
+	description string,
+	codeIDs []uint64,
+) *PinCodesProposal {
+	return &PinCodesProposal{
+		Title:       title,
+		Description: description,
+		CodeIDs:     codeIDs,
+	}
+}
+
 // ProposalRoute returns the routing key of a parameter change proposal.
 func (p PinCodesProposal) ProposalRoute() string { return RouterKey }
 
@@ -708,6 +750,18 @@ func (p PinCodesProposal) String() string {
   Description: %s
   Codes:       %v
 `, p.Title, p.Description, p.CodeIDs)
+}
+
+func NewUnpinCodesProposal(
+	title string,
+	description string,
+	codeIDs []uint64,
+) *UnpinCodesProposal {
+	return &UnpinCodesProposal{
+		Title:       title,
+		Description: description,
+		CodeIDs:     codeIDs,
+	}
 }
 
 // ProposalRoute returns the routing key of a parameter change proposal.
@@ -762,6 +816,18 @@ func validateProposalCommons(title, description string) error {
 		return sdkerrors.Wrapf(govtypes.ErrInvalidProposalContent, "proposal description is longer than max length of %d", govtypes.MaxDescriptionLength)
 	}
 	return nil
+}
+
+func NewUpdateInstantiateConfigProposal(
+	title string,
+	description string,
+	accessConfigUpdates []AccessConfigUpdate,
+) *UpdateInstantiateConfigProposal {
+	return &UpdateInstantiateConfigProposal{
+		Title:               title,
+		Description:         description,
+		AccessConfigUpdates: accessConfigUpdates,
+	}
 }
 
 // ProposalRoute returns the routing key of a parameter change proposal.


### PR DESCRIPTION
Part of #1063 
Add gov proposal simulations:
- migrate contract proposal
- pin contract proposal
- unpin contract proposal
- update instantiate config proposal
- sudo contract proposal **(commented out because it fails)**
- store and instantiate contract proposal **(commented out because it fails)**