### PR TITLE
[Do not merge] ADR-8 vertical spike

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -630,12 +630,13 @@ func NewWasmApp(
 	// Create Interchain Accounts Stack
 	// SendPacket, since it is originating from the application to core IBC:
 	// icaAuthModuleKeeper.SendTx -> icaController.SendPacket -> fee.SendPacket -> channel.SendPacket
-	var icaControllerStack porttypes.IBCModule
+	var icaControllerStack porttypes.Middleware
 	// integration point for custom authentication modules
 	// see https://medium.com/the-interchain-foundation/ibc-go-v6-changes-to-interchain-accounts-and-how-it-impacts-your-chain-806c185300d7
 	var noAuthzModule porttypes.IBCModule
 	icaControllerStack = icacontroller.NewIBCMiddleware(noAuthzModule, app.ICAControllerKeeper)
 	icaControllerStack = ibcfee.NewIBCMiddleware(icaControllerStack, app.IBCFeeKeeper)
+	icaControllerStack = xadr8.NewIBCMiddleware2(icaControllerStack, &adr8Keeper, xadr8.NewICAControllerPacketDecoder(), app.WasmKeeper)
 
 	// RecvPacket, message that originates from core IBC and goes down to app, the flow is:
 	// channel.RecvPacket -> fee.OnRecvPacket -> icaHost.OnRecvPacket

--- a/app/wasm.go
+++ b/app/wasm.go
@@ -1,5 +1,10 @@
 package app
 
+import (
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	"github.com/CosmWasm/wasmd/x/xwasmvm/custom"
+)
+
 // AllCapabilities returns all capabilities available with the current wasmvm
 // See https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md
 // This functionality is going to be moved upstream: https://github.com/CosmWasm/wasmvm/issues/425
@@ -10,5 +15,16 @@ func AllCapabilities() []string {
 		"stargate",
 		"cosmwasm_1_1",
 		"cosmwasm_1_2",
+	}
+}
+
+// CustomMsgDecorator is hack to add a custom message that is not part of wasmvm, yet.
+// used for rapid prototyping only
+func CustomMsgDecorator(k custom.Adr8Keeper) func(nested wasmkeeper.Messenger) wasmkeeper.Messenger {
+	return func(nested wasmkeeper.Messenger) wasmkeeper.Messenger {
+		return wasmkeeper.NewMessageHandlerChain(
+			custom.XMessageHandler(k),
+			nested,
+		)
 	}
 }

--- a/tests/e2e/ibc_adr8_test.go
+++ b/tests/e2e/ibc_adr8_test.go
@@ -1,0 +1,104 @@
+package e2e
+
+import (
+	"bytes"
+	"testing"
+
+	wasmvm "github.com/CosmWasm/wasmvm"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	ibctesting "github.com/cosmos/ibc-go/v7/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
+	"github.com/CosmWasm/wasmd/x/xwasmvm/custom"
+
+	"github.com/CosmWasm/wasmd/app"
+	wasmibctesting "github.com/CosmWasm/wasmd/x/wasm/ibctesting"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+func TestIBCAdr8WithTransfer(t *testing.T) {
+	// scenario:
+	// given 2 chains
+	//   with an ics-20 channel established
+	//   and a callback for a contract on chain A registered for ics-20 packet ack/ timeout
+	// when the ack is relayed
+	// then the callback is executed
+	var contractAckCallbackCalled bool
+	mockOpt := wasmkeeper.WithWasmEngineDecorator(func(old wasmtypes.WasmerEngine) wasmtypes.WasmerEngine {
+		// hack to mock the new vm methods
+		xvm, ok := old.(*xwasmvm.XVM)
+		require.True(t, ok)
+		xvm.OnIBCPacketAckedFn = func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+			contractAckCallbackCalled = true
+			return &wasmvmtypes.IBCBasicResponse{}, 0, nil
+		}
+		return xvm
+	})
+
+	marshaler := app.MakeEncodingConfig().Marshaler
+	coord := wasmibctesting.NewCoordinator(t, 2, []wasmkeeper.Option{mockOpt}) // add mock to chain A
+	chainA := coord.GetChain(wasmibctesting.GetChainID(1))
+	chainB := coord.GetChain(wasmibctesting.GetChainID(2))
+
+	contractAddr := InstantiateReflectContract(t, chainA) // test with a real contract
+
+	// actorChainA := contractAddr
+	// actorChainB := sdk.AccAddress(chainB.SenderPrivKey.PubKey().Address())
+	receiver := sdk.AccAddress(bytes.Repeat([]byte{1}, address.Len))
+	// payee := sdk.AccAddress(bytes.Repeat([]byte{2}, address.Len))
+	// oneToken := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1)))
+
+	path := wasmibctesting.NewPath(chainA, chainB)
+	path.EndpointA.ChannelConfig = &ibctesting.ChannelConfig{
+		PortID:  ibctransfertypes.PortID,
+		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Order:   channeltypes.UNORDERED,
+	}
+	path.EndpointB.ChannelConfig = &ibctesting.ChannelConfig{
+		PortID:  ibctransfertypes.PortID,
+		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Order:   channeltypes.UNORDERED,
+	}
+	// with an ics-20 transfer channel setup between both chains
+	coord.Setup(path)
+	require.True(t, chainA.App.IBCFeeKeeper.IsFeeEnabled(chainA.GetContext(), ibctransfertypes.PortID, path.EndpointA.ChannelID))
+
+	// when an ics20 transfer package is sent
+	transferCoin := sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1))
+	myIBCTransfer := wasmvmtypes.CosmosMsg{IBC: &wasmvmtypes.IBCMsg{Transfer: &wasmvmtypes.TransferMsg{
+		ChannelID: path.EndpointA.ChannelID,
+		ToAddress: receiver.String(),
+		Amount:    wasmkeeper.ConvertSdkCoinToWasmCoin(transferCoin),
+		Timeout:   wasmvmtypes.IBCTimeout{Block: &wasmvmtypes.IBCTimeoutBlock{Revision: 1, Height: 1_000}},
+	}}}
+	regMsg := custom.CustomADR8Msg{
+		RegisterPacketProcessedCallback: &custom.RegisterPacketProcessedCallback{
+			Sequence:            1, // hard code seq here as reflect contract does not read response from transfer msg
+			ChannelID:           path.EndpointA.ChannelID,
+			PortID:              ibctransfertypes.PortID,
+			MaxCallbackGasLimit: 200_000,
+		},
+	}
+	myCallbackRegistr := MustEncodeAsReflectCustomMessage(t, regMsg)
+	MustExecViaReflectContract(t, chainA, contractAddr, myIBCTransfer, myCallbackRegistr)
+	coord.CommitBlock(chainA, chainB)
+
+	// and packages relayed
+	require.NoError(t, coord.RelayAndAckPendingPackets(path))
+
+	// then
+	expBalance := ibctransfertypes.GetTransferCoin(path.EndpointB.ChannelConfig.PortID, path.EndpointB.ChannelID, transferCoin.Denom, transferCoin.Amount)
+	gotBalance := chainB.Balance(receiver, expBalance.Denom)
+	assert.Equal(t, expBalance.String(), gotBalance.String())
+
+	// then
+	assert.True(t, contractAckCallbackCalled, "contract callback was not executed")
+}

