### PR TITLE
Bump actions/checkout from 3.5.0 to 3.5.1 and bufbuild/buf-setup-action from 1.16.0 to 1.17.0

### DIFF
--- a/.github/workflows/codeql-analizer.yml
+++ b/.github/workflows/codeql-analizer.yml
@@ -19,11 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-<<<<<<< HEAD
         uses: actions/checkout@v3.4.0
-=======
-        uses: actions/checkout@v3.5.1
->>>>>>> d95eebf4 (Bump actions/checkout from 3.5.0 to 3.5.1 (#1329))
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analizer.yml
+++ b/.github/workflows/codeql-analizer.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v3.5.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -17,14 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 <<<<<<< HEAD
-<<<<<<< HEAD
       - uses: actions/checkout@v3.4.0
       - uses: bufbuild/buf-setup-action@v1.15.1
 =======
       - uses: actions/checkout@v3.5.0
-=======
-      - uses: actions/checkout@v3.5.1
->>>>>>> d95eebf4 (Bump actions/checkout from 3.5.0 to 3.5.1 (#1329))
       - uses: bufbuild/buf-setup-action@v1.17.0
 >>>>>>> cbfa6abc (Bump bufbuild/buf-setup-action from 1.16.0 to 1.17.0 (#1318))
 

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -16,13 +16,8 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-<<<<<<< HEAD
-      - uses: actions/checkout@v3.4.0
-      - uses: bufbuild/buf-setup-action@v1.15.1
-=======
-      - uses: actions/checkout@v3.5.0
+      - uses: actions/checkout@v3.5.1
       - uses: bufbuild/buf-setup-action@v1.17.0
->>>>>>> cbfa6abc (Bump bufbuild/buf-setup-action from 1.16.0 to 1.17.0 (#1318))
 
       # lint checks
       - uses: bufbuild/buf-lint-action@v1


### PR DESCRIPTION
Fix conflicts