### PR TITLE
Use large resouce class for CI system tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
   test-system:
     executor: golang
     parallelism: 1
+    resource_class: large
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
better machine type for system tests on CircleCI
System tests are flickering: 
* https://app.circleci.com/pipelines/github/CosmWasm/wasmd/3733/workflows/808a7a32-fb30-4fc5-a41f-7175903da16c/jobs/15866
* https://app.circleci.com/pipelines/github/CosmWasm/wasmd/3724/workflows/b1b80b81-5b0d-4f99-b3e1-368370b20712/jobs/15859?invite=true#step-104-202