### PR TITLE
Export empty byte code when code hash is empty

### DIFF
--- a/x/wasm/keeper/genesis.go
+++ b/x/wasm/keeper/genesis.go
@@ -78,9 +78,13 @@ func ExportGenesis(ctx sdk.Context, keeper *Keeper) *types.GenesisState {
 	genState.Params = keeper.GetParams(ctx)
 
 	keeper.IterateCodeInfos(ctx, func(codeID uint64, info types.CodeInfo) bool {
-		bytecode, err := keeper.GetByteCode(ctx, codeID)
-		if err != nil {
-			panic(err)
+		var bytecode []byte
+		var err error
+		if len(info.CodeHash) != 0 {
+			bytecode, err = keeper.GetByteCode(ctx, codeID)
+			if err != nil {
+				panic(err)
+			}
 		}
 		genState.Codes = append(genState.Codes, types.Code{
 			CodeID:    codeID,


### PR DESCRIPTION
## Description
It seems that Terra made the decision to abandon the code of all contracts when upgrading from Columbus-4 to Columbus-5 because of incompatibility. It also removed CodeHash and CodeBytes when exporting the Columbus-4 Genesis to reduce unnecessary space usage. This resulted in the addition of [exception handling](https://github.com/classic-terra/core/blob/v2.0.1/x/wasm/genesis.go#L70C1-L76) to the GenesisExport function of Columbus-5.

The purpose of this PR is to resolve the panic issue that occurs during the export of Genesis in Classic Terra Core v2.1.1 with using CosmWasm/wasmd v0.30.0

Related Issue: https://github.com/classic-terra/core/issues/296