### PR TITLE
Build release + artifact on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  gh: circleci/github-cli@2.2.0
 
 executors:
   golang:
@@ -171,7 +173,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - setup_remote_docker:
-          version: 20.10.18
+          docker_layer_caching: true
       - run:
           name: Build Docker artifact
           command: docker build --pull -t "cosmwasm/wasmd:${CIRCLE_SHA1}" .
@@ -188,7 +190,7 @@ jobs:
             fi
       - when:
           condition:
-            equal: [main, << pipeline.git.branch >>]
+            equal: [ main, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: Push application Docker image to docker hub
@@ -205,8 +207,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - setup_remote_docker:
-          # >= v20.10 https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
-          version: 20.10.11
+          docker_layer_caching: true
       - run:
           name: Build Docker artifact
           command: docker build --pull -t "cosmwasm/wasmd:${CIRCLE_TAG}" .
@@ -217,8 +218,35 @@ jobs:
             docker push "cosmwasm/wasmd:${CIRCLE_TAG}"
             docker logout
 
+  release-tagged:
+    executor: golang
+    environment:
+      BUILD_DIR: /tmp/workspace
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Fetch static artifact
+          command: docker create --name wasmd_temp "cosmwasm/wasmd:${CIRCLE_TAG}"; docker cp wasmd_temp:/usr/bin/wasmd ${BUILD_DIR};  docker rm -f wasmd_temp
+      - run:
+          name: gzip
+          command: tar -zcvf ${BUILD_DIR}/wasmd-${CIRCLE_TAG}-linux-amd64.tar.gz -C ${BUILD_DIR} wasmd
+      - gh/setup:
+          token: GITHUB_CREDS
+      - run:
+          name: Create release
+          command: |
+            gh release create ${CIRCLE_TAG} ${BUILD_DIR}/wasmd-${CIRCLE_TAG}-linux-amd64.tar.gz \
+            --title "$CIRCLE_TAG" \
+            --draft \
+            --notes "# Wasmd ${CIRCLE_TAG} Release
+            See the [CHANGELOG](https://github.com/CosmWasm/wasmd/blob/${CIRCLE_TAG}/CHANGELOG.md) for details on the changes in this version.
+            "
+
 workflows:
-  version: 2
   test-suite:
     jobs:
       - docker-image:
@@ -233,7 +261,9 @@ workflows:
               ignore:
                 - /.*/
           requires:
-            - setup-dependencies
+            - docker-image
+            - test-system
+            - simulations
       - setup-dependencies:
           # filters here are needed to enable this job also for tags
           filters:
@@ -258,3 +288,13 @@ workflows:
       - simulations:
           requires:
             - setup-dependencies
+      - release-tagged:
+          requires:
+            - docker-tagged
+          filters:
+            tags:
+              only:
+                - /^v.*/
+            branches:
+              ignore:
+                - /.*/


### PR DESCRIPTION
Store artifact on release.
Step 1 for https://github.com/CosmWasm/wasmd/issues/1480

CircleCI is setup with `GITHUB_CREDS` to evaluate this for 90days