### PR TITLE
Run unit tests on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,19 @@ jobs:
       - run:
           name: Build
           command: |
+            set -o errexit
             LEDGER_ENABLED=false make build
+      - run:
+          name: Check libwasmvm-version
+          command: |
+            set -o errexit
+            ./build/wasmd version
+            ./build/wasmd query wasm libwasmvm-version
+      - run:
+          name: Test
+          command: |
+            set -o errexit
+            make test
 
   benchmark:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@5.0
+
 executors:
   golang:
     docker:
@@ -95,6 +98,25 @@ jobs:
             - "profiles/*"
       - store_artifacts:
           path: /tmp/logs
+
+  test-windows:
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - run:
+          name: Install make
+          command: choco install make
+      - run:
+          name: Show Go version information
+          command: |
+            go version
+            make --version
+      - run:
+          name: Build
+          command: |
+            make build
 
   benchmark:
     executor: golang
@@ -241,3 +263,4 @@ workflows:
       - simulations:
           requires:
             - setup-dependencies
+      - test-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,13 @@ jobs:
             set -o errexit
             ./build/wasmd.exe version
             ./build/wasmd.exe query wasm libwasmvm-version
+      - run:
+          name: Test
+          # Copy wasmvm.dll to system dir because we don't know the full path of the test binary
+          command: |
+            set -o errexit
+            /usr/bin/find $HOME/go/pkg/mod/github.com/ -name wasmvm.dll -exec cp "{}" /c/Windows/System32 \;
+            make test
 
   benchmark:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,12 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install make
-          command: choco install make
+          name: Install make and mingw
+          # See https://github.com/docker/containerd-packaging/pull/294 for discussion around mingw version
+          command: |
+            set -o errexit
+            choco install -y make
+            choco install -y mingw --version 10.2.0 --allow-downgrade
       - run:
           name: Show Go version information
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,16 +124,22 @@ jobs:
             set -o errexit
             LEDGER_ENABLED=false make build
       - run:
+          name: Copy wasmvm.dll to  build folder (next to wasmd.exe)
+          command: |
+            set -o errexit
+            /usr/bin/find $HOME/go/pkg/mod/github.com/ -name wasmvm.dll -exec cp "{}" build/ \;
+      - run:
           name: Check libwasmvm-version
           command: |
             set -o errexit
-            ./build/wasmd version
-            ./build/wasmd query wasm libwasmvm-version
-      - run:
-          name: Test
-          command: |
-            set -o errexit
-            make test
+            ./build/wasmd.exe version
+            ./build/wasmd.exe query wasm libwasmvm-version
+      # Fails with 'exit status 0xc0000135', i.e. the .dll is not found
+      # - run:
+      #     name: Test
+      #     command: |
+      #       set -o errexit
+      #       make test
 
   benchmark:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run:
           name: Build
           command: |
-            make build
+            LEDGER_ENABLED=false make build
 
   benchmark:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
   setup-dependencies:
     executor: golang
     steps:
-      - run: exit 1 # Disable this job and all its dependents
       - checkout
       - restore_cache:
           name: "Restore go modules cache"
@@ -134,12 +133,6 @@ jobs:
             set -o errexit
             ./build/wasmd.exe version
             ./build/wasmd.exe query wasm libwasmvm-version
-      # Fails with 'exit status 0xc0000135', i.e. the .dll is not found
-      # - run:
-      #     name: Test
-      #     command: |
-      #       set -o errexit
-      #       make test
 
   benchmark:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
   setup-dependencies:
     executor: golang
     steps:
+      - run: exit 1 # Disable this job and all its dependents
       - checkout
       - restore_cache:
           name: "Restore go modules cache"

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ all: install lint test
 
 build: go.sum
 ifeq ($(OS),Windows_NT)
-	exit 1
+	go build -mod=readonly $(BUILD_FLAGS) -o build/wasmd.exe ./cmd/wasmd
 else
 	go build -mod=readonly $(BUILD_FLAGS) -o build/wasmd ./cmd/wasmd
 endif

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -59,10 +59,12 @@ func setup(t testing.TB, withGenesis bool, invCheckPeriod uint, opts ...wasm.Opt
 	snapshotDir := filepath.Join(nodeHome, "data", "snapshots")
 	snapshotDB, err := sdk.NewLevelDB("metadata", snapshotDir)
 	require.NoError(t, err)
+	t.Cleanup(func() { snapshotDB.Close() })
 	snapshotStore, err := snapshots.NewStore(snapshotDB, snapshotDir)
 	require.NoError(t, err)
 	baseAppOpts := []func(*bam.BaseApp){bam.SetSnapshotStore(snapshotStore), bam.SetSnapshotKeepRecent(2)}
 	db := dbm.NewMemDB()
+	t.Cleanup(func() { db.Close() })
 	app := NewWasmApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, nodeHome, invCheckPeriod, MakeEncodingConfig(), wasm.EnableAllProposals, EmptyBaseAppOptions{}, opts, baseAppOpts...)
 	if withGenesis {
 		return app, NewDefaultGenesisState()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.19
 
 require (
-	github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6
+	github.com/CosmWasm/wasmvm v1.1.2-0.20221130134100-af1e10ee7bb3
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/cosmos-sdk v0.45.11
 	github.com/cosmos/gogoproto v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.19
 
 require (
-	github.com/CosmWasm/wasmvm v1.1.1
+	github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/cosmos-sdk v0.45.11
 	github.com/cosmos/gogoproto v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v1.1.1 h1:0xtdrmmsP9fibe+x42WcMkp5aQ738BICgcH3FNVLzm4=
-github.com/CosmWasm/wasmvm v1.1.1/go.mod h1:ei0xpvomwSdONsxDuONzV7bL1jSET1M8brEx0FCXc+A=
+github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6 h1:l/TeEThJGvSboam0t/vAg7EZcfjIFsbpZyYqydUh99Y=
+github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6/go.mod h1:OIhXFPi9BbcEL1USBj4OIrBTtSSds+9eEql56fsdyfE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6 h1:l/TeEThJGvSboam0t/vAg7EZcfjIFsbpZyYqydUh99Y=
-github.com/CosmWasm/wasmvm v1.1.2-0.20221127235710-6dd44ce800a6/go.mod h1:OIhXFPi9BbcEL1USBj4OIrBTtSSds+9eEql56fsdyfE=
+github.com/CosmWasm/wasmvm v1.1.2-0.20221130134100-af1e10ee7bb3 h1:3/j1ovbHGsXsAEO79vLLPkEJCko/U+SQ7r9t0L00Wc0=
+github.com/CosmWasm/wasmvm v1.1.2-0.20221130134100-af1e10ee7bb3/go.mod h1:OIhXFPi9BbcEL1USBj4OIrBTtSSds+9eEql56fsdyfE=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=


### PR DESCRIPTION
This is a follow-up of #1110 (merge that first, then rebase this PR). The main point here is that we are running wasmd unit-tests on Windows. This works more or less. But a lot of tests are failing.

A lot of failures look something like this:

>     testing.go:1097: TempDir RemoveAll cleanup: remove C:\Users\CIRCLE~1.PAC\AppData\Local\Temp\TestPinPong2683230876\001\data\snapshots\metadata.db\000001.log: The process cannot access the file because it is being used by another process.

I don't know how this happens. Maybe the app needs to be shut down before `nodeHome := t.TempDir()` is deleted or something like this.

Any help would be appreciated.