### PR TITLE
chore: upgrade to go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.20
 
 commands:
   make:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CosmWasm/wasmd
 
-go 1.19
+go 1.20
 
 require (
 	github.com/CosmWasm/wasmvm v1.2.3


### PR DESCRIPTION
This PR upgrades go in wasmd to v1.20

closes: https://github.com/CosmWasm/wasmd/issues/1385
