### PR TITLE
Use ICS4Wrapper to send raw IBC packets & fix Fee middleware in wasm stack

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -522,6 +522,7 @@ func NewWasmApp(
 		app.BankKeeper,
 		app.StakingKeeper,
 		app.DistrKeeper,
+		app.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
 		app.IBCKeeper.ChannelKeeper,
 		&app.IBCKeeper.PortKeeper,
 		scopedWasmKeeper,

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -663,6 +663,7 @@ func setupKeeper(t *testing.T) (*Keeper, sdk.Context, []sdk.StoreKey) {
 		nil,
 		nil,
 		nil,
+		nil,
 		tempDir,
 		wasmConfig,
 		AvailableCapabilities,

--- a/x/wasm/keeper/handler_plugin_test.go
+++ b/x/wasm/keeper/handler_plugin_test.go
@@ -307,7 +307,7 @@ func TestIBCRawPacketHandler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			capturedPacket = nil
 			// when
-			h := NewIBCRawPacketHandler(spec.chanKeeper, spec.capKeeper)
+			h := NewIBCRawPacketHandler(spec.chanKeeper, spec.chanKeeper, spec.capKeeper)
 			evts, data, gotErr := h.DispatchMsg(ctx, RandomAccountAddress(t), ibcPort, wasmvmtypes.CosmosMsg{IBC: &wasmvmtypes.IBCMsg{SendPacket: &spec.srcMsg}})
 			// then
 			require.True(t, spec.expErr.Is(gotErr), "exp %v but got %#+v", spec.expErr, gotErr)

--- a/x/wasm/keeper/keeper_cgo.go
+++ b/x/wasm/keeper/keeper_cgo.go
@@ -11,6 +11,8 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"
+
+	ibctransfertypes "github.com/cosmos/ibc-go/v4/modules/core/05-port/types"
 )
 
 // NewKeeper creates a new contract Keeper instance
@@ -23,6 +25,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	stakingKeeper types.StakingKeeper,
 	distKeeper types.DistributionKeeper,
+	ics4Wrapper ibctransfertypes.ICS4Wrapper,
 	channelKeeper types.ChannelKeeper,
 	portKeeper types.PortKeeper,
 	capabilityKeeper types.CapabilityKeeper,
@@ -52,7 +55,7 @@ func NewKeeper(
 		accountPruner:        NewVestingCoinBurner(bankKeeper),
 		portKeeper:           portKeeper,
 		capabilityKeeper:     capabilityKeeper,
-		messenger:            NewDefaultMessageHandler(router, channelKeeper, capabilityKeeper, bankKeeper, cdc, portSource),
+		messenger:            NewDefaultMessageHandler(router, ics4Wrapper, channelKeeper, capabilityKeeper, bankKeeper, cdc, portSource),
 		queryGasLimit:        wasmConfig.SmartQueryGasLimit,
 		paramSpace:           paramSpace,
 		gasRegister:          NewDefaultWasmGasRegister(),

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -749,7 +749,7 @@ func TestInstantiateWithContractFactoryChildQueriesParent(t *testing.T) {
 	router := baseapp.NewMsgServiceRouter()
 	router.SetInterfaceRegistry(keepers.EncodingConfig.InterfaceRegistry)
 	types.RegisterMsgServer(router, NewMsgServerImpl(NewDefaultPermissionKeeper(keeper)))
-	keeper.messenger = NewDefaultMessageHandler(router, nil, nil, nil, keepers.EncodingConfig.Marshaler, nil)
+	keeper.messenger = NewDefaultMessageHandler(router, nil, nil, nil, nil, keepers.EncodingConfig.Marshaler, nil)
 	// overwrite wasmvm in response handler
 	keeper.wasmVMResponseHandler = NewDefaultWasmVMContractResponseHandler(NewMessageDispatcher(keeper.messenger, keeper))
 

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -115,7 +115,7 @@ func TestConstructorOptions(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			k := NewKeeper(nil, nil, paramtypes.NewSubspace(nil, nil, nil, nil, ""), authkeeper.AccountKeeper{}, &bankkeeper.BaseKeeper{}, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, "tempDir", types.DefaultWasmConfig(), AvailableCapabilities, spec.srcOpt)
+			k := NewKeeper(nil, nil, paramtypes.NewSubspace(nil, nil, nil, nil, ""), authkeeper.AccountKeeper{}, &bankkeeper.BaseKeeper{}, stakingkeeper.Keeper{}, distributionkeeper.Keeper{}, nil, nil, nil, nil, nil, nil, nil, "tempDir", types.DefaultWasmConfig(), AvailableCapabilities, spec.srcOpt)
 			spec.verify(t, k)
 		})
 	}

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -380,6 +380,7 @@ func createTestInput(
 		bankKeeper,
 		stakingKeeper,
 		distKeeper,
+		ibcKeeper.ChannelKeeper, // ICS4Wrapper
 		ibcKeeper.ChannelKeeper,
 		&ibcKeeper.PortKeeper,
 		scopedWasmKeeper,


### PR DESCRIPTION
This PR adds an ICS4Wrapper to the wasm keeper, which serves as the interface for sending raw IBC packets. This feature enables the chain to use middlewares with IBC-enabled contracts.

As of v0.31, the Fee middleware is only configured for incoming packets, as shown in this code snippet: [link](https://github.com/CosmWasm/wasmd/blob/v0.31.0/app/app.go#L568). On the other hand, for outgoing packets, the wasm keeper directly uses the IBC channel keeper, as shown here: [link](https://github.com/CosmWasm/wasmd/blob/v0.31.0//x/wasm/keeper/handler_plugin.go#L192). Consequently, the Fee middleware is bypassed for outgoing packets. Since IBC relayer fees are paid on the sending chains, this means that a relayer can be paid for relaying IBC packets to wasmd but not for relaying packets from wasmd.