### PR TITLE
Make `CaptureIbcEvents` in ibctesting public

### DIFF
--- a/x/wasm/ibctesting/chain.go
+++ b/x/wasm/ibctesting/chain.go
@@ -335,12 +335,12 @@ func (chain *TestChain) SendMsgs(msgs ...sdk.Msg) (*sdk.Result, error) {
 
 	chain.Coordinator.IncrementTime()
 
-	chain.captureIBCEvents(r)
+	chain.CaptureIBCEvents(r)
 
 	return r, nil
 }
 
-func (chain *TestChain) captureIBCEvents(r *sdk.Result) {
+func (chain *TestChain) CaptureIBCEvents(r *sdk.Result) {
 	toSend := getSendPackets(r.Events)
 	if len(toSend) > 0 {
 		// Keep a queue on the chain that we can relay in tests

--- a/x/wasm/ibctesting/faucet.go
+++ b/x/wasm/ibctesting/faucet.go
@@ -47,6 +47,6 @@ func (chain *TestChain) SendNonDefaultSenderMsgs(senderPrivKey cryptotypes.PrivK
 	if err != nil {
 		return r, err
 	}
-	chain.captureIBCEvents(r)
+	chain.CaptureIBCEvents(r)
 	return r, nil
 }


### PR DESCRIPTION
Before this change, it wasn't possible to implement the `chain.SendMsgs` method without [copying](https://github.com/public-awesome/ics721/blob/main/e2e/suite_helpers.go#L81-L98) the method and its dependents over to your testing code.