### PR TITLE
fix: use a constant for badAddress in tx_test.go

### DIFF
--- a/x/wasm/types/tx_test.go
+++ b/x/wasm/types/tx_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 const firstCodeID = 1
+const badAddress = "abcd"
 
 func TestStoreCodeValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, ContractAddrLen)).String()
 	sdk.GetConfig().SetAddressVerifier(VerifyAddressLen())
@@ -76,7 +76,6 @@ func TestStoreCodeValidation(t *testing.T) {
 }
 
 func TestInstantiateContractValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	sdk.GetConfig().SetAddressVerifier(VerifyAddressLen())
@@ -182,7 +181,6 @@ func TestInstantiateContractValidation(t *testing.T) {
 }
 
 func TestInstantiateContract2Validation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	sdk.GetConfig().SetAddressVerifier(VerifyAddressLen())
@@ -316,7 +314,6 @@ func TestInstantiateContract2Validation(t *testing.T) {
 }
 
 func TestExecuteContractValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 
@@ -423,7 +420,6 @@ func TestExecuteContractValidation(t *testing.T) {
 }
 
 func TestMsgUpdateAdministrator(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	otherGoodAddress := sdk.AccAddress(bytes.Repeat([]byte{0x1}, 20)).String()
@@ -493,7 +489,6 @@ func TestMsgUpdateAdministrator(t *testing.T) {
 }
 
 func TestMsgClearAdministrator(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	anotherGoodAddress := sdk.AccAddress(bytes.Repeat([]byte{0x2}, 20)).String()
@@ -542,7 +537,6 @@ func TestMsgClearAdministrator(t *testing.T) {
 }
 
 func TestMsgMigrateContract(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	anotherGoodAddress := sdk.AccAddress(bytes.Repeat([]byte{0x2}, 20)).String()
@@ -666,7 +660,6 @@ func TestMsgJsonSignBytes(t *testing.T) {
 }
 
 func TestMsgUpdateInstantiateConfig(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	anotherGoodAddress := sdk.AccAddress(bytes.Repeat([]byte{0x2}, 20)).String()
@@ -726,7 +719,6 @@ func TestMsgUpdateInstantiateConfig(t *testing.T) {
 }
 
 func TestMsgUpdateParamsValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 
@@ -828,7 +820,6 @@ func TestMsgAddCodeUploadParamsAddressesValidation(t *testing.T) {
 }
 
 func TestMsgRemoveCodeUploadParamsAddressesValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 
@@ -889,7 +880,6 @@ func TestMsgRemoveCodeUploadParamsAddressesValidation(t *testing.T) {
 }
 
 func TestMsgPinCodesValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 
@@ -936,7 +926,6 @@ func TestMsgPinCodesValidation(t *testing.T) {
 }
 
 func TestMsgUnpinCodesValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 
@@ -1058,7 +1047,6 @@ func TestMsgSudoContractValidation(t *testing.T) {
 }
 
 func TestMsgStoreAndInstantiateContractValidation(t *testing.T) {
-	badAddress := "abcd"
 	// proper address size
 	goodAddress := sdk.AccAddress(make([]byte, 20)).String()
 	sdk.GetConfig().SetAddressVerifier(VerifyAddressLen())

--- a/x/wasm/types/tx_test.go
+++ b/x/wasm/types/tx_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const firstCodeID = 1
-const badAddress = "abcd"
+const (
+	firstCodeID = 1
+	badAddress  = "abcd"
+)
 
 func TestStoreCodeValidation(t *testing.T) {
 	// proper address size


### PR DESCRIPTION
This PR adds a constant to tx_test.go, esnuring 
consistency for badAddress and reducing the likelihood of 
typos. 


- use a constant for badAddress
