### PR TITLE
Restrict pagination on all-state-query

### DIFF
--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -368,7 +368,10 @@ func GetCmdGetContractStateAll() *cobra.Command {
 		SilenceUsage: true,
 	}
 	flags.AddQueryFlagsToCmd(cmd)
-	flags.AddPaginationFlagsToCmd(cmd, "contract state")
+	cmd.Flags().String(flags.FlagPageKey, "", "pagination page-key of contract state to query for")
+	cmd.Flags().Uint64(flags.FlagLimit, 100, "pagination limit of contract state to query for")
+	cmd.Flags().Bool(flags.FlagReverse, false, "results are sorted in descending order")
+
 	return cmd
 }
 

--- a/x/wasm/keeper/querier.go
+++ b/x/wasm/keeper/querier.go
@@ -117,6 +117,10 @@ func (q GrpcQuerier) AllContractState(c context.Context, req *types.QueryAllCont
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
+	if req.Pagination != nil &&
+		(req.Pagination.Offset != 0 || req.Pagination.CountTotal) {
+		return nil, status.Error(codes.InvalidArgument, "offset and count queries not supported anymore")
+	}
 	contractAddr, err := sdk.AccAddressFromBech32(req.Address)
 	if err != nil {
 		return nil, err

--- a/x/wasm/keeper/querier_test.go
+++ b/x/wasm/keeper/querier_test.go
@@ -64,12 +64,16 @@ func TestQueryAllContractState(t *testing.T) {
 					Offset: 1,
 				},
 			},
-			expModelContains: []types.Model{
-				{Key: []byte("foo"), Value: []byte(`"bar"`)},
+			expErr: status.Error(codes.InvalidArgument, "offset and count queries not supported anymore"),
+		},
+		"with pagination count": {
+			srcQuery: &types.QueryAllContractStateRequest{
+				Address: contractAddr.String(),
+				Pagination: &query.PageRequest{
+					CountTotal: true,
+				},
 			},
-			expModelContainsNot: []types.Model{
-				{Key: []byte{0x0, 0x1}, Value: []byte(`{"count":8}`)},
-			},
+			expErr: status.Error(codes.InvalidArgument, "offset and count queries not supported anymore"),
 		},
 		"with pagination limit": {
 			srcQuery: &types.QueryAllContractStateRequest{
@@ -108,6 +112,7 @@ func TestQueryAllContractState(t *testing.T) {
 				require.Equal(t, spec.expErr.Error(), err.Error())
 				return
 			}
+			require.NoError(t, err)
 			for _, exp := range spec.expModelContains {
 				assert.Contains(t, got.Models, exp)
 			}


### PR DESCRIPTION
Iterating via key is the best performing option.