### PR TITLE
Bump golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.46.2
+      - image: golangci/golangci-lint:v1.50.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR bumps golangci-lint to the latest version, making it possible to use go 1.19 more easily.