--- a/tests/e2e/ibc_adr8_test.go
+++ b/tests/e2e/ibc_adr8_test.go
@@ -3,11 +3,17 @@ package e2e
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/gogoproto/proto"
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	hosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
@@ -101,4 +107,98 @@ func TestIBCAdr8WithTransfer(t *testing.T) {
 
 	// then
 	assert.True(t, contractAckCallbackCalled, "contract callback was not executed")
+}
+
+func TestAdr8WithICA(t *testing.T) {
+	// scenario:
+	// given a host and controller chain
+	//		 with a channel established to the host chain
+	//       and an ICA account owned by a contract
+	// when the contract sends an ICA tx and registers for a callback
+	// then the contract should receive the callback on ack
+
+	var contractAckCallbackCalled bool
+	mockOpt := wasmkeeper.WithWasmEngineDecorator(func(old wasmtypes.WasmerEngine) wasmtypes.WasmerEngine {
+		// hack to mock the new vm methods
+		xvm, ok := old.(*xwasmvm.XVM)
+		require.True(t, ok)
+		xvm.OnIBCPacketAckedFn = func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+			contractAckCallbackCalled = true
+			return &wasmvmtypes.IBCBasicResponse{}, 0, nil
+		}
+		return xvm
+	})
+
+	coord := wasmibctesting.NewCoordinator(t, 2, []wasmkeeper.Option{}, []wasmkeeper.Option{mockOpt}) // add mock to chain 2
+	hostChain := coord.GetChain(ibctesting.GetChainID(1))
+	hostParams := hosttypes.NewParams(true, []string{sdk.MsgTypeURL(&banktypes.MsgSend{})})
+	hostChain.App.ICAHostKeeper.SetParams(hostChain.GetContext(), hostParams)
+
+	controllerChain := coord.GetChain(ibctesting.GetChainID(2))
+	contractAddr := InstantiateReflectContract(t, controllerChain) // test with a real contract
+
+	path := wasmibctesting.NewPath(controllerChain, hostChain)
+	coord.SetupConnections(path)
+
+	// register contract for ICA address
+	msg := icacontrollertypes.NewMsgRegisterInterchainAccount(path.EndpointA.ConnectionID, contractAddr.String(), "")
+	res := MustExecViaStargateReflectContract(t, controllerChain, contractAddr, msg)
+	chanID, portID, version := parseIBCChannelEvents(t, res)
+
+	// next open channels on both sides
+	path.EndpointA.ChannelID = chanID
+	path.EndpointA.ChannelConfig = &ibctesting.ChannelConfig{
+		PortID:  portID,
+		Version: version,
+		Order:   channeltypes.ORDERED,
+	}
+	path.EndpointB.ChannelConfig = &ibctesting.ChannelConfig{
+		PortID:  icatypes.HostPortID,
+		Version: icatypes.Version,
+		Order:   channeltypes.ORDERED,
+	}
+	coord.CreateChannels(path)
+
+	// assert ICA exists on controller
+	icaRsp, err := controllerChain.App.ICAControllerKeeper.InterchainAccount(sdk.WrapSDKContext(controllerChain.GetContext()), &icacontrollertypes.QueryInterchainAccountRequest{
+		Owner:        contractAddr.String(),
+		ConnectionId: path.EndpointA.ConnectionID,
+	})
+	require.NoError(t, err)
+	icaAddr := sdk.MustAccAddressFromBech32(icaRsp.GetAddress())
+	hostChain.Fund(icaAddr, sdk.NewInt(1_000))
+
+	// submit a tx to controller to be relayed
+	targetAddr := sdk.AccAddress(bytes.Repeat([]byte{1}, address.Len))
+	sendCoin := sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100))
+	payloadMsg := banktypes.NewMsgSend(icaAddr, targetAddr, sdk.NewCoins(sendCoin))
+	rawPayloadData, err := icatypes.SerializeCosmosTx(controllerChain.Codec, []proto.Message{payloadMsg})
+	require.NoError(t, err)
+	payloadPacket := icatypes.InterchainAccountPacketData{
+		Type: icatypes.EXECUTE_TX,
+		Data: rawPayloadData,
+		Memo: "testing",
+	}
+	relativeTimeout := uint64(time.Minute.Nanoseconds()) // note this is in nanoseconds
+	msgSendTx := icacontrollertypes.NewMsgSendTx(contractAddr.String(), path.EndpointA.ConnectionID, relativeTimeout, payloadPacket)
+	MustExecViaStargateReflectContract(t, controllerChain, contractAddr, msgSendTx)
+	regMsg := custom.CustomADR8Msg{
+		RegisterPacketProcessedCallback: &custom.RegisterPacketProcessedCallback{
+			Sequence:            1, // hard code seq here as reflect contract does not read response from transfer msg
+			ChannelID:           path.EndpointA.ChannelID,
+			PortID:              path.EndpointA.ChannelConfig.PortID,
+			MaxCallbackGasLimit: 200_000,
+		},
+	}
+	myCallbackRegistrMsg := MustEncodeAsReflectCustomMessage(t, regMsg)
+	MustExecViaReflectContract(t, controllerChain, contractAddr, myCallbackRegistrMsg)
+
+	assert.Equal(t, 1, len(controllerChain.PendingSendPackets))
+	require.NoError(t, coord.RelayAndAckPendingPackets(path))
+
+	gotBalance := hostChain.Balance(targetAddr, sdk.DefaultBondDenom)
+	assert.Equal(t, sendCoin.String(), gotBalance.String())
+
+	// and verify contract callback executed
+	assert.True(t, contractAckCallbackCalled)
 }

--- a/tests/e2e/reflect_helper.go
+++ b/tests/e2e/reflect_helper.go
@@ -24,7 +24,7 @@ func InstantiateReflectContract(t *testing.T, chain *ibctesting.TestChain) sdk.A
 
 // MustExecViaReflectContract submit execute message to send payload to reflect contract
 func MustExecViaReflectContract(t *testing.T, chain *ibctesting.TestChain, contractAddr sdk.AccAddress, msgs ...wasmvmtypes.CosmosMsg) *sdk.Result {
-	rsp, err := ExecViaReflectContract(t, chain, contractAddr, msgs)
+	rsp, err := ExecViaReflectContract(t, chain, contractAddr, msgs...)
 	require.NoError(t, err)
 	return rsp
 }
