### PR TITLE
fix: stargate querier does not reset the structure state

### DIFF
--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -600,6 +600,7 @@ func ConvertProtoToJSONMarshal(cdc codec.Codec, protoResponse codec.ProtoMarshal
 		return nil, sdkerrors.Wrap(err, "to json")
 	}
 
+	protoResponse.Reset()
 	return bz, nil
 }
 

--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -749,6 +749,31 @@ func TestConvertProtoToJSONMarshal(t *testing.T) {
 	}
 }
 
+func TestResetProtoMarshalerAfterJsonMarshal(t *testing.T) {
+	appCodec := app.MakeEncodingConfig().Marshaler
+
+	protoMarshaler := &banktypes.QueryAllBalancesResponse{}
+	expected := appCodec.MustMarshalJSON(&banktypes.QueryAllBalancesResponse{
+		Balances: sdk.NewCoins(sdk.NewCoin("bar", sdk.NewInt(30))),
+		Pagination: &query.PageResponse{
+			NextKey: []byte("foo"),
+		},
+	})
+
+	bz, err := hex.DecodeString("0a090a036261721202333012050a03666f6f")
+	require.NoError(t, err)
+
+	// first marshal
+	response, err := keeper.ConvertProtoToJSONMarshal(appCodec, protoMarshaler, bz)
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+
+	// second marshal
+	response, err = keeper.ConvertProtoToJSONMarshal(appCodec, protoMarshaler, bz)
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}
+
 // TestDeterministicJsonMarshal tests that we get deterministic JSON marshalled response upon
 // proto struct update in the state machine.
 func TestDeterministicJsonMarshal(t *testing.T) {


### PR DESCRIPTION
Currently, the stargate querier marshal the result to the given structure stored in accepted list, but it does not reset the state. So the result will be unexpected. For example, the current stargate querier process is like:

```go
cdc, _ := app.MakeCodecs()

protoResponse := &banktypes.QueryAllBalancesResponse{}

bz, err := cdc.Marshal(&banktypes.QueryAllBalancesResponse{
Balances: sdk.NewCoins(sdk.NewInt64Coin("test", 1)),
})

// First stargate query to QueryAllBalances 
err = cdc.Unmarshal(bz, protoResponse)
if err != nil {
panic(err)
}

// Second stargate query to QueryAllBalances 
err = cdc.Unmarshal(bz, protoResponse)
if err != nil {
panic(err)
}

fmt.Println(protoResponse.String())
// balances:<denom:"test" amount:"1" > balances:<denom:"test" amount:"1" >
// but the expected result is: balances:<denom:"test" amount:"1" >>
```

As a result, we should reset the protoResponse after marshaling.