### PR TITLE
Add Encodings For `MsgFundCommunityPool` from Distribution

### DIFF
--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -146,13 +146,13 @@ func EncodeDistributionMsg(sender sdk.AccAddress, msg *wasmvmtypes.DistributionM
 		}
 		return []sdk.Msg{&withdrawMsg}, nil
 	case msg.FundCommunityPool != nil:
-		amt,  err := ConvertWasmCoinsToSdkCoins(msg.FundCommunityPool.Amount)
+		amt, err := ConvertWasmCoinsToSdkCoins(msg.FundCommunityPool.Amount)
 		if err != nil {
 			return nil, err
 		}
 		fundMsg := distributiontypes.MsgFundCommunityPool{
 			Depositor: sender.String(),
-			Amount: amt,
+			Amount:    amt,
 		}
 		return []sdk.Msg{&fundMsg}, nil
 	default:

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -145,6 +145,16 @@ func EncodeDistributionMsg(sender sdk.AccAddress, msg *wasmvmtypes.DistributionM
 			ValidatorAddress: msg.WithdrawDelegatorReward.Validator,
 		}
 		return []sdk.Msg{&withdrawMsg}, nil
+	case msg.FundCommunityPool != nil:
+		amt,  err := ConvertWasmCoinsToSdkCoins(msg.FundCommunityPool.Amount)
+		if err != nil {
+			return nil, err
+		}
+		fundMsg := distributiontypes.MsgFundCommunityPool{
+			Depositor: sender.String(),
+			Amount: amt,
+		}
+		return []sdk.Msg{&fundMsg}, nil
 	default:
 		return nil, errorsmod.Wrap(types.ErrUnknownMsg, "unknown variant of Distribution")
 	}

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -383,6 +383,28 @@ func TestEncoding(t *testing.T) {
 				},
 			},
 		},
+		"distribution fund community pool": {
+			sender: addr1,
+			srcMsg: wasmvmtypes.CosmosMsg{
+				Distribution: &wasmvmtypes.DistributionMsg {
+					FundCommunityPool: &wasmvmtypes.FundCommunityPoolMsg{
+						Amount: wasmvmtypes.Coins{
+							wasmvmtypes.NewCoin(200, "stones"),
+							wasmvmtypes.NewCoin(200, "feathers"),
+						},
+					},
+				},
+			},
+			output: []sdk.Msg{
+				&distributiontypes.MsgFundCommunityPool{
+					Depositor: addr1.String(),
+					Amount: sdk.NewCoins(
+						sdk.NewInt64Coin("stones", 200),
+						sdk.NewInt64Coin("feathers", 200),
+					),
+				},
+			},
+		},
 		"stargate encoded bank msg": {
 			sender: addr2,
 			srcMsg: wasmvmtypes.CosmosMsg{

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -386,7 +386,7 @@ func TestEncoding(t *testing.T) {
 		"distribution fund community pool": {
 			sender: addr1,
 			srcMsg: wasmvmtypes.CosmosMsg{
-				Distribution: &wasmvmtypes.DistributionMsg {
+				Distribution: &wasmvmtypes.DistributionMsg{
 					FundCommunityPool: &wasmvmtypes.FundCommunityPoolMsg{
 						Amount: wasmvmtypes.Coins{
 							wasmvmtypes.NewCoin(200, "stones"),


### PR DESCRIPTION
Hello. This is a follow-up for the follwoing issues and PRs:

- https://github.com/CosmWasm/wasmvm/pull/433
- https://github.com/classic-terra/core/issues/288
- https://github.com/CosmWasm/cosmwasm/issues/1741

This PR conducts following changes:

- add `MsgFundCommunityPool` to the supported Msg encodings
- `Depositor` field is automatically filled with sender address (= contract)
- add encoding test

**Note** that this PR depends on changes in wasmvm repository. I ran the build and unit-tests locally where I could easily swap the wasmvm dependency with my local wasmvm repo using replace section in `go.mod`. So before merging a version bump of wasmvm might be required.