@@ -46,13 +46,13 @@ func MustExecViaStargateReflectContract[T sdkMessageType](t *testing.T, chain *i
 			},
 		}
 	}
-	rsp, err := ExecViaReflectContract(t, chain, contractAddr, vmMsgs)
+	rsp, err := ExecViaReflectContract(t, chain, contractAddr, vmMsgs...)
 	require.NoError(t, err)
 	return rsp
 }
 
 // ExecViaReflectContract submit execute message to send payload to reflect contract
-func ExecViaReflectContract(t *testing.T, chain *ibctesting.TestChain, contractAddr sdk.AccAddress, msgs []wasmvmtypes.CosmosMsg) (*sdk.Result, error) {
+func ExecViaReflectContract(t *testing.T, chain *ibctesting.TestChain, contractAddr sdk.AccAddress, msgs ...wasmvmtypes.CosmosMsg) (*sdk.Result, error) {
 	require.NotEmpty(t, msgs)
 	reflectSend := testdata.ReflectHandleMsg{
 		Reflect: &testdata.ReflectPayload{Msgs: msgs},
@@ -65,4 +65,16 @@ func ExecViaReflectContract(t *testing.T, chain *ibctesting.TestChain, contractA
 		Msg:      reflectSendBz,
 	}
 	return chain.SendMsgs(execMsg)
+}
+
+func MustEncodeAsReflectCustomMessage(t *testing.T, payload interface{}) wasmvmtypes.CosmosMsg {
+	bz, err := json.Marshal(payload)
+	require.NoError(t, err)
+	// reflect expected payload to be wrapped in another obj
+	reflectCustomMsg := struct {
+		Raw []byte `json:"raw,omitempty"`
+	}{Raw: bz}
+	bz, err = json.Marshal(reflectCustomMsg)
+	require.NoError(t, err)
+	return wasmvmtypes.CosmosMsg{Custom: bz}
 }

--- a/x/wasm/ibc_test.go
+++ b/x/wasm/ibc_test.go
@@ -169,7 +169,7 @@ func TestMapToWasmVMIBCPacket(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			got := newIBCPacket(spec.src)
+			got := types.AsIBCPacket(spec.src)
 			assert.Equal(t, spec.exp, got)
 		})
 	}

--- a/x/wasm/ioutils/ioutil_test.go
+++ b/x/wasm/ioutils/ioutil_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"errors"
-	"github.com/cometbft/cometbft/libs/rand"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/cometbft/cometbft/libs/rand"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/x/wasm/keeper/adr8_authorization.go
+++ b/x/wasm/keeper/adr8_authorization.go
@@ -1,0 +1,21 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CosmWasm/wasmd/x/xadr8"
+)
+
+var _ xadr8.Authorization = &AcceptOnlyContracts{}
+
+type AcceptOnlyContracts struct {
+	k *Keeper
+}
+
+func NewAcceptOnlyContracts(k *Keeper) *AcceptOnlyContracts {
+	return &AcceptOnlyContracts{k: k}
+}
+
+func (a AcceptOnlyContracts) IsAuthorized(ctx sdk.Context, actor sdk.AccAddress) (bool, error) {
+	return a.k.HasContractInfo(ctx, actor), nil
+}

--- a/x/wasm/keeper/ard8_callbacks.go
+++ b/x/wasm/keeper/ard8_callbacks.go
@@ -1,0 +1,44 @@
+package keeper
+
+import (
+	"time"
+
+	errorsmod "cosmossdk.io/errors"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/CosmWasm/wasmd/x/xadr8"
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
+)
+
+// OnIBCPacketAcked forwards the callback to the contract
+func (k Keeper) OnIBCPacketAcked(ctx sdk.Context, packet channeltypes.Packet, acknowledgement []byte, relayer sdk.AccAddress, contractAddr sdk.AccAddress, meta xadr8.CustomDataI) error {
+	defer telemetry.MeasureSince(time.Now(), "wasm", "contract", "callback-ibc-ack-packet")
+	contractInfo, codeInfo, prefixStore, err := k.contractInstance(ctx, contractAddr)
+	if err != nil {
+		return err
+	}
+
+	env := types.NewEnv(ctx, contractAddr)
+	querier := k.newQueryHandler(ctx, contractAddr)
+
+	gas := k.runtimeGasForContract(ctx)
+	res, gasUsed, execErr := k.wasmVM.OnIBCPacketAcked(codeInfo.CodeHash, env, xwasmvm.IBCPacketAckedMsg{
+		Acknowledgement: wasmvmtypes.IBCAcknowledgement{Data: acknowledgement},
+		OriginalPacket:  types.AsIBCPacket(packet),
+		Relayer:         relayer.String(),
+	}, prefixStore, cosmwasmAPI, querier, ctx.GasMeter(), gas, costJSONDeserialization)
+	k.consumeRuntimeGas(ctx, gasUsed)
+	if execErr != nil {
+		return errorsmod.Wrap(types.ErrExecuteFailed, execErr.Error())
+	}
+	return k.handleIBCBasicContractResponse(ctx, contractAddr, contractInfo.IBCPortID, res)
+}
+
+func (k Keeper) OnIBCPacketTimedOut(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress, contractAddr sdk.AccAddress, meta xadr8.CustomDataI) error {
+	// TODO implement me
+	panic("implement me")
+}

