### PR TITLE
add non cgo build

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -102,61 +101,6 @@ type Keeper struct {
 	maxQueryStackSize    uint32
 	acceptedAccountTypes map[reflect.Type]struct{}
 	accountPruner        AccountPruner
-}
-
-// NewKeeper creates a new contract Keeper instance
-// If customEncoders is non-nil, we can use this to override some of the message handler, especially custom
-func NewKeeper(
-	cdc codec.Codec,
-	storeKey sdk.StoreKey,
-	paramSpace paramtypes.Subspace,
-	accountKeeper types.AccountKeeper,
-	bankKeeper types.BankKeeper,
-	stakingKeeper types.StakingKeeper,
-	distKeeper types.DistributionKeeper,
-	channelKeeper types.ChannelKeeper,
-	portKeeper types.PortKeeper,
-	capabilityKeeper types.CapabilityKeeper,
-	portSource types.ICS20TransferPortSource,
-	router MessageRouter,
-	_ GRPCQueryRouter,
-	homeDir string,
-	wasmConfig types.WasmConfig,
-	availableCapabilities string,
-	opts ...Option,
-) Keeper {
-	wasmer, err := wasmvm.NewVM(filepath.Join(homeDir, "wasm"), availableCapabilities, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
-	if err != nil {
-		panic(err)
-	}
-	// set KeyTable if it has not already been set
-	if !paramSpace.HasKeyTable() {
-		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
-	}
-
-	keeper := &Keeper{
-		storeKey:             storeKey,
-		cdc:                  cdc,
-		wasmVM:               wasmer,
-		accountKeeper:        accountKeeper,
-		bank:                 NewBankCoinTransferrer(bankKeeper),
-		accountPruner:        NewVestingCoinBurner(bankKeeper),
-		portKeeper:           portKeeper,
-		capabilityKeeper:     capabilityKeeper,
-		messenger:            NewDefaultMessageHandler(router, channelKeeper, capabilityKeeper, bankKeeper, cdc, portSource),
-		queryGasLimit:        wasmConfig.SmartQueryGasLimit,
-		paramSpace:           paramSpace,
-		gasRegister:          NewDefaultWasmGasRegister(),
-		maxQueryStackSize:    types.DefaultMaxQueryStackSize,
-		acceptedAccountTypes: defaultAcceptedAccountTypes,
-	}
-	keeper.wasmVMQueryHandler = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, channelKeeper, keeper)
-	for _, o := range opts {
-		o.apply(keeper)
-	}
-	// not updateable, yet
-	keeper.wasmVMResponseHandler = NewDefaultWasmVMContractResponseHandler(NewMessageDispatcher(keeper.messenger, keeper))
-	return *keeper
 }
 
 func (k Keeper) getUploadAccessConfig(ctx sdk.Context) types.AccessConfig {

--- a/x/wasm/keeper/keeper_cgo.go
+++ b/x/wasm/keeper/keeper_cgo.go
@@ -1,0 +1,69 @@
+//go:build cgo
+
+package keeper
+
+import (
+	"path/filepath"
+
+	wasmvm "github.com/CosmWasm/wasmvm"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+// NewKeeper creates a new contract Keeper instance
+// If customEncoders is non-nil, we can use this to override some of the message handler, especially custom
+func NewKeeper(
+	cdc codec.Codec,
+	storeKey sdk.StoreKey,
+	paramSpace paramtypes.Subspace,
+	accountKeeper types.AccountKeeper,
+	bankKeeper types.BankKeeper,
+	stakingKeeper types.StakingKeeper,
+	distKeeper types.DistributionKeeper,
+	channelKeeper types.ChannelKeeper,
+	portKeeper types.PortKeeper,
+	capabilityKeeper types.CapabilityKeeper,
+	portSource types.ICS20TransferPortSource,
+	router MessageRouter,
+	queryRouter GRPCQueryRouter,
+	homeDir string,
+	wasmConfig types.WasmConfig,
+	availableCapabilities string,
+	opts ...Option,
+) Keeper {
+	wasmer, err := wasmvm.NewVM(filepath.Join(homeDir, "wasm"), availableCapabilities, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
+	if err != nil {
+		panic(err)
+	}
+	// set KeyTable if it has not already been set
+	if !paramSpace.HasKeyTable() {
+		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
+	}
+
+	keeper := &Keeper{
+		storeKey:             storeKey,
+		cdc:                  cdc,
+		wasmVM:               wasmer,
+		accountKeeper:        accountKeeper,
+		bank:                 NewBankCoinTransferrer(bankKeeper),
+		accountPruner:        NewVestingCoinBurner(bankKeeper),
+		portKeeper:           portKeeper,
+		capabilityKeeper:     capabilityKeeper,
+		messenger:            NewDefaultMessageHandler(router, channelKeeper, capabilityKeeper, bankKeeper, cdc, portSource),
+		queryGasLimit:        wasmConfig.SmartQueryGasLimit,
+		paramSpace:           paramSpace,
+		gasRegister:          NewDefaultWasmGasRegister(),
+		maxQueryStackSize:    types.DefaultMaxQueryStackSize,
+		acceptedAccountTypes: defaultAcceptedAccountTypes,
+	}
+	keeper.wasmVMQueryHandler = DefaultQueryPlugins(bankKeeper, stakingKeeper, distKeeper, channelKeeper, keeper)
+	for _, o := range opts {
+		o.apply(keeper)
+	}
+	// not updateable, yet
+	keeper.wasmVMResponseHandler = NewDefaultWasmVMContractResponseHandler(NewMessageDispatcher(keeper.messenger, keeper))
+	return *keeper
+}

--- a/x/wasm/keeper/keeper_no_cgo.go
+++ b/x/wasm/keeper/keeper_no_cgo.go
@@ -1,0 +1,35 @@
+//go:build !cgo
+
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+// NewKeeper creates a new contract Keeper instance
+// If customEncoders is non-nil, we can use this to override some of the message handler, especially custom
+func NewKeeper(
+	cdc codec.Codec,
+	storeKey sdk.StoreKey,
+	paramSpace paramtypes.Subspace,
+	accountKeeper types.AccountKeeper,
+	bankKeeper types.BankKeeper,
+	stakingKeeper types.StakingKeeper,
+	distKeeper types.DistributionKeeper,
+	channelKeeper types.ChannelKeeper,
+	portKeeper types.PortKeeper,
+	capabilityKeeper types.CapabilityKeeper,
+	portSource types.ICS20TransferPortSource,
+	router MessageRouter,
+	queryRouter GRPCQueryRouter,
+	homeDir string,
+	wasmConfig types.WasmConfig,
+	availableCapabilities string,
+	opts ...Option,
+) Keeper {
+	panic("not implemented, please build with cgo enabled")
+}


### PR DESCRIPTION
This is a replacement for https://github.com/CosmWasm/wasmd/pull/1162 which now only requires a change in the keeper. 

The original POC required the cli to be modified because `wasmvm.LibwasmvmVersion()` wasn't handling the cgo,no_cgo but now it does by returning an error.