### PR TITLE
Allow better override of wasmVM in x/wasm keeper

### DIFF
--- a/x/wasm/keeper/keeper_cgo.go
+++ b/x/wasm/keeper/keeper_cgo.go
@@ -35,7 +35,6 @@ func NewKeeper(
 	authority string,
 	opts ...Option,
 ) Keeper {
-
 	keeper := &Keeper{
 		storeKey:             storeKey,
 		cdc:                  cdc,
@@ -56,7 +55,8 @@ func NewKeeper(
 		authority: authority,
 	}
 	keeper.wasmVMQueryHandler = DefaultQueryPlugins(bankKeeper, stakingKeeper, distrKeeper, channelKeeper, keeper)
-	for _, o := range opts {
+	preOpts, postOpts := splitOpts(opts)
+	for _, o := range preOpts {
 		o.apply(keeper)
 	}
 	// only set the wasmvm if no one set this in the options
@@ -69,7 +69,10 @@ func NewKeeper(
 		}
 	}
 
-	// not updateable, yet
+	for _, o := range postOpts {
+		o.apply(keeper)
+	}
+	// not updatable, yet
 	keeper.wasmVMResponseHandler = NewDefaultWasmVMContractResponseHandler(NewMessageDispatcher(keeper.messenger, keeper))
 	return *keeper
 }

--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -16,6 +16,13 @@ func (f optsFn) apply(keeper *Keeper) {
 	f(keeper)
 }
 
+// option that is applied after keeper is setup with the VM. Used for decorators mainly.
+type postOptsFn func(*Keeper)
+
+func (f postOptsFn) apply(keeper *Keeper) {
+	f(keeper)
+}
+
 // WithWasmEngine is an optional constructor parameter to replace the default wasmVM engine with the
 // given one.
 func WithWasmEngine(x types.WasmerEngine) Option {
@@ -26,7 +33,7 @@ func WithWasmEngine(x types.WasmerEngine) Option {
 
 // WithWasmEngineDecorator is an optional constructor parameter to decorate the default wasmVM engine.
 func WithWasmEngineDecorator(d func(old types.WasmerEngine) types.WasmerEngine) Option {
-	return optsFn(func(k *Keeper) {
+	return postOptsFn(func(k *Keeper) {
 		k.wasmVM = d(k.wasmVM)
 	})
 }
@@ -42,7 +49,7 @@ func WithMessageHandler(x Messenger) Option {
 // WithMessageHandlerDecorator is an optional constructor parameter to decorate the wasm handler for wasmVM messages.
 // This option should not be combined with Option `WithMessageEncoders` or `WithMessageHandler`
 func WithMessageHandlerDecorator(d func(old Messenger) Messenger) Option {
-	return optsFn(func(k *Keeper) {
+	return postOptsFn(func(k *Keeper) {
 		k.messenger = d(k.messenger)
 	})
 }
@@ -58,7 +65,7 @@ func WithQueryHandler(x WasmVMQueryHandler) Option {
 // WithQueryHandlerDecorator is an optional constructor parameter to decorate the default wasm query handler for wasmVM requests.
 // This option should not be combined with Option `WithQueryPlugins` or `WithQueryHandler`
 func WithQueryHandlerDecorator(d func(old WasmVMQueryHandler) WasmVMQueryHandler) Option {
-	return optsFn(func(k *Keeper) {
+	return postOptsFn(func(k *Keeper) {
 		k.wasmVMQueryHandler = d(k.wasmVMQueryHandler)
 	})
 }
@@ -188,4 +195,17 @@ func asTypeMap(accts []authtypes.AccountI) map[reflect.Type]struct{} {
 		m[at] = struct{}{}
 	}
 	return m
+}
+
+// split into pre and post VM operations
+func splitOpts(opts []Option) ([]Option, []Option) {
+	pre, post := make([]Option, 0), make([]Option, 0)
+	for _, o := range opts {
+		if _, ok := o.(postOptsFn); ok {
+			post = append(post, o)
+		} else {
+			pre = append(pre, o)
+		}
+	}
+	return pre, post
 }


### PR DESCRIPTION
The current code always creates one VM and then possibly overrides it with the options. However, creating the wasmVm will also create directories and initialize Rust structs that are not cleanly deleted. It would be better to never create it in the first place if it is overridden later.

This PR pushes the initialization towards the end of NewKeeper for this. A concrete use-case is in creating a wasmvm.VM externally and passing it in for more control, which will likely be necessary with ibc wasm light client.
