### PR TITLE
list-contract-by-code bugfix

### DIFF
--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -580,6 +580,7 @@ func GetCmdListContractsByCreator() *cobra.Command {
 		SilenceUsage: true,
 	}
 	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "list contracts by creator")
 	return cmd
 }
 


### PR DESCRIPTION
Adds Pagination Flags to the `list-contract-by-code` wasm query command.

Without the pagination flags, the query panics with
```
panic: flag accessed but not defined: page-key
```