### PR TITLE
remove "check" from make test-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ distclean: clean
 ### Testing
 
 test: test-unit
-test-all: check test-race test-cover test-system
+test-all: test-race test-cover test-system
 
 test-unit:
 	@VERSION=$(VERSION) go test -mod=readonly -tags='ledger test_ledger_mock' ./...


### PR DESCRIPTION
this PR fixes `make test-all` by removing the `check` job from it.