--- a/x/wasm/keeper/keeper_cgo.go
+++ b/x/wasm/keeper/keeper_cgo.go
@@ -5,9 +5,10 @@ package keeper
 import (
 	"path/filepath"
 
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
+
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
-	wasmvm "github.com/CosmWasm/wasmvm"
 	"github.com/cosmos/cosmos-sdk/codec"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
@@ -34,7 +35,7 @@ func NewKeeper(
 	authority string,
 	opts ...Option,
 ) Keeper {
-	wasmer, err := wasmvm.NewVM(filepath.Join(homeDir, "wasm"), availableCapabilities, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
+	wasmer, err := xwasmvm.NewVM(filepath.Join(homeDir, "wasm"), availableCapabilities, contractMemoryLimit, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
 	if err != nil {
 		panic(err)
 	}

--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -20,6 +20,14 @@ type Messenger interface {
 	DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error)
 }
 
+var _ Messenger = MessengerFn(nil)
+
+type MessengerFn func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error)
+
+func (m MessengerFn) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+	return m(ctx, contractAddr, contractIBCPortID, msg)
+}
+
 // replyer is a subset of keeper that can handle replies to submessages
 type replyer interface {
 	reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) ([]byte, error)

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	wasmvm "github.com/CosmWasm/wasmvm"
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
 
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -31,7 +31,7 @@ func TestConstructorOptions(t *testing.T) {
 		},
 		"decorate wasmvm": {
 			srcOpt: WithWasmEngineDecorator(func(old types.WasmerEngine) types.WasmerEngine {
-				require.IsType(t, &wasmvm.VM{}, old)
+				require.IsType(t, &xwasmvm.XVM{}, old)
 				return &wasmtesting.MockWasmer{}
 			}),
 			verify: func(t *testing.T, k Keeper) {

--- a/x/wasm/keeper/wasmtesting/mock_engine.go
+++ b/x/wasm/keeper/wasmtesting/mock_engine.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
+
 	errorsmod "cosmossdk.io/errors"
 
 	wasmvm "github.com/CosmWasm/wasmvm"
@@ -18,25 +20,41 @@ var _ types.WasmerEngine = &MockWasmer{}
 // MockWasmer implements types.WasmerEngine for testing purpose. One or multiple messages can be stubbed.
 // Without a stub function a panic is thrown.
 type MockWasmer struct {
-	CreateFn            func(codeID wasmvm.WasmCode) (wasmvm.Checksum, error)
-	AnalyzeCodeFn       func(codeID wasmvm.Checksum) (*wasmvmtypes.AnalysisReport, error)
-	InstantiateFn       func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, initMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
-	ExecuteFn           func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, executeMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
-	QueryFn             func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error)
-	MigrateFn           func(codeID wasmvm.Checksum, env wasmvmtypes.Env, migrateMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
-	SudoFn              func(codeID wasmvm.Checksum, env wasmvmtypes.Env, sudoMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
-	ReplyFn             func(codeID wasmvm.Checksum, env wasmvmtypes.Env, reply wasmvmtypes.Reply, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
-	GetCodeFn           func(codeID wasmvm.Checksum) (wasmvm.WasmCode, error)
-	CleanupFn           func()
-	IBCChannelOpenFn    func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBC3ChannelOpenResponse, uint64, error)
-	IBCChannelConnectFn func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelConnectMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
-	IBCChannelCloseFn   func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelCloseMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
-	IBCPacketReceiveFn  func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketReceiveMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCReceiveResult, uint64, error)
-	IBCPacketAckFn      func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketAckMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
-	IBCPacketTimeoutFn  func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketTimeoutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
-	PinFn               func(checksum wasmvm.Checksum) error
-	UnpinFn             func(checksum wasmvm.Checksum) error
-	GetMetricsFn        func() (*wasmvmtypes.Metrics, error)
+	CreateFn              func(codeID wasmvm.WasmCode) (wasmvm.Checksum, error)
+	AnalyzeCodeFn         func(codeID wasmvm.Checksum) (*wasmvmtypes.AnalysisReport, error)
+	InstantiateFn         func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, initMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
+	ExecuteFn             func(codeID wasmvm.Checksum, env wasmvmtypes.Env, info wasmvmtypes.MessageInfo, executeMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
+	QueryFn               func(codeID wasmvm.Checksum, env wasmvmtypes.Env, queryMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) ([]byte, uint64, error)
+	MigrateFn             func(codeID wasmvm.Checksum, env wasmvmtypes.Env, migrateMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
+	SudoFn                func(codeID wasmvm.Checksum, env wasmvmtypes.Env, sudoMsg []byte, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
+	ReplyFn               func(codeID wasmvm.Checksum, env wasmvmtypes.Env, reply wasmvmtypes.Reply, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.Response, uint64, error)
+	GetCodeFn             func(codeID wasmvm.Checksum) (wasmvm.WasmCode, error)
+	CleanupFn             func()
+	IBCChannelOpenFn      func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBC3ChannelOpenResponse, uint64, error)
+	IBCChannelConnectFn   func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelConnectMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	IBCChannelCloseFn     func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelCloseMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	IBCPacketReceiveFn    func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketReceiveMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCReceiveResult, uint64, error)
+	IBCPacketAckFn        func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketAckMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	IBCPacketTimeoutFn    func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketTimeoutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	PinFn                 func(checksum wasmvm.Checksum) error
+	UnpinFn               func(checksum wasmvm.Checksum) error
+	GetMetricsFn          func() (*wasmvmtypes.Metrics, error)
+	OnIBCPacketAckedFn    func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	OnIBCPacketTimedOutFn func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketTimedOutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+}
+
+func (m *MockWasmer) OnIBCPacketAcked(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+	if m.OnIBCPacketAckedFn == nil {
+		panic("not expected to be called")
+	}
+	return m.OnIBCPacketAckedFn(checksum, env, msg, store, goapi, querier, gasMeter, gasLimit, deserCost)
+}
+
+func (m *MockWasmer) OnIBCPacketTimedOut(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg xwasmvm.IBCPacketTimedOutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+	if m.OnIBCPacketTimedOutFn == nil {
+		panic("not expected to be called")
+	}
+	return m.OnIBCPacketTimedOutFn(checksum, env, msg, store, goapi, querier, gasMeter, gasLimit, deserCost)
 }
 
 func (m *MockWasmer) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBC3ChannelOpenResponse, uint64, error) {

--- a/x/wasm/types/type_converters.go
+++ b/x/wasm/types/type_converters.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+)
+
+func AsIBCPacket(packet channeltypes.Packet) wasmvmtypes.IBCPacket {
+	timeout := wasmvmtypes.IBCTimeout{
+		Timestamp: packet.TimeoutTimestamp,
+	}
+	if !packet.TimeoutHeight.IsZero() {
+		timeout.Block = &wasmvmtypes.IBCTimeoutBlock{
+			Height:   packet.TimeoutHeight.RevisionHeight,
+			Revision: packet.TimeoutHeight.RevisionNumber,
+		}
+	}
+
+	return wasmvmtypes.IBCPacket{
+		Data:     packet.Data,
+		Src:      wasmvmtypes.IBCEndpoint{ChannelID: packet.SourceChannel, PortID: packet.SourcePort},
+		Dest:     wasmvmtypes.IBCEndpoint{ChannelID: packet.DestinationChannel, PortID: packet.DestinationPort},
+		Sequence: packet.Sequence,
+		Timeout:  timeout,
+	}
+}

--- a/x/wasm/types/wasmer_engine.go
+++ b/x/wasm/types/wasmer_engine.go
@@ -4,6 +4,8 @@ import (
 	wasmvm "github.com/CosmWasm/wasmvm"
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CosmWasm/wasmd/x/xwasmvm"
 )
 
 // DefaultMaxQueryStackSize maximum size of the stack of contract instances doing queries
@@ -239,6 +241,33 @@ type WasmerEngine interface {
 
 	// GetMetrics some internal metrics for monitoring purposes.
 	GetMetrics() (*wasmvmtypes.Metrics, error)
+
+	// OnIBCPacketAcked adr-8 callback, executed for a registered hook after ibc package acknowledged was processed
+	// todo: should we merge this with timout and just add another flag?
+	OnIBCPacketAcked(
+		checksum wasmvm.Checksum,
+		env wasmvmtypes.Env,
+		msg xwasmvm.IBCPacketAckedMsg,
+		store wasmvm.KVStore,
+		goapi wasmvm.GoAPI,
+		querier wasmvm.Querier,
+		gasMeter wasmvm.GasMeter,
+		gasLimit uint64,
+		deserCost wasmvmtypes.UFraction,
+	) (*wasmvmtypes.IBCBasicResponse, uint64, error) // todo: refine proper response type	// OnIBCPacketAcked adr-8 callback, executed for a registered hook after ibc package is acknowledged
+
+	// OnIBCPacketTimedOut adr-8 callback, executed for a registered hook after ibc package timeout was processed
+	OnIBCPacketTimedOut(
+		checksum wasmvm.Checksum,
+		env wasmvmtypes.Env,
+		msg xwasmvm.IBCPacketTimedOutMsg,
+		store wasmvm.KVStore,
+		goapi wasmvm.GoAPI,
+		querier wasmvm.Querier,
+		gasMeter wasmvm.GasMeter,
+		gasLimit uint64,
+		deserCost wasmvmtypes.UFraction,
+	) (*wasmvmtypes.IBCBasicResponse, uint64, error) // todo: refine proper response type
 }
 
 var _ wasmvm.KVStore = &StoreAdapter{}

--- a/x/xadr8/README.md
+++ b/x/xadr8/README.md
@@ -1,0 +1,2 @@
+# ADR-8 framework
+Non CosmWasm related code that could be moved upstream to ibc-go

--- a/x/xadr8/keeper.go
+++ b/x/xadr8/keeper.go
@@ -1,0 +1,169 @@
+package xadr8
+
+import (
+	"encoding/json"
+	"errors"
+
+	errorsmod "cosmossdk.io/errors"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+)
+
+type PacketId = channeltypes.PacketId
+
+type Keeper struct {
+	storeKey      storetypes.StoreKey
+	channelKeeper ChannelKeeper
+	auth          Authorization
+}
+type Authorization interface {
+	// is actor authorized to register a callback for a package
+	IsAuthorized(ctx sdk.Context, actor sdk.AccAddress) (bool, error)
+}
+
+var _ Authorization = AuthorizationFn(nil)
+
+type AuthorizationFn func(ctx sdk.Context, actor sdk.AccAddress) (bool, error)
+
+func (a AuthorizationFn) IsAuthorized(ctx sdk.Context, actor sdk.AccAddress) (bool, error) {
+	return a(ctx, actor)
+}
+
+func NewKeeper(storeKey storetypes.StoreKey, channelKeeper ChannelKeeper, auth Authorization) *Keeper {
+	// todoL ensure non nil values
+	return &Keeper{
+		storeKey:      storeKey,
+		channelKeeper: channelKeeper,
+		auth:          auth,
+	}
+}
+
+func (k Keeper) RegisterPacketProcessedCallback(
+	ctx sdk.Context,
+	sender sdk.AccAddress,
+	packetID PacketId,
+	limit uint64,
+	meta CustomDataI,
+) error {
+	ok, err := k.auth.IsAuthorized(ctx, sender)
+	if err != nil {
+		return errorsmod.Wrap(err, "authorization")
+	}
+	if !ok {
+		return errors.New("unauthorized") // todo: register proper error
+	}
+	// do some sanity checks. copied from ics29 async fees
+	//
+	nextSeqSend, found := k.channelKeeper.GetNextSequenceSend(ctx, packetID.PortId, packetID.ChannelId)
+	if !found {
+		return channeltypes.ErrSequenceSendNotFound.Wrapf("channel does not exist, portID: %s, channelID: %s", packetID.PortId, packetID.ChannelId)
+	}
+
+	// only allow packets which have been sent
+	if packetID.Sequence >= nextSeqSend {
+		return channeltypes.ErrPacketNotSent
+	}
+
+	// only allow packets which have not completed the packet life cycle
+	// todo: better use channelKeeper.HasPacketCommitment ???
+
+	if bz := k.channelKeeper.GetPacketCommitment(ctx, packetID.PortId, packetID.ChannelId, packetID.Sequence); len(bz) == 0 {
+		return channeltypes.ErrPacketCommitmentNotFound.Wrap("packet has already been acknowledged or timed out")
+	}
+	// as there is no information about the package stored on chain, we can not do more to ensure the
+	// actor is authorized.
+
+	// burn the gas to charge the caller
+	ctx.GasMeter().ConsumeGas(limit, "register ibc callback hook")
+
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&CallbackData{
+		ContractAddr: sender,
+		Limit:        limit,
+		MetaData:     meta,
+	})
+	if err != nil {
+		return err
+	}
+	store.Set(BuildCallbackKey(packetID), bz)
+
+	return nil
+}
+
+type Executor interface {
+	// Do calls the contract to execute the hook. It is executed with the
+	// gas limit that was registered with the hook. The operation runs within
+	// a cached store so that an error rolls back this state but does not affect
+	// the store otherwise.
+	Do(ctx sdk.Context, contractAddr sdk.AccAddress, meta CustomDataI) error
+}
+
+var _ Executor = ExecutorFn(nil)
+
+type ExecutorFn func(ctx sdk.Context, contractAddr sdk.AccAddress, meta CustomDataI) error
+
+func (e ExecutorFn) Do(ctx sdk.Context, contractAddr sdk.AccAddress, meta CustomDataI) error {
+	return e(ctx, contractAddr, meta)
+}
+
+func (k Keeper) ExecutePacketCallback(
+	ctx sdk.Context,
+	packetID PacketId,
+	sender string,
+	exec Executor,
+) error {
+	store := ctx.KVStore(k.storeKey)
+	key := BuildCallbackKey(packetID)
+	if !store.Has(key) { // this cheaper on gas and would handle the majority of packets
+		return nil
+	}
+	// always do housekeeping
+	defer store.Delete(BuildCallbackKey(packetID))
+
+	var o CallbackData
+	// deserialize. Should be from proto instead
+	if err := json.Unmarshal(store.Get(key), &o); err != nil {
+		return err
+	}
+	if o.ContractAddr.String() != sender {
+		// somebody wasted money for a callback they are not allowed to receive.
+		// too bad we could not check on register but here we do nothing
+		return nil
+	}
+
+	// execute callback in a cached store environment so that we can revert
+	// on any failure
+	cachedCtx, commit := ctx.CacheContext()
+
+	// setup a new gas meter with the defined limit.
+	// the gas was paid before by the contract. no need to charge twice
+	gm := sdk.NewGasMeter(o.Limit)
+	cachedCtx = cachedCtx.WithGasMeter(gm)
+
+	// todo: handle panics for the callback call
+	if err := exec.Do(cachedCtx, o.ContractAddr, o.MetaData); err != nil {
+		// todo: emit event with error
+	} else {
+		commit()
+	}
+	return nil
+}
+
+// CallbackData contains the persisted data to execute a callback
+// Todo: define in protobuf. Using json de-/serialization only for rapid prototyping
+type CallbackData struct {
+	Limit        sdk.Gas
+	ContractAddr sdk.AccAddress
+	MetaData     CustomDataI // todo: should be Any type in proto
+}
+
+// CustomDataI is an extension that is persisted as a proto any type and can be used by to add additional custom data
+type CustomDataI interface{}
+
+type ChannelKeeper interface {
+	GetChannel(ctx sdk.Context, srcPort, srcChan string) (channel channeltypes.Channel, found bool)
+	GetPacketCommitment(ctx sdk.Context, portID, channelID string, sequence uint64) []byte
+	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
+}

--- a/x/xadr8/keys.go
+++ b/x/xadr8/keys.go
@@ -12,9 +12,43 @@ const (
 	Version       = "adr8-demo-1"
 )
 
-var CallbackKeyPrefix = []byte{0x01}
+var (
+	CallbackKeyPrefix = []byte{0x01}
+	separator         = []byte{0xff}
+)
 
-func BuildCallbackKey(p PacketId) []byte {
-	sep := []byte{0xff}
-	return append(CallbackKeyPrefix, bytes.Join([][]byte{[]byte(p.PortId), []byte(p.ChannelId), sdk.Uint64ToBigEndian(p.Sequence)}, sep)...)
+func BuildCallbackKey(p PacketId, actor string) []byte {
+	return bytes.Join([][]byte{BuildCallbackKeyPrefix(p), []byte(actor)}, separator)
+}
+
+func BuildCallbackKeyPrefix(p PacketId) []byte {
+	return append(CallbackKeyPrefix, bytes.Join([][]byte{[]byte(p.PortId), []byte(p.ChannelId), sdk.Uint64ToBigEndian(p.Sequence)}, separator)...)
+}
+
+// prefixRange turns a prefix into (start, end) to create
+// and iterator
+// copied from: https://github.com/iov-one/weave/blob/74fafaa757cbd510a61cc9e8b32ad8c9185d0d2e/orm/query.go#L32
+func PrefixRange(prefix []byte) ([]byte, []byte) {
+	// special case: no prefix is whole range
+	if len(prefix) == 0 {
+		return nil, nil
+	}
+
+	// copy the prefix and update last byte
+	end := make([]byte, len(prefix))
+	copy(end, prefix)
+	l := len(end) - 1
+	end[l]++
+
+	// wait, what if that overflowed?....
+	for end[l] == 0 && l > 0 {
+		l--
+		end[l]++
+	}
+
+	// okay, funny guy, you gave us FFF, no end to this range...
+	if l == 0 && end[0] == 0 {
+		end = nil
+	}
+	return prefix, end
 }

--- a/x/xadr8/keys.go
+++ b/x/xadr8/keys.go
@@ -1,0 +1,20 @@
+package xadr8
+
+import (
+	"bytes"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	SubModuleName = "adr8ibc"
+	StoreKey      = SubModuleName
+	Version       = "adr8-demo-1"
+)
+
+var CallbackKeyPrefix = []byte{0x01}
+
+func BuildCallbackKey(p PacketId) []byte {
+	sep := []byte{0xff}
+	return append(CallbackKeyPrefix, bytes.Join([][]byte{[]byte(p.PortId), []byte(p.ChannelId), sdk.Uint64ToBigEndian(p.Sequence)}, sep)...)
+}

--- a/x/xadr8/middleware.go
+++ b/x/xadr8/middleware.go
@@ -12,8 +12,19 @@ import (
 
 var _ porttypes.Middleware = &IBCMiddleware{}
 
+// PacketDecoder IBC packet decoder definition
 type PacketDecoder interface {
+	// DecodeSender returns sender address of the given packet, true
+	// false on any issue of when not found
 	DecodeSender(packet channeltypes.Packet) (string, bool)
+}
+
+var _ PacketDecoder = PacketDecoderFn(nil)
+
+type PacketDecoderFn func(packet channeltypes.Packet) (string, bool)
+
+func (p PacketDecoderFn) DecodeSender(packet channeltypes.Packet) (string, bool) {
+	return p(packet)
 }
 
 // CallbackExecutor is an abstract callback executor. To be implemented by contract engines

--- a/x/xadr8/middleware.go
+++ b/x/xadr8/middleware.go
@@ -1,0 +1,142 @@
+package xadr8
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
+)
+
+var _ porttypes.Middleware = &IBCMiddleware{}
+
+type PacketDecoder interface {
+	DecodeSender(packet channeltypes.Packet) (string, bool)
+}
+
+// CallbackExecutor is an abstract callback executor. To be implemented by contract engines
+type CallbackExecutor interface {
+	// does it make sense to have 2 methods or have a single method with additinal flag for ack/timeout??
+
+	OnIBCPacketAcked(
+		ctx sdk.Context,
+		packet channeltypes.Packet,
+		acknowledgement []byte,
+		relayer sdk.AccAddress,
+		contractAddr sdk.AccAddress,
+		meta CustomDataI,
+	) error
+
+	OnIBCPacketTimedOut(
+		ctx sdk.Context,
+		packet channeltypes.Packet,
+		relayer sdk.AccAddress,
+		contractAddr sdk.AccAddress,
+		meta CustomDataI,
+	) error
+}
+
+// IBCMiddleware adr-8 middleware
+type IBCMiddleware struct {
+	porttypes.Middleware
+	packetDecoder PacketDecoder
+	k             *Keeper
+	exec          CallbackExecutor
+}
+
+// NewIBCMiddleware constructor with generic decoder
+func NewIBCMiddleware[T SenderAuthorized](
+	cdc codec.Codec,
+	next porttypes.Middleware,
+	k *Keeper,
+	exec CallbackExecutor,
+) *IBCMiddleware {
+	return NewIBCMiddleware2(next, k, NewGenericPacketDecoder[T](cdc), exec)
+}
+
+// NewIBCMiddleware2 constructor that allows a custom decoder
+func NewIBCMiddleware2(
+	next porttypes.Middleware,
+	k *Keeper,
+	decoder PacketDecoder,
+	exec CallbackExecutor,
+) *IBCMiddleware {
+	return &IBCMiddleware{
+		Middleware:    next,
+		k:             k,
+		exec:          exec,
+		packetDecoder: decoder,
+	}
+}
+
+func (m IBCMiddleware) OnAcknowledgementPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+) error {
+	err := m.Middleware.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
+	if err != nil {
+		return err
+	}
+	// todo: should panics be handled or ignored
+	sender, ok := m.packetDecoder.DecodeSender(packet)
+	if !ok {
+		return nil
+	}
+	return m.k.ExecutePacketCallback(ctx, channeltypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence),
+		sender,
+		ExecutorFn(func(ctx sdk.Context, contractAddr sdk.AccAddress, meta CustomDataI) error {
+			return m.exec.OnIBCPacketAcked(ctx, packet, acknowledgement, relayer, contractAddr, meta)
+		}))
+}
+
+func (m IBCMiddleware) OnTimeoutPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) error {
+	err := m.Middleware.OnTimeoutPacket(ctx, packet, relayer)
+	if err != nil {
+		return err
+	}
+	sender, ok := m.packetDecoder.DecodeSender(packet)
+	if !ok {
+		return nil
+	}
+	return m.k.ExecutePacketCallback(ctx, channeltypes.NewPacketID(packet.SourcePort, packet.SourceChannel, packet.Sequence),
+		sender,
+		ExecutorFn(func(ctx sdk.Context, contractAddr sdk.AccAddress, meta CustomDataI) error {
+			return m.exec.OnIBCPacketTimedOut(ctx, packet, relayer, contractAddr, meta)
+		}))
+}
+
+var _ porttypes.Middleware = &IBCMiddleware{}
+
+// IBCMiddlewareAdapter is an adapter to build a Middleware for IBC modules
+type IBCMiddlewareAdapter struct {
+	porttypes.IBCModule
+	w porttypes.ICS4Wrapper
+}
+
+// NewIBCMiddlewareAdapter constructor
+func NewIBCMiddlewareAdapter(app porttypes.IBCModule, w porttypes.ICS4Wrapper) porttypes.Middleware {
+	if w, ok := app.(porttypes.Middleware); ok {
+		return w
+	}
+	return &IBCMiddlewareAdapter{IBCModule: app, w: w}
+}
+
+func (m IBCMiddlewareAdapter) SendPacket(ctx sdk.Context, chanCap *capabilitytypes.Capability, sourcePort string, sourceChannel string, timeoutHeight clienttypes.Height, timeoutTimestamp uint64, data []byte) (sequence uint64, err error) {
+	return m.w.SendPacket(ctx, chanCap, sourcePort, sourceChannel, timeoutHeight, timeoutTimestamp, data)
+}
+
+func (m IBCMiddlewareAdapter) WriteAcknowledgement(ctx sdk.Context, chanCap *capabilitytypes.Capability, packet ibcexported.PacketI, ack ibcexported.Acknowledgement) error {
+	return m.w.WriteAcknowledgement(ctx, chanCap, packet, ack)
+}
+
+func (m IBCMiddlewareAdapter) GetAppVersion(ctx sdk.Context, portID, channelID string) (string, bool) {
+	return m.w.GetAppVersion(ctx, portID, channelID)
+}

