### PR TITLE
bump cosmos-sdk and ibc in the v50 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/cometbft/cometbft v0.38.0-rc3
 	github.com/cosmos/cosmos-db v1.0.0
 	github.com/cosmos/ibc-go/modules/capability v1.0.0-rc5
-	github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1
+	github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1.0.20230910030911-23eabb55bf29
 	github.com/spf13/viper v1.16.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
 )

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/CosmWasm/wasmd
 
 go 1.21
 
-toolchain go1.21.0
-
 require (
 	github.com/CosmWasm/wasmvm v1.4.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.0
 require (
 	github.com/CosmWasm/wasmvm v1.4.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
-	github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230907064029-0fa4c54a9839
+	github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230908143326-ccd7288ef3b1
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/iavl v1.0.0-rc.1

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/cosmos/ibc-go/modules/capability v1.0.0-rc5 h1:OwYsRIM2gwe3ifuvi2sriE
 github.com/cosmos/ibc-go/modules/capability v1.0.0-rc5/go.mod h1:YriReKrNl7ZKBW6FSmgV7v4BhrN84tm672YjU0Y2C2I=
 github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1 h1:UEUKKl7VCYWFpiz7U1ZuhFspiGWTp756/MaHUGaxJEM=
 github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1/go.mod h1:BWqKQL2n7CAeOpHrVTSLKDxrYs/es/CbdCgvVOVSgfg=
+github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1.0.20230910030911-23eabb55bf29 h1:RhPbhPM4/kmRFpERucwmD4CDorv5pVM1pBt6E/xU5XQ=
+github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1.0.20230910030911-23eabb55bf29/go.mod h1:BWqKQL2n7CAeOpHrVTSLKDxrYs/es/CbdCgvVOVSgfg=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/cosmos/cosmos-db v1.0.0 h1:EVcQZ+qYag7W6uorBKFPvX6gRjw6Uq2hIh4hCWjuQ0
 github.com/cosmos/cosmos-db v1.0.0/go.mod h1:iBvi1TtqaedwLdcrZVYRSSCb6eSy61NLj4UNmdIgs0U=
 github.com/cosmos/cosmos-proto v1.0.0-beta.3 h1:VitvZ1lPORTVxkmF2fAp3IiA61xVwArQYKXTdEcpW6o=
 github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960BvcTqtwuAxid3b/2rOD6I=
-github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230907064029-0fa4c54a9839 h1:jI4Pzews7nNy1Ld2gzZ09G6qKqlu2D7LghXugZaEn8I=
-github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230907064029-0fa4c54a9839/go.mod h1:olbHxcVB4zWwnF+oNPbKIoEIO5HgHndzKUqdpuu4s34=
+github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230908143326-ccd7288ef3b1 h1:oXu4UwvrVUGSMnJWaa4C+tdPJHDtfmSNORZe8jRYfVo=
+github.com/cosmos/cosmos-sdk v0.50.0-rc.0.0.20230908143326-ccd7288ef3b1/go.mod h1:olbHxcVB4zWwnF+oNPbKIoEIO5HgHndzKUqdpuu4s34=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,6 @@ github.com/cosmos/iavl v1.0.0-rc.1 h1:5+73BEWW1gZOIUJKlk/1fpD4lOqqeFBA8KuV+NpkCp
 github.com/cosmos/iavl v1.0.0-rc.1/go.mod h1:CmTGqMnRnucjxbjduneZXT+0vPgNElYvdefjX2q9tYc=
 github.com/cosmos/ibc-go/modules/capability v1.0.0-rc5 h1:OwYsRIM2gwe3ifuvi2sriEvDBd3t43vTF2GEi1SOchM=
 github.com/cosmos/ibc-go/modules/capability v1.0.0-rc5/go.mod h1:YriReKrNl7ZKBW6FSmgV7v4BhrN84tm672YjU0Y2C2I=
-github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1 h1:UEUKKl7VCYWFpiz7U1ZuhFspiGWTp756/MaHUGaxJEM=
-github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1/go.mod h1:BWqKQL2n7CAeOpHrVTSLKDxrYs/es/CbdCgvVOVSgfg=
 github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1.0.20230910030911-23eabb55bf29 h1:RhPbhPM4/kmRFpERucwmD4CDorv5pVM1pBt6E/xU5XQ=
 github.com/cosmos/ibc-go/v8 v8.0.0-alpha.1.0.20230910030911-23eabb55bf29/go.mod h1:BWqKQL2n7CAeOpHrVTSLKDxrYs/es/CbdCgvVOVSgfg=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -93,8 +93,6 @@ var moduleBasics = module.NewBasicManager(
 	distribution.AppModuleBasic{},
 	gov.NewAppModuleBasic([]govclient.ProposalHandler{
 		paramsclient.ProposalHandler,
-		// upgradeclient.LegacyProposalHandler,
-		// upgradeclient.LegacyCancelProposalHandler,
 	}),
 	params.AppModuleBasic{},
 	crisis.AppModuleBasic{},


### PR DESCRIPTION
This PR bumps cosmos-sdk in the sdk50 branch of wasmd so that ongoing development is easier. 

It also gets rid of `toolchain`, fixing codeql.