### PR TITLE
Bump pinned docker version in circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,8 +154,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - setup_remote_docker:
-          # >= v20.10 https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
-          version: 20.10.11
+          version: 20.10.18
       - run:
           name: Build Docker artifact
           command: docker build --pull -t "cosmwasm/wasmd:${CIRCLE_SHA1}" .


### PR DESCRIPTION
`20.10.18` has become [default](https://circleci.com/docs/building-docker-images/#docker-version)