--- a/x/xadr8/packet_decoder.go
+++ b/x/xadr8/packet_decoder.go
@@ -3,6 +3,9 @@ package xadr8
 import (
 	"reflect"
 
+	"github.com/cosmos/cosmos-sdk/types/address"
+	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	gogoproto "github.com/cosmos/gogoproto/proto"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
@@ -13,24 +16,29 @@ type SenderAuthorized interface {
 	GetSender() string
 }
 
-type GenericPacketDecoder[T SenderAuthorized] struct {
-	cdc codec.Codec
-}
-
 // NewGenericPacketDecoder constructor
-func NewGenericPacketDecoder[T SenderAuthorized](cdc codec.Codec) *GenericPacketDecoder[T] {
-	return &GenericPacketDecoder[T]{cdc: cdc}
+func NewGenericPacketDecoder[T SenderAuthorized](cdc codec.Codec) PacketDecoder {
+	return PacketDecoderFn(func(packet channeltypes.Packet) (string, bool) {
+		var data T
+		if x := reflect.ValueOf(data); x.Kind() == reflect.Ptr && x.IsNil() {
+			v := reflect.New(reflect.TypeOf(data).Elem())
+			data = v.Interface().(T)
+		}
+		if err := cdc.UnmarshalJSON(packet.GetData(), data); err != nil {
+			return "", false
+		}
+		sender := data.GetSender()
+		return sender, sender != "" // sanity check for non empty addresses
+	})
 }
 
-func (m GenericPacketDecoder[T]) DecodeSender(packet channeltypes.Packet) (string, bool) {
-	var data T
-	if x := reflect.ValueOf(data); x.Kind() == reflect.Ptr && x.IsNil() {
-		v := reflect.New(reflect.TypeOf(data).Elem())
-		data = v.Interface().(T)
-	}
-	if err := m.cdc.UnmarshalJSON(packet.GetData(), data); err != nil {
-		return "", false
-	}
-	sender := data.GetSender()
-	return sender, sender != "" // sanity check for non empty addresses
+var portPrefixLen = len(icatypes.ControllerPortPrefix)
+
+func NewICAControllerPacketDecoder() PacketDecoder {
+	return PacketDecoderFn(func(packet channeltypes.Packet) (string, bool) {
+		if len(packet.SourcePort) < portPrefixLen+address.Len {
+			return "", false
+		}
+		return packet.SourcePort[portPrefixLen:], true
+	})
 }

--- a/x/xadr8/packet_decoder.go
+++ b/x/xadr8/packet_decoder.go
@@ -1,0 +1,36 @@
+package xadr8
+
+import (
+	"reflect"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+)
+
+type SenderAuthorized interface {
+	gogoproto.Message
+	GetSender() string
+}
+
+type GenericPacketDecoder[T SenderAuthorized] struct {
+	cdc codec.Codec
+}
+
+// NewGenericPacketDecoder constructor
+func NewGenericPacketDecoder[T SenderAuthorized](cdc codec.Codec) *GenericPacketDecoder[T] {
+	return &GenericPacketDecoder[T]{cdc: cdc}
+}
+
+func (m GenericPacketDecoder[T]) DecodeSender(packet channeltypes.Packet) (string, bool) {
+	var data T
+	if x := reflect.ValueOf(data); x.Kind() == reflect.Ptr && x.IsNil() {
+		v := reflect.New(reflect.TypeOf(data).Elem())
+		data = v.Interface().(T)
+	}
+	if err := m.cdc.UnmarshalJSON(packet.GetData(), data); err != nil {
+		return "", false
+	}
+	sender := data.GetSender()
+	return sender, sender != "" // sanity check for non empty addresses
+}

--- a/x/xwasmvm/README.md
+++ b/x/xwasmvm/README.md
@@ -1,0 +1,3 @@
+# xwasmvm
+
+hack to add some functionality to spike new methods before moving to wasmvm

--- a/x/xwasmvm/custom/custom_msg_handler.go
+++ b/x/xwasmvm/custom/custom_msg_handler.go
@@ -1,0 +1,78 @@
+package custom
+
+import (
+	"encoding/json"
+
+	"github.com/CosmWasm/wasmd/x/xadr8"
+
+	errorsmod "cosmossdk.io/errors"
+
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	"github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+// hack for fast prototyping. should not be here at all
+type Adr8Keeper interface {
+	RegisterPacketProcessedCallback(
+		ctx sdk.Context,
+		sender sdk.AccAddress,
+		packetID xadr8.PacketId,
+		limit uint64,
+		meta xadr8.CustomDataI,
+	) error
+}
+
+func XMessageHandler(k Adr8Keeper) wasmkeeper.MessengerFn {
+	if k == nil {
+		panic("keeper must not be nil")
+	}
+	return func(ctx sdk.Context, sender sdk.AccAddress, _ string, srcMsg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, err error) {
+		if srcMsg.Custom == nil {
+			return nil, nil, types.ErrUnknownMsg
+		}
+		var tmp map[string][]byte // unwrap from reflect msg container
+		if err := json.Unmarshal(srcMsg.Custom, &tmp); err != nil {
+			return nil, nil, err
+		}
+		if bz, ok := tmp["raw"]; ok {
+			srcMsg.Custom = bz
+		}
+		println(string(srcMsg.Custom))
+
+		// decode from transport format
+		var msg CustomADR8Msg
+		if err := json.Unmarshal(srcMsg.Custom, &msg); err != nil {
+			return nil, nil, err
+		}
+		return handleMySpikedMsgs(ctx, sender, msg, k)
+	}
+}
+
+func handleMySpikedMsgs(ctx sdk.Context, sender sdk.AccAddress, msg CustomADR8Msg, k Adr8Keeper) ([]sdk.Event, [][]byte, error) {
+	switch {
+	case msg.RegisterPacketProcessedCallback != nil:
+		var noCustomMetadata xadr8.CustomDataI
+		// todo: convert to ibc-go sdk message type for proper registration
+		// I call the xibcgo keeper here as a shortcut only.
+		err := k.RegisterPacketProcessedCallback(
+			ctx,
+			sender,
+			xadr8.PacketId{
+				PortId:    msg.RegisterPacketProcessedCallback.PortID,
+				ChannelId: msg.RegisterPacketProcessedCallback.ChannelID,
+				Sequence:  msg.RegisterPacketProcessedCallback.Sequence,
+			},
+			msg.RegisterPacketProcessedCallback.MaxCallbackGasLimit,
+			noCustomMetadata,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, nil // todo: hack called the keeper already. no msg returned here to end the processing
+	default:
+		return nil, nil, errorsmod.Wrap(types.ErrUnknownMsg, "unknown variant of IBC")
+	}
+}

--- a/x/xwasmvm/custom/msg.go
+++ b/x/xwasmvm/custom/msg.go
@@ -1,0 +1,19 @@
+package custom
+
+type CustomADR8Msg struct {
+	RegisterPacketProcessedCallback           *RegisterPacketProcessedCallback   `json:"register_packet_processed_callback,omitempty"`
+	UnregisterRegisterPacketProcessedCallback *UnRegisterPacketProcessedCallback `json:"unregister_register_packet_processed_callback,omitempty"`
+}
+
+type RegisterPacketProcessedCallback struct {
+	// Sequence is the ibc packet sequence number
+	Sequence            uint64 `json:"sequence"`
+	ChannelID           string `json:"channel_id"`
+	PortID              string `json:"port_id"`
+	MaxCallbackGasLimit uint64 `json:"max_callback_gas_limit"`
+}
+
+type UnRegisterPacketProcessedCallback struct {
+	Sequence  uint64 `json:"sequence"`
+	ChannelID string `json:"channel_id"`
+}

--- a/x/xwasmvm/xwasmvm.go
+++ b/x/xwasmvm/xwasmvm.go
@@ -1,0 +1,41 @@
+// Package xwasmvm is an extended wasmvm api for testing with mock impl only
+package xwasmvm
+
+import (
+	wasmvm "github.com/CosmWasm/wasmvm"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
+)
+
+type (
+	IBCPacketAckedMsg    = wasmvmtypes.IBCPacketAckMsg
+	IBCPacketTimedOutMsg = wasmvmtypes.IBCPacketTimeoutMsg
+)
+
+// var _ types.WasmerEngine = &XVM{}
+
+type XVM struct {
+	*wasmvm.VM
+	OnIBCPacketAckedFn    func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+	OnIBCPacketTimedOutFn func(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg IBCPacketTimedOutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error)
+}
+
+func (m XVM) OnIBCPacketAcked(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg IBCPacketAckedMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+	if m.OnIBCPacketAckedFn == nil {
+		panic("not expected to be called")
+	}
+	return m.OnIBCPacketAckedFn(checksum, env, msg, store, goapi, querier, gasMeter, gasLimit, deserCost)
+}
+
+func (m XVM) OnIBCPacketTimedOut(checksum wasmvm.Checksum, env wasmvmtypes.Env, msg IBCPacketTimedOutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResponse, uint64, error) {
+	return m.OnIBCPacketTimedOut(checksum, env, msg, store, goapi, querier, gasMeter, gasLimit, deserCost)
+}
+
+func NewVM(dataDir string, supportedCapabilities string, memoryLimit uint32, printDebug bool, cacheSize uint32) (*XVM, error) {
+	vm, err := wasmvm.NewVM(dataDir, supportedCapabilities, memoryLimit, printDebug, cacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &XVM{
+		VM: vm,
+	}, nil
+}


### PR DESCRIPTION
Spike to discuss a concrete example.
This includes a some of hacks to make it work without modifying wasmvm.

A good start would be to look at `TestIBCAdr8WithTransfer` for the test scenario. Ics29 fees or edge cases are not covered
The middleware integration is done in `app.go`

For the callback to the contracts, 2 new methods are added to the wasmvm interface and mocked for proof of concept
* OnIBCPacketAcked
* OnIBCPacketTimedOut

For the callback registration a custom message was added that the reflect contract emits in the test:
```go
type RegisterPacketProcessedCallback struct {
	// Sequence is the ibc packet sequence number
	Sequence            uint64 `json:"sequence"`
	ChannelID           string `json:"channel_id"`
	PortID              string `json:"port_id"`
	MaxCallbackGasLimit uint64 `json:"max_callback_gas_limit"`
}
```

The message is handled in the `XMessageHandler` and contains some ugly hack for the reflect contract.

### Authorization
* on callback registration, it is checked that the actor is a contract
* on ack/timeout handling, the packet sender is only accepted for a registered hook

### New Packages
* xwasmvm are extensions to WasmVm for the spike only. If they make sense, then they should be moved upstream
* xadr8 are common parts that are not CosmWasm specific. If they make sense, they could be living in ibc-go for example
