### PR TITLE
Revisit circleCI workflow for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,7 @@ workflows:
               ignore:
                 - /.*/
           requires:
-            - docker-image
-            - test-system
-            - simulations
+            - setup-dependencies
       - setup-dependencies:
           # filters here are needed to enable this job also for tags
           filters:


### PR DESCRIPTION
The docker tag and release step must not depend on other steps that are not enabled for tags.
No need to re-run them as people would not tag a broken build ...