### PR TITLE
chore: lint main with latest golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.19
 
 commands:
   make:
@@ -171,7 +171,7 @@ jobs:
             fi
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >> ]
+            equal: [main, << pipeline.git.branch >>]
           steps:
             - run:
                 name: Push application Docker image to docker hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
 
 commands:
   make:
@@ -61,7 +61,7 @@ jobs:
 
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.50.1
+      - image: golangci/golangci-lint:v1.52.2
     steps:
       - checkout
       - run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - exportloopref

--- a/x/wasm/keeper/proposal_integration_test.go
+++ b/x/wasm/keeper/proposal_integration_test.go
@@ -64,7 +64,7 @@ func TestStoreCodeProposal(t *testing.T) {
 			ctx, _ := parentCtx.CacheContext()
 			myActorAddress := RandomBech32AccountAddress(t)
 
-			src := types.StoreCodeProposalFixture(func(p *types.StoreCodeProposal) {
+			src := types.StoreCodeProposalFixture(func(p *types.StoreCodeProposal) { //nolint:staticcheck // testing deprecated function
 				p.RunAs = myActorAddress
 				p.WASMByteCode = spec.code
 				p.UnpinCode = spec.unpinCode
@@ -141,7 +141,7 @@ func TestInstantiateProposal(t *testing.T) {
 		oneAddress   sdk.AccAddress = bytes.Repeat([]byte{0x1}, types.ContractAddrLen)
 		otherAddress sdk.AccAddress = bytes.Repeat([]byte{0x2}, types.ContractAddrLen)
 	)
-	src := types.InstantiateContractProposalFixture(func(p *types.InstantiateContractProposal) {
+	src := types.InstantiateContractProposalFixture(func(p *types.InstantiateContractProposal) { //nolint:staticcheck // testing deprecated function
 		p.CodeID = firstCodeID
 		p.RunAs = oneAddress.String()
 		p.Admin = otherAddress.String()
@@ -200,7 +200,7 @@ func TestInstantiate2Proposal(t *testing.T) {
 		label                       = "label"
 		salt                        = []byte("mySalt")
 	)
-	src := types.InstantiateContract2ProposalFixture(func(p *types.InstantiateContract2Proposal) {
+	src := types.InstantiateContract2ProposalFixture(func(p *types.InstantiateContract2Proposal) { //nolint:staticcheck // testing deprecated function
 		p.CodeID = firstCodeID
 		p.RunAs = oneAddress.String()
 		p.Admin = otherAddress.String()
@@ -270,7 +270,7 @@ func TestInstantiateProposal_NoAdmin(t *testing.T) {
 	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
-			src := types.InstantiateContractProposalFixture(func(p *types.InstantiateContractProposal) {
+			src := types.InstantiateContractProposalFixture(func(p *types.InstantiateContractProposal) { //nolint:staticcheck // testing deprecated function
 				p.CodeID = firstCodeID
 				p.RunAs = oneAddress.String()
 				p.Admin = spec.srcAdmin
@@ -338,7 +338,7 @@ func TestStoreAndInstantiateContractProposal(t *testing.T) {
 		otherAddress sdk.AccAddress = bytes.Repeat([]byte{0x2}, types.ContractAddrLen)
 	)
 
-	src := types.StoreAndInstantiateContractProposalFixture(func(p *types.StoreAndInstantiateContractProposal) {
+	src := types.StoreAndInstantiateContractProposalFixture(func(p *types.StoreAndInstantiateContractProposal) { //nolint:staticcheck // testing deprecated function
 		p.WASMByteCode = wasmCode
 		p.RunAs = oneAddress.String()
 		p.Admin = otherAddress.String()
@@ -418,7 +418,7 @@ func TestMigrateProposal(t *testing.T) {
 	migMsgBz, err := json.Marshal(migMsg)
 	require.NoError(t, err)
 
-	src := &types.MigrateContractProposal{
+	src := &types.MigrateContractProposal{ //nolint:staticcheck // testing deprecated function
 		Title:       "Foo",
 		Description: "Bar",
 		CodeID:      2,
@@ -475,7 +475,7 @@ func TestExecuteProposal(t *testing.T) {
 	require.NoError(t, err)
 
 	// try with runAs that doesn't have pemission
-	badSrc := &types.ExecuteContractProposal{
+	badSrc := &types.ExecuteContractProposal{ //nolint:staticcheck // testing deprecated function
 		Title:       "First",
 		Description: "Beneficiary has no permission to run",
 		Contract:    contractAddr.String(),
@@ -494,7 +494,7 @@ func TestExecuteProposal(t *testing.T) {
 	require.Equal(t, bal.Amount, sdk.NewInt(100))
 
 	// try again with the proper run-as
-	src := &types.ExecuteContractProposal{
+	src := &types.ExecuteContractProposal{ //nolint:staticcheck // testing deprecated function
 		Title:       "Second",
 		Description: "Verifier can execute",
 		Contract:    contractAddr.String(),
@@ -540,7 +540,7 @@ func TestSudoProposal(t *testing.T) {
 	require.NoError(t, err)
 
 	// sudo can do anything
-	src := &types.SudoContractProposal{
+	src := &types.SudoContractProposal{ //nolint:staticcheck // testing deprecated function
 		Title:       "Sudo",
 		Description: "Steal funds for the verifier",
 		Contract:    contractAddr.String(),
@@ -574,7 +574,7 @@ func TestAdminProposals(t *testing.T) {
 	}{
 		"update with different admin": {
 			state: types.ContractInfoFixture(),
-			srcProposal: &types.UpdateAdminProposal{
+			srcProposal: &types.UpdateAdminProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				Contract:    contractAddr.String(),
@@ -586,7 +586,7 @@ func TestAdminProposals(t *testing.T) {
 			state: types.ContractInfoFixture(func(info *types.ContractInfo) {
 				info.Admin = ""
 			}),
-			srcProposal: &types.UpdateAdminProposal{
+			srcProposal: &types.UpdateAdminProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				Contract:    contractAddr.String(),
@@ -596,7 +596,7 @@ func TestAdminProposals(t *testing.T) {
 		},
 		"clear admin": {
 			state: types.ContractInfoFixture(),
-			srcProposal: &types.ClearAdminProposal{
+			srcProposal: &types.ClearAdminProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				Contract:    contractAddr.String(),
@@ -607,7 +607,7 @@ func TestAdminProposals(t *testing.T) {
 			state: types.ContractInfoFixture(func(info *types.ContractInfo) {
 				info.Admin = ""
 			}),
-			srcProposal: &types.ClearAdminProposal{
+			srcProposal: &types.ClearAdminProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				Contract:    contractAddr.String(),
@@ -710,7 +710,7 @@ func TestPinCodesProposal(t *testing.T) {
 			gotPinnedChecksums = nil
 			ctx, _ := parentCtx.CacheContext()
 			mock.PinFn = spec.mockFn
-			proposal := &types.PinCodesProposal{
+			proposal := &types.PinCodesProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				CodeIDs:     spec.srcCodeIDs,
@@ -800,7 +800,7 @@ func TestUnpinCodesProposal(t *testing.T) {
 			gotUnpinnedChecksums = nil
 			ctx, _ := parentCtx.CacheContext()
 			mock.UnpinFn = spec.mockFn
-			proposal := &types.UnpinCodesProposal{
+			proposal := &types.UnpinCodesProposal{ //nolint:staticcheck // testing deprecated function
 				Title:       "Foo",
 				Description: "Bar",
 				CodeIDs:     spec.srcCodeIDs,
@@ -898,7 +898,7 @@ func TestUpdateInstantiateConfigProposal(t *testing.T) {
 
 			govAuthority := keepers.AccountKeeper.GetModuleAddress(govtypes.ModuleName).String()
 			msgServer := govkeeper.NewMsgServerImpl(keepers.GovKeeper)
-			proposal := &types.UpdateInstantiateConfigProposal{
+			proposal := &types.UpdateInstantiateConfigProposal{ //nolint:staticcheck // testing deprecated function
 				Title:               "Foo",
 				Description:         "Bar",
 				AccessConfigUpdates: updates,

--- a/x/wasm/keeper/relay_test.go
+++ b/x/wasm/keeper/relay_test.go
@@ -463,7 +463,7 @@ func TestOnRecvPacket(t *testing.T) {
 			msg := wasmvmtypes.IBCPacketReceiveMsg{Packet: myPacket}
 			if spec.expPanic {
 				assert.Panics(t, func() {
-					keepers.WasmKeeper.OnRecvPacket(ctx, spec.contractAddr, msg)
+					_, _ = keepers.WasmKeeper.OnRecvPacket(ctx, spec.contractAddr, msg)
 				})
 				return
 			}


### PR DESCRIPTION
This PR is a regular update of the linter for wasmd

- bump golang and linter in ci
- cleanup lints
