### PR TITLE
Pass empty attribute value through stack

### DIFF
--- a/x/wasm/keeper/events_test.go
+++ b/x/wasm/keeper/events_test.go
@@ -119,9 +119,9 @@ func TestNewCustomEvents(t *testing.T) {
 			src: wasmvmtypes.Events{{
 				Type:       "foo",
 				Attributes: []wasmvmtypes.EventAttribute{{Key: "myKey", Value: "\n\n\n"}},
-			}},			exp: sdk.Events{sdk.NewEvent("wasm-foo",
-			sdk.NewAttribute("_contract_address", myContract.String()),
-			sdk.NewAttribute("myKey", ""))},
+			}}, exp: sdk.Events{sdk.NewEvent("wasm-foo",
+				sdk.NewAttribute("_contract_address", myContract.String()),
+				sdk.NewAttribute("myKey", ""))},
 		},
 		"error on short event type": {
 			src: wasmvmtypes.Events{{

--- a/x/wasm/relay_pingpong_test.go
+++ b/x/wasm/relay_pingpong_test.go
@@ -262,6 +262,9 @@ func (p player) IBCPacketReceive(_ wasmvm.Checksum, _ wasmvmtypes.Env, msg wasmv
 
 	return &wasmvmtypes.IBCReceiveResult{
 		Ok: &wasmvmtypes.IBCReceiveResponse{
+			Attributes: wasmvmtypes.EventAttributes{
+				{Key: "empty-value-test"},
+			},
 			Acknowledgement: receivedBall.BuildAck().GetBytes(),
 			Messages:        []wasmvmtypes.SubMsg{{Msg: wasmvmtypes.CosmosMsg{IBC: respHit}, ReplyOn: wasmvmtypes.ReplyNever}},
 		},


### PR DESCRIPTION
Abusing ping-pong test as hack to fail fast when Event attributes are handled differently by the IBC + SDK stack.
Relates to #1617