### PR TITLE
marshaler to codec

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -313,7 +313,7 @@ func NewWasmApp(
 ) *WasmApp {
 	encodingConfig := MakeEncodingConfig()
 
-	appCodec, legacyAmino := encodingConfig.Marshaler, encodingConfig.Amino
+	appCodec, legacyAmino := encodingConfig.Codec, encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
 	txConfig := encodingConfig.TxConfig
 

--- a/app/params/encoding.go
+++ b/app/params/encoding.go
@@ -10,7 +10,7 @@ import (
 // This is provided for compatibility between protobuf and amino implementations.
 type EncodingConfig struct {
 	InterfaceRegistry types.InterfaceRegistry
-	Marshaler         codec.Codec
+	Codec             codec.Codec
 	TxConfig          client.TxConfig
 	Amino             *codec.LegacyAmino
 }

--- a/app/params/proto.go
+++ b/app/params/proto.go
@@ -10,12 +10,12 @@ import (
 func MakeEncodingConfig() EncodingConfig {
 	amino := codec.NewLegacyAmino()
 	interfaceRegistry := types.NewInterfaceRegistry()
-	marshaler := codec.NewProtoCodec(interfaceRegistry)
-	txCfg := tx.NewTxConfig(marshaler, tx.DefaultSignModes)
+	codec := codec.NewProtoCodec(interfaceRegistry)
+	txCfg := tx.NewTxConfig(codec, tx.DefaultSignModes)
 
 	return EncodingConfig{
 		InterfaceRegistry: interfaceRegistry,
-		Marshaler:         marshaler,
+		Codec:             codec,
 		TxConfig:          txCfg,
 		Amino:             amino,
 	}

--- a/cmd/wasmd/root.go
+++ b/cmd/wasmd/root.go
@@ -54,7 +54,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	cfg.Seal()
 
 	initClientCtx := client.Context{}.
-		WithCodec(encodingConfig.Marshaler).
+		WithCodec(encodingConfig.Codec).
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
 		WithLegacyAmino(encodingConfig.Amino).
@@ -170,7 +170,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		keys.Commands(app.DefaultNodeHome),
 	)
 	// add rosetta
-	rootCmd.AddCommand(rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler))
+	rootCmd.AddCommand(rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {

--- a/tests/e2e/ibc_fees_test.go
+++ b/tests/e2e/ibc_fees_test.go
@@ -114,7 +114,7 @@ func TestIBCFeesWasm(t *testing.T) {
 	//   and an ibc channel established
 	// when an ics-29 fee is attached to an ibc package
 	// then the relayer's payee is receiving the fee(s) on success
-	marshaler := app.MakeEncodingConfig().Codec
+	codec := app.MakeEncodingConfig().Codec
 	coord := wasmibctesting.NewCoordinator(t, 2)
 	chainA := coord.GetChain(wasmibctesting.GetChainID(1))
 	chainB := coord.GetChain(ibctesting.GetChainID(2))

--- a/tests/e2e/ibc_fees_test.go
+++ b/tests/e2e/ibc_fees_test.go
@@ -29,7 +29,7 @@ func TestIBCFeesTransfer(t *testing.T) {
 	//   with an ics-20 channel established
 	// when an ics-29 fee is attached to an ibc package
 	// then the relayer's payee is receiving the fee(s) on success
-	marshaler := app.MakeEncodingConfig().Codec
+	codec := app.MakeEncodingConfig().Codec
 	coord := wasmibctesting.NewCoordinator(t, 2)
 	chainA := coord.GetChain(wasmibctesting.GetChainID(1))
 	chainB := coord.GetChain(wasmibctesting.GetChainID(2))

--- a/tests/e2e/ibc_fees_test.go
+++ b/tests/e2e/ibc_fees_test.go
@@ -29,7 +29,7 @@ func TestIBCFeesTransfer(t *testing.T) {
 	//   with an ics-20 channel established
 	// when an ics-29 fee is attached to an ibc package
 	// then the relayer's payee is receiving the fee(s) on success
-	marshaler := app.MakeEncodingConfig().Marshaler
+	marshaler := app.MakeEncodingConfig().Codec
 	coord := wasmibctesting.NewCoordinator(t, 2)
 	chainA := coord.GetChain(wasmibctesting.GetChainID(1))
 	chainB := coord.GetChain(wasmibctesting.GetChainID(2))
@@ -114,7 +114,7 @@ func TestIBCFeesWasm(t *testing.T) {
 	//   and an ibc channel established
 	// when an ics-29 fee is attached to an ibc package
 	// then the relayer's payee is receiving the fee(s) on success
-	marshaler := app.MakeEncodingConfig().Marshaler
+	marshaler := app.MakeEncodingConfig().Codec
 	coord := wasmibctesting.NewCoordinator(t, 2)
 	chainA := coord.GetChain(wasmibctesting.GetChainID(1))
 	chainB := coord.GetChain(ibctesting.GetChainID(2))

--- a/tests/e2e/ibc_fees_test.go
+++ b/tests/e2e/ibc_fees_test.go
@@ -43,12 +43,12 @@ func TestIBCFeesTransfer(t *testing.T) {
 	path := wasmibctesting.NewPath(chainA, chainB)
 	path.EndpointA.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  ibctransfertypes.PortID,
-		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Version: string(codec.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
 		Order:   channeltypes.UNORDERED,
 	}
 	path.EndpointB.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  ibctransfertypes.PortID,
-		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Version: string(codec.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
 		Order:   channeltypes.UNORDERED,
 	}
 	// with an ics-20 transfer channel setup between both chains
@@ -138,12 +138,12 @@ func TestIBCFeesWasm(t *testing.T) {
 	path := wasmibctesting.NewPath(chainA, chainB)
 	path.EndpointA.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  ibcContractPortID,
-		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Version: string(codec.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
 		Order:   channeltypes.UNORDERED,
 	}
 	path.EndpointB.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  ibctransfertypes.PortID,
-		Version: string(marshaler.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
+		Version: string(codec.MustMarshalJSON(&ibcfee.Metadata{FeeVersion: ibcfee.Version, AppVersion: ibctransfertypes.Version})),
 		Order:   channeltypes.UNORDERED,
 	}
 	// with an ics-29 fee enabled channel setup between both chains

--- a/x/wasm/genesis_test.go
+++ b/x/wasm/genesis_test.go
@@ -67,16 +67,16 @@ func TestInitGenesis(t *testing.T) {
 	assertExecuteResponse(t, res.Data, []byte{0xf0, 0x0b, 0xaa})
 
 	// ensure all contract state is as after init
-	assertCodeList(t, q, data.ctx, 1, data.encConf.Marshaler)
-	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Marshaler)
+	assertCodeList(t, q, data.ctx, 1, data.encConf.Codec)
+	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Codec)
 
-	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Marshaler)
-	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Marshaler)
+	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Codec)
+	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Codec)
 	assertContractState(t, q, data.ctx, contractBech32Addr, state{
 		Verifier:    fred.String(),
 		Beneficiary: bob.String(),
 		Funder:      creator.String(),
-	}, data.encConf.Marshaler)
+	}, data.encConf.Codec)
 
 	// export into genstate
 	genState := keeper.ExportGenesis(data.ctx, &data.keeper)
@@ -90,14 +90,14 @@ func TestInitGenesis(t *testing.T) {
 	require.NoError(t, err)
 
 	// run same checks again on newdata, to make sure it was reinitialized correctly
-	assertCodeList(t, q2, newData.ctx, 1, data.encConf.Marshaler)
-	assertCodeBytes(t, q2, newData.ctx, 1, testContract, data.encConf.Marshaler)
+	assertCodeList(t, q2, newData.ctx, 1, data.encConf.Codec)
+	assertCodeBytes(t, q2, newData.ctx, 1, testContract, data.encConf.Codec)
 
-	assertContractList(t, q2, newData.ctx, 1, []string{contractBech32Addr}, data.encConf.Marshaler)
-	assertContractInfo(t, q2, newData.ctx, contractBech32Addr, 1, creator, data.encConf.Marshaler)
+	assertContractList(t, q2, newData.ctx, 1, []string{contractBech32Addr}, data.encConf.Codec)
+	assertContractInfo(t, q2, newData.ctx, contractBech32Addr, 1, creator, data.encConf.Codec)
 	assertContractState(t, q2, newData.ctx, contractBech32Addr, state{
 		Verifier:    fred.String(),
 		Beneficiary: bob.String(),
 		Funder:      creator.String(),
-	}, data.encConf.Marshaler)
+	}, data.encConf.Codec)
 }

--- a/x/wasm/keeper/genesis_test.go
+++ b/x/wasm/keeper/genesis_test.go
@@ -660,7 +660,7 @@ func setupKeeper(t *testing.T) (*Keeper, sdk.Context) {
 	wasmConfig := types.DefaultWasmConfig()
 
 	srcKeeper := NewKeeper(
-		encodingConfig.Marshaler,
+		encodingConfig.Codec,
 		keyWasm,
 		authkeeper.AccountKeeper{},
 		&bankkeeper.BaseKeeper{},

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -561,7 +561,7 @@ func TestEncoding(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			var ctx sdk.Context
-			encoder := DefaultEncoders(encodingConfig.Marshaler, tc.transferPortSource)
+			encoder := DefaultEncoders(encodingConfig.Codec, tc.transferPortSource)
 			res, err := encoder.Encode(ctx, tc.sender, tc.srcContractIBCPort, tc.srcMsg)
 			if tc.expError {
 				assert.Error(t, err)
@@ -796,7 +796,7 @@ func TestEncodeGovMsg(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			var ctx sdk.Context
-			encoder := DefaultEncoders(encodingConfig.Marshaler, tc.transferPortSource)
+			encoder := DefaultEncoders(encodingConfig.Codec, tc.transferPortSource)
 			res, gotEncErr := encoder.Encode(ctx, tc.sender, "myIBCPort", tc.srcMsg)
 			if tc.expError {
 				assert.Error(t, gotEncErr)

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -754,7 +754,7 @@ func TestInstantiateWithContractFactoryChildQueriesParent(t *testing.T) {
 	router := baseapp.NewMsgServiceRouter()
 	router.SetInterfaceRegistry(keepers.EncodingConfig.InterfaceRegistry)
 	types.RegisterMsgServer(router, NewMsgServerImpl(keeper))
-	keeper.messenger = NewDefaultMessageHandler(router, nil, nil, nil, nil, keepers.EncodingConfig.Marshaler, nil)
+	keeper.messenger = NewDefaultMessageHandler(router, nil, nil, nil, nil, keepers.EncodingConfig.Codec, nil)
 	// overwrite wasmvm in response handler
 	keeper.wasmVMResponseHandler = NewDefaultWasmVMContractResponseHandler(NewMessageDispatcher(keeper.messenger, keeper))
 

--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -958,7 +958,7 @@ func TestConvertProtoToJSONMarshal(t *testing.T) {
 		t.Run(fmt.Sprintf("Case %s", tc.name), func(t *testing.T) {
 			originalVersionBz, err := hex.DecodeString(tc.originalResponse)
 			require.NoError(t, err)
-			appCodec := app.MakeEncodingConfig().Marshaler
+			appCodec := app.MakeEncodingConfig().Codec
 
 			jsonMarshalledResponse, err := keeper.ConvertProtoToJSONMarshal(appCodec, tc.protoResponseStruct, originalVersionBz)
 			if tc.expectedError {
@@ -976,7 +976,7 @@ func TestConvertProtoToJSONMarshal(t *testing.T) {
 }
 
 func TestResetProtoMarshalerAfterJsonMarshal(t *testing.T) {
-	appCodec := app.MakeEncodingConfig().Marshaler
+	appCodec := app.MakeEncodingConfig().Codec
 
 	protoMarshaler := &banktypes.QueryAllBalancesResponse{}
 	expected := appCodec.MustMarshalJSON(&banktypes.QueryAllBalancesResponse{
@@ -1052,7 +1052,7 @@ func TestDeterministicJsonMarshal(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Case %s", tc.name), func(t *testing.T) {
-			appCodec := app.MakeEncodingConfig().Marshaler
+			appCodec := app.MakeEncodingConfig().Codec
 
 			originVersionBz, err := hex.DecodeString(tc.originalResponse)
 			require.NoError(t, err)

--- a/x/wasm/keeper/reflect_test.go
+++ b/x/wasm/keeper/reflect_test.go
@@ -47,7 +47,7 @@ const (
 )
 
 func TestReflectContractSend(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)))
 	accKeeper, keeper, bankKeeper := keepers.AccountKeeper, keepers.ContractKeeper, keepers.BankKeeper
 
@@ -126,7 +126,7 @@ func TestReflectContractSend(t *testing.T) {
 }
 
 func TestReflectCustomMsg(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	accKeeper, keeper, bankKeeper := keepers.AccountKeeper, keepers.ContractKeeper, keepers.BankKeeper
 
@@ -217,7 +217,7 @@ func TestReflectCustomMsg(t *testing.T) {
 }
 
 func TestMaskReflectCustomQuery(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 
@@ -265,7 +265,7 @@ func TestMaskReflectCustomQuery(t *testing.T) {
 }
 
 func TestReflectStargateQuery(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 
@@ -308,7 +308,7 @@ func TestReflectStargateQuery(t *testing.T) {
 }
 
 func TestReflectTotalSupplyQuery(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 	// upload code
@@ -359,7 +359,7 @@ func TestReflectTotalSupplyQuery(t *testing.T) {
 }
 
 func TestReflectInvalidStargateQuery(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 
@@ -440,7 +440,7 @@ type reflectState struct {
 }
 
 func TestMaskReflectWasmQueries(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 
@@ -510,7 +510,7 @@ func TestMaskReflectWasmQueries(t *testing.T) {
 }
 
 func TestWasmRawQueryWithNil(t *testing.T) {
-	cdc := MakeEncodingConfig(t).Marshaler
+	cdc := MakeEncodingConfig(t).Codec
 	ctx, keepers := CreateTestInput(t, false, ReflectFeatures, WithMessageEncoders(reflectEncoders(cdc)), WithQueryPlugins(reflectPlugins()))
 	keeper := keepers.WasmKeeper
 

--- a/x/wasm/keeper/submsg_test.go
+++ b/x/wasm/keeper/submsg_test.go
@@ -224,7 +224,7 @@ func TestDispatchSubMsgErrorHandling(t *testing.T) {
 		assert.NotEqual(t, contract, eventAddr)
 
 		var res types.MsgInstantiateContractResponse
-		keepers.EncodingConfig.Marshaler.MustUnmarshal(response.Ok.Data, &res)
+		keepers.EncodingConfig.Codec.MustUnmarshal(response.Ok.Data, &res)
 		assert.Equal(t, eventAddr, res.Address)
 	}
 

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -108,7 +108,7 @@ var moduleBasics = module.NewBasicManager(
 func MakeTestCodec(tb testing.TB) codec.Codec {
 	tb.Helper()
 
-	return MakeEncodingConfig(tb).Marshaler
+	return MakeEncodingConfig(tb).Codec
 }
 
 func MakeEncodingConfig(_ testing.TB) wasmappparams.EncodingConfig {
@@ -261,7 +261,7 @@ func createTestInput(
 	ctx = types.WithTXCounter(ctx, 0)
 
 	encodingConfig := MakeEncodingConfig(tb)
-	appCodec, legacyAmino := encodingConfig.Marshaler, encodingConfig.Amino
+	appCodec, legacyAmino := encodingConfig.Codec, encodingConfig.Amino
 
 	paramsKeeper := paramskeeper.NewKeeper(
 		appCodec,

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -64,7 +64,7 @@ func setupTest(t *testing.T) testData {
 	queryRouter.SetInterfaceRegistry(encConf.InterfaceRegistry)
 	serviceRouter.SetInterfaceRegistry(encConf.InterfaceRegistry)
 	data := testData{
-		module:           NewAppModule(encConf.Marshaler, keepers.WasmKeeper, keepers.StakingKeeper, keepers.AccountKeeper, keepers.BankKeeper, nil, newMockSubspace(types.DefaultParams())),
+		module:           NewAppModule(encConf.Codec, keepers.WasmKeeper, keepers.StakingKeeper, keepers.AccountKeeper, keepers.BankKeeper, nil, newMockSubspace(types.DefaultParams())),
 		ctx:              ctx,
 		acctKeeper:       keepers.AccountKeeper,
 		keeper:           *keepers.WasmKeeper,
@@ -75,7 +75,7 @@ func setupTest(t *testing.T) testData {
 		msgServiceRouter: serviceRouter,
 		encConf:          encConf,
 	}
-	data.module.RegisterServices(module.NewConfigurator(encConf.Marshaler, serviceRouter, queryRouter))
+	data.module.RegisterServices(module.NewConfigurator(encConf.Codec, serviceRouter, queryRouter))
 	return data
 }
 
@@ -153,12 +153,12 @@ func TestHandleCreate(t *testing.T) {
 			res, err := h(data.ctx, tc.msg)
 			if !tc.isValid {
 				require.Error(t, err, "%#v", res)
-				assertCodeList(t, q, data.ctx, 0, data.encConf.Marshaler)
-				assertCodeBytes(t, q, data.ctx, 1, nil, data.encConf.Marshaler)
+				assertCodeList(t, q, data.ctx, 0, data.encConf.Codec)
+				assertCodeBytes(t, q, data.ctx, 1, nil, data.encConf.Codec)
 				return
 			}
 			require.NoError(t, err)
-			assertCodeList(t, q, data.ctx, 1, data.encConf.Marshaler)
+			assertCodeList(t, q, data.ctx, 1, data.encConf.Codec)
 		})
 	}
 }
@@ -220,16 +220,16 @@ func TestHandleInstantiate(t *testing.T) {
 	require.Equal(t, "wasm", res.Events[1].Type)
 	assertAttribute(t, "_contract_address", contractBech32Addr, res.Events[1].Attributes[0])
 
-	assertCodeList(t, q, data.ctx, 1, data.encConf.Marshaler)
-	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Marshaler)
+	assertCodeList(t, q, data.ctx, 1, data.encConf.Codec)
+	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Codec)
 
-	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Marshaler)
-	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Marshaler)
+	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Codec)
+	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Codec)
 	assertContractState(t, q, data.ctx, contractBech32Addr, state{
 		Verifier:    fred.String(),
 		Beneficiary: bob.String(),
 		Funder:      creator.String(),
-	}, data.encConf.Marshaler)
+	}, data.encConf.Codec)
 }
 
 func TestHandleExecute(t *testing.T) {
@@ -354,16 +354,16 @@ func TestHandleExecute(t *testing.T) {
 	assert.Equal(t, sdk.Coins{}, data.bankKeeper.GetAllBalances(data.ctx, contractAcct.GetAddress()))
 
 	// ensure all contract state is as after init
-	assertCodeList(t, q, data.ctx, 1, data.encConf.Marshaler)
-	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Marshaler)
+	assertCodeList(t, q, data.ctx, 1, data.encConf.Codec)
+	assertCodeBytes(t, q, data.ctx, 1, testContract, data.encConf.Codec)
 
-	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Marshaler)
-	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Marshaler)
+	assertContractList(t, q, data.ctx, 1, []string{contractBech32Addr}, data.encConf.Codec)
+	assertContractInfo(t, q, data.ctx, contractBech32Addr, 1, creator, data.encConf.Codec)
 	assertContractState(t, q, data.ctx, contractBech32Addr, state{
 		Verifier:    fred.String(),
 		Beneficiary: bob.String(),
 		Funder:      creator.String(),
-	}, data.encConf.Marshaler)
+	}, data.encConf.Codec)
 }
 
 func TestHandleExecuteEscrow(t *testing.T) {


### PR DESCRIPTION
SDK has changed verbiage and this PR changes the term "marshaler" to 
codec to match
