### PR TITLE
fix: make sure wasmvm cache metrics collector registration after VM setup

### DIFF
--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -126,7 +126,7 @@ func WithAccountPruner(x AccountPruner) Option {
 }
 
 func WithVMCacheMetrics(r prometheus.Registerer) Option {
-	return optsFn(func(k *Keeper) {
+	return postOptsFn(func(k *Keeper) {
 		NewWasmVMMetricsCollector(k.wasmVM).Register(r)
 	})
 }


### PR DESCRIPTION
Close: #1574

This PR intends to fix the bug mentioned by #1574, to make sure wasmvm cache metrics collector registration after VM setup.