### PR TITLE
add proposal annotations

### DIFF
--- a/proto/cosmwasm/wasm/v1/proposal.proto
+++ b/proto/cosmwasm/wasm/v1/proposal.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmwasm.wasm.v1;
 
 import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "cosmwasm/wasm/v1/types.proto";
 
@@ -12,6 +13,8 @@ option (gogoproto.equal_all) = true;
 
 // StoreCodeProposal gov proposal content type to submit WASM code to the system
 message StoreCodeProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -39,6 +42,8 @@ message StoreCodeProposal {
 // InstantiateContractProposal gov proposal content type to instantiate a
 // contract.
 message InstantiateContractProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -63,6 +68,8 @@ message InstantiateContractProposal {
 // InstantiateContract2Proposal gov proposal content type to instantiate
 // contract 2
 message InstantiateContract2Proposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -91,6 +98,8 @@ message InstantiateContract2Proposal {
 
 // MigrateContractProposal gov proposal content type to migrate a contract.
 message MigrateContractProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -107,6 +116,8 @@ message MigrateContractProposal {
 
 // SudoContractProposal gov proposal content type to call sudo on a contract.
 message SudoContractProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -120,6 +131,8 @@ message SudoContractProposal {
 // ExecuteContractProposal gov proposal content type to call execute on a
 // contract.
 message ExecuteContractProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -139,6 +152,8 @@ message ExecuteContractProposal {
 
 // UpdateAdminProposal gov proposal content type to set an admin for a contract.
 message UpdateAdminProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -152,6 +167,8 @@ message UpdateAdminProposal {
 // ClearAdminProposal gov proposal content type to clear the admin of a
 // contract.
 message ClearAdminProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1;
   // Description is a human readable text
@@ -163,6 +180,8 @@ message ClearAdminProposal {
 // PinCodesProposal gov proposal content type to pin a set of code ids in the
 // wasmvm cache.
 message PinCodesProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1 [ (gogoproto.moretags) = "yaml:\"title\"" ];
   // Description is a human readable text
@@ -177,6 +196,8 @@ message PinCodesProposal {
 // UnpinCodesProposal gov proposal content type to unpin a set of code ids in
 // the wasmvm cache.
 message UnpinCodesProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1 [ (gogoproto.moretags) = "yaml:\"title\"" ];
   // Description is a human readable text
@@ -200,6 +221,8 @@ message AccessConfigUpdate {
 // UpdateInstantiateConfigProposal gov proposal content type to update
 // instantiate config to a  set of code ids.
 message UpdateInstantiateConfigProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+
   // Title is a short summary
   string title = 1 [ (gogoproto.moretags) = "yaml:\"title\"" ];
   // Description is a human readable text
@@ -213,6 +236,8 @@ message UpdateInstantiateConfigProposal {
 // StoreAndInstantiateContractProposal gov proposal content type to store
 // and instantiate the contract.
 message StoreAndInstantiateContractProposal {
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
+  
   // Title is a short summary
   string title = 1;
   // Description is a human readable text


### PR DESCRIPTION
add `implements_interface` annotations which are useful for new telescope encoders/decoders/amino. 

example: https://gist.github.com/pyramation/217af77396606ddd6d3c7873fb85e9c7