### PR TITLE
feat: QOL Capabilities functions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -161,6 +161,16 @@ func GetEnabledProposals() []wasm.ProposalType {
 	return proposals
 }
 
+// GetDefaultCosmosCapabilities returns the default capabilities for a cosmos-sdk based chain.
+func GetDefaultCosmosCapabilities() string {
+	return "iterator,staking,stargate"
+}
+
+// GetDefaultWasmCapabilities returns the default capabilities for a cosmwasm based chain.
+func GetDefaultWasmCapabilities() string {
+	return "cosmwasm_1_1,cosmwasm_1_2"
+}
+
 // These constants are derived from the above variables.
 // These are the ones we will want to use in the code, based on
 // any overrides above
@@ -584,7 +594,7 @@ func NewWasmApp(
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
 	// See https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md
-	availableCapabilities := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2"
+	availableCapabilities := fmt.Sprintf("%s,%s", GetDefaultCosmosCapabilities(), GetDefaultWasmCapabilities())
 	app.WasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],


### PR DESCRIPTION
Per: https://github.com/CosmWasm/wasmvm/pull/413

I have added some capability functions here instead of in wasmvm. 

This way a chain like Juno can add `wasmd.GetDefaultWasmCapabilities()` for future upgrades without us forgetting to add the capabilities (that wasmd implement)