### PR TITLE
fix: sort coins in `ConvertWasmCoinsToSdkCoins`

### DIFF
--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -331,6 +331,7 @@ func ConvertWasmCoinsToSdkCoins(coins []wasmvmtypes.Coin) (sdk.Coins, error) {
 		}
 		toSend = append(toSend, c)
 	}
+	toSend.Sort()
 	return toSend, nil
 }
 


### PR DESCRIPTION
When sending e.g. `BankMsg::Send` from a contract, it appears that currently the coins in `amount` parameter need to be sorted. This is inconvenient as contracts need to add additional logic to sort coins before sending them. This PR simply sorts them instead in wasmd when converting them into SDK Coins.