### PR TITLE
fix: use protos from sdk v0.50.x

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,7 +1,7 @@
 version: v1
 name: buf.build/cosmwasm/wasmd
 deps:
-  - buf.build/cosmos/cosmos-sdk:v0.47.0
+  - buf.build/cosmos/cosmos-sdk:v0.50.0
   - buf.build/cosmos/cosmos-proto:1935555c206d4afb9e94615dfd0fad31
   - buf.build/cosmos/gogo-proto:a14993478f40695898ed8a86931094b6656e8a5d
   - buf.build/googleapis/googleapis:8d7204855ec14631a499bd7393ce1970

--- a/x/wasm/types/authz.pb.go
+++ b/x/wasm/types/authz.pb.go
@@ -5,10 +5,6 @@ package types
 
 import (
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	_ "github.com/cosmos/cosmos-proto"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
@@ -16,14 +12,15 @@ import (
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -44,11 +41,9 @@ func (*StoreCodeAuthorization) ProtoMessage()    {}
 func (*StoreCodeAuthorization) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{0}
 }
-
 func (m *StoreCodeAuthorization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *StoreCodeAuthorization) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StoreCodeAuthorization.Marshal(b, m, deterministic)
@@ -61,15 +56,12 @@ func (m *StoreCodeAuthorization) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *StoreCodeAuthorization) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StoreCodeAuthorization.Merge(m, src)
 }
-
 func (m *StoreCodeAuthorization) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *StoreCodeAuthorization) XXX_DiscardUnknown() {
 	xxx_messageInfo_StoreCodeAuthorization.DiscardUnknown(m)
 }
@@ -89,11 +81,9 @@ func (*ContractExecutionAuthorization) ProtoMessage()    {}
 func (*ContractExecutionAuthorization) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{1}
 }
-
 func (m *ContractExecutionAuthorization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ContractExecutionAuthorization) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractExecutionAuthorization.Marshal(b, m, deterministic)
@@ -106,15 +96,12 @@ func (m *ContractExecutionAuthorization) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *ContractExecutionAuthorization) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractExecutionAuthorization.Merge(m, src)
 }
-
 func (m *ContractExecutionAuthorization) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ContractExecutionAuthorization) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractExecutionAuthorization.DiscardUnknown(m)
 }
@@ -134,11 +121,9 @@ func (*ContractMigrationAuthorization) ProtoMessage()    {}
 func (*ContractMigrationAuthorization) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{2}
 }
-
 func (m *ContractMigrationAuthorization) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ContractMigrationAuthorization) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractMigrationAuthorization.Marshal(b, m, deterministic)
@@ -151,15 +136,12 @@ func (m *ContractMigrationAuthorization) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *ContractMigrationAuthorization) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractMigrationAuthorization.Merge(m, src)
 }
-
 func (m *ContractMigrationAuthorization) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ContractMigrationAuthorization) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractMigrationAuthorization.DiscardUnknown(m)
 }
@@ -183,11 +165,9 @@ func (*CodeGrant) ProtoMessage()    {}
 func (*CodeGrant) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{3}
 }
-
 func (m *CodeGrant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *CodeGrant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CodeGrant.Marshal(b, m, deterministic)
@@ -200,15 +180,12 @@ func (m *CodeGrant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *CodeGrant) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CodeGrant.Merge(m, src)
 }
-
 func (m *CodeGrant) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *CodeGrant) XXX_DiscardUnknown() {
 	xxx_messageInfo_CodeGrant.DiscardUnknown(m)
 }
@@ -235,11 +212,9 @@ func (*ContractGrant) ProtoMessage()    {}
 func (*ContractGrant) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{4}
 }
-
 func (m *ContractGrant) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ContractGrant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractGrant.Marshal(b, m, deterministic)
@@ -252,15 +227,12 @@ func (m *ContractGrant) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *ContractGrant) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractGrant.Merge(m, src)
 }
-
 func (m *ContractGrant) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ContractGrant) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractGrant.DiscardUnknown(m)
 }
@@ -280,11 +252,9 @@ func (*MaxCallsLimit) ProtoMessage()    {}
 func (*MaxCallsLimit) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{5}
 }
-
 func (m *MaxCallsLimit) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MaxCallsLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MaxCallsLimit.Marshal(b, m, deterministic)
@@ -297,15 +267,12 @@ func (m *MaxCallsLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *MaxCallsLimit) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MaxCallsLimit.Merge(m, src)
 }
-
 func (m *MaxCallsLimit) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MaxCallsLimit) XXX_DiscardUnknown() {
 	xxx_messageInfo_MaxCallsLimit.DiscardUnknown(m)
 }
@@ -325,11 +292,9 @@ func (*MaxFundsLimit) ProtoMessage()    {}
 func (*MaxFundsLimit) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{6}
 }
-
 func (m *MaxFundsLimit) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MaxFundsLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MaxFundsLimit.Marshal(b, m, deterministic)
@@ -342,15 +307,12 @@ func (m *MaxFundsLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *MaxFundsLimit) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MaxFundsLimit.Merge(m, src)
 }
-
 func (m *MaxFundsLimit) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MaxFundsLimit) XXX_DiscardUnknown() {
 	xxx_messageInfo_MaxFundsLimit.DiscardUnknown(m)
 }
@@ -373,11 +335,9 @@ func (*CombinedLimit) ProtoMessage()    {}
 func (*CombinedLimit) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{7}
 }
-
 func (m *CombinedLimit) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *CombinedLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CombinedLimit.Marshal(b, m, deterministic)
@@ -390,15 +350,12 @@ func (m *CombinedLimit) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *CombinedLimit) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CombinedLimit.Merge(m, src)
 }
-
 func (m *CombinedLimit) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *CombinedLimit) XXX_DiscardUnknown() {
 	xxx_messageInfo_CombinedLimit.DiscardUnknown(m)
 }
@@ -408,7 +365,8 @@ var xxx_messageInfo_CombinedLimit proto.InternalMessageInfo
 // AllowAllMessagesFilter is a wildcard to allow any type of contract payload
 // message.
 // Since: wasmd 0.30
-type AllowAllMessagesFilter struct{}
+type AllowAllMessagesFilter struct {
+}
 
 func (m *AllowAllMessagesFilter) Reset()         { *m = AllowAllMessagesFilter{} }
 func (m *AllowAllMessagesFilter) String() string { return proto.CompactTextString(m) }
@@ -416,11 +374,9 @@ func (*AllowAllMessagesFilter) ProtoMessage()    {}
 func (*AllowAllMessagesFilter) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{8}
 }
-
 func (m *AllowAllMessagesFilter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AllowAllMessagesFilter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AllowAllMessagesFilter.Marshal(b, m, deterministic)
@@ -433,15 +389,12 @@ func (m *AllowAllMessagesFilter) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *AllowAllMessagesFilter) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AllowAllMessagesFilter.Merge(m, src)
 }
-
 func (m *AllowAllMessagesFilter) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AllowAllMessagesFilter) XXX_DiscardUnknown() {
 	xxx_messageInfo_AllowAllMessagesFilter.DiscardUnknown(m)
 }
@@ -462,11 +415,9 @@ func (*AcceptedMessageKeysFilter) ProtoMessage()    {}
 func (*AcceptedMessageKeysFilter) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{9}
 }
-
 func (m *AcceptedMessageKeysFilter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AcceptedMessageKeysFilter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AcceptedMessageKeysFilter.Marshal(b, m, deterministic)
@@ -479,15 +430,12 @@ func (m *AcceptedMessageKeysFilter) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-
 func (m *AcceptedMessageKeysFilter) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AcceptedMessageKeysFilter.Merge(m, src)
 }
-
 func (m *AcceptedMessageKeysFilter) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AcceptedMessageKeysFilter) XXX_DiscardUnknown() {
 	xxx_messageInfo_AcceptedMessageKeysFilter.DiscardUnknown(m)
 }
@@ -508,11 +456,9 @@ func (*AcceptedMessagesFilter) ProtoMessage()    {}
 func (*AcceptedMessagesFilter) Descriptor() ([]byte, []int) {
 	return fileDescriptor_36ff3a20cf32b258, []int{10}
 }
-
 func (m *AcceptedMessagesFilter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AcceptedMessagesFilter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AcceptedMessagesFilter.Marshal(b, m, deterministic)
@@ -525,15 +471,12 @@ func (m *AcceptedMessagesFilter) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *AcceptedMessagesFilter) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AcceptedMessagesFilter.Merge(m, src)
 }
-
 func (m *AcceptedMessagesFilter) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AcceptedMessagesFilter) XXX_DiscardUnknown() {
 	xxx_messageInfo_AcceptedMessagesFilter.DiscardUnknown(m)
 }
@@ -1022,7 +965,6 @@ func encodeVarintAuthz(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *StoreCodeAuthorization) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1193,11 +1135,9 @@ func (m *AcceptedMessagesFilter) Size() (n int) {
 func sovAuthz(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozAuthz(x uint64) (n int) {
 	return sovAuthz(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *StoreCodeAuthorization) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1282,7 +1222,6 @@ func (m *StoreCodeAuthorization) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ContractExecutionAuthorization) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1367,7 +1306,6 @@ func (m *ContractExecutionAuthorization) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ContractMigrationAuthorization) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1452,7 +1390,6 @@ func (m *ContractMigrationAuthorization) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *CodeGrant) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1573,7 +1510,6 @@ func (m *CodeGrant) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ContractGrant) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1728,7 +1664,6 @@ func (m *ContractGrant) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MaxCallsLimit) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1798,7 +1733,6 @@ func (m *MaxCallsLimit) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MaxFundsLimit) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1883,7 +1817,6 @@ func (m *MaxFundsLimit) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *CombinedLimit) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1987,7 +1920,6 @@ func (m *CombinedLimit) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AllowAllMessagesFilter) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2038,7 +1970,6 @@ func (m *AllowAllMessagesFilter) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AcceptedMessageKeysFilter) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2121,7 +2052,6 @@ func (m *AcceptedMessageKeysFilter) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AcceptedMessagesFilter) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2204,7 +2134,6 @@ func (m *AcceptedMessagesFilter) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipAuthz(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/genesis.pb.go
+++ b/x/wasm/types/genesis.pb.go
@@ -5,22 +5,19 @@ package types
 
 import (
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -42,11 +39,9 @@ func (*GenesisState) ProtoMessage()    {}
 func (*GenesisState) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{0}
 }
-
 func (m *GenesisState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_GenesisState.Marshal(b, m, deterministic)
@@ -59,15 +54,12 @@ func (m *GenesisState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-
 func (m *GenesisState) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_GenesisState.Merge(m, src)
 }
-
 func (m *GenesisState) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *GenesisState) XXX_DiscardUnknown() {
 	xxx_messageInfo_GenesisState.DiscardUnknown(m)
 }
@@ -117,11 +109,9 @@ func (*Code) ProtoMessage()    {}
 func (*Code) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{1}
 }
-
 func (m *Code) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *Code) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Code.Marshal(b, m, deterministic)
@@ -134,15 +124,12 @@ func (m *Code) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *Code) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Code.Merge(m, src)
 }
-
 func (m *Code) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *Code) XXX_DiscardUnknown() {
 	xxx_messageInfo_Code.DiscardUnknown(m)
 }
@@ -191,11 +178,9 @@ func (*Contract) ProtoMessage()    {}
 func (*Contract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{2}
 }
-
 func (m *Contract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *Contract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Contract.Marshal(b, m, deterministic)
@@ -208,15 +193,12 @@ func (m *Contract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *Contract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Contract.Merge(m, src)
 }
-
 func (m *Contract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *Contract) XXX_DiscardUnknown() {
 	xxx_messageInfo_Contract.DiscardUnknown(m)
 }
@@ -263,11 +245,9 @@ func (*Sequence) ProtoMessage()    {}
 func (*Sequence) Descriptor() ([]byte, []int) {
 	return fileDescriptor_2ab3f539b23472a6, []int{3}
 }
-
 func (m *Sequence) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *Sequence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Sequence.Marshal(b, m, deterministic)
@@ -280,15 +260,12 @@ func (m *Sequence) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *Sequence) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Sequence.Merge(m, src)
 }
-
 func (m *Sequence) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *Sequence) XXX_DiscardUnknown() {
 	xxx_messageInfo_Sequence.DiscardUnknown(m)
 }
@@ -603,7 +580,6 @@ func encodeVarintGenesis(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *GenesisState) Size() (n int) {
 	if m == nil {
 		return 0
@@ -700,11 +676,9 @@ func (m *Sequence) Size() (n int) {
 func sovGenesis(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozGenesis(x uint64) (n int) {
 	return sovGenesis(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -890,7 +864,6 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *Code) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1047,7 +1020,6 @@ func (m *Code) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *Contract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1231,7 +1203,6 @@ func (m *Contract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *Sequence) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1335,7 +1306,6 @@ func (m *Sequence) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipGenesis(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/ibc.pb.go
+++ b/x/wasm/types/ibc.pb.go
@@ -5,20 +5,17 @@ package types
 
 import (
 	fmt "fmt"
+	_ "github.com/cosmos/gogoproto/gogoproto"
+	proto "github.com/cosmos/gogoproto/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
-
-	_ "github.com/cosmos/gogoproto/gogoproto"
-	proto "github.com/cosmos/gogoproto/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -47,11 +44,9 @@ func (*MsgIBCSend) ProtoMessage()    {}
 func (*MsgIBCSend) Descriptor() ([]byte, []int) {
 	return fileDescriptor_af0d1c43ea53c4b9, []int{0}
 }
-
 func (m *MsgIBCSend) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgIBCSend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgIBCSend.Marshal(b, m, deterministic)
@@ -64,15 +59,12 @@ func (m *MsgIBCSend) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *MsgIBCSend) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgIBCSend.Merge(m, src)
 }
-
 func (m *MsgIBCSend) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgIBCSend) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgIBCSend.DiscardUnknown(m)
 }
@@ -91,11 +83,9 @@ func (*MsgIBCSendResponse) ProtoMessage()    {}
 func (*MsgIBCSendResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_af0d1c43ea53c4b9, []int{1}
 }
-
 func (m *MsgIBCSendResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgIBCSendResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgIBCSendResponse.Marshal(b, m, deterministic)
@@ -108,15 +98,12 @@ func (m *MsgIBCSendResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *MsgIBCSendResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgIBCSendResponse.Merge(m, src)
 }
-
 func (m *MsgIBCSendResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgIBCSendResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgIBCSendResponse.DiscardUnknown(m)
 }
@@ -134,11 +121,9 @@ func (*MsgIBCCloseChannel) ProtoMessage()    {}
 func (*MsgIBCCloseChannel) Descriptor() ([]byte, []int) {
 	return fileDescriptor_af0d1c43ea53c4b9, []int{2}
 }
-
 func (m *MsgIBCCloseChannel) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgIBCCloseChannel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgIBCCloseChannel.Marshal(b, m, deterministic)
@@ -151,15 +136,12 @@ func (m *MsgIBCCloseChannel) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *MsgIBCCloseChannel) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgIBCCloseChannel.Merge(m, src)
 }
-
 func (m *MsgIBCCloseChannel) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgIBCCloseChannel) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgIBCCloseChannel.DiscardUnknown(m)
 }
@@ -315,7 +297,6 @@ func encodeVarintIbc(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *MsgIBCSend) Size() (n int) {
 	if m == nil {
 		return 0
@@ -367,11 +348,9 @@ func (m *MsgIBCCloseChannel) Size() (n int) {
 func sovIbc(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozIbc(x uint64) (n int) {
 	return sovIbc(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *MsgIBCSend) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -526,7 +505,6 @@ func (m *MsgIBCSend) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgIBCSendResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -596,7 +574,6 @@ func (m *MsgIBCSendResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgIBCCloseChannel) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -679,7 +656,6 @@ func (m *MsgIBCCloseChannel) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipIbc(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/proposal_legacy.pb.go
+++ b/x/wasm/types/proposal_legacy.pb.go
@@ -6,24 +6,21 @@ package types
 import (
 	bytes "bytes"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	_ "github.com/cosmos/cosmos-proto"
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -65,11 +62,9 @@ func (*StoreCodeProposal) ProtoMessage() {}
 func (*StoreCodeProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{0}
 }
-
 func (m *StoreCodeProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *StoreCodeProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StoreCodeProposal.Marshal(b, m, deterministic)
@@ -82,15 +77,12 @@ func (m *StoreCodeProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
-
 func (m *StoreCodeProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StoreCodeProposal.Merge(m, src)
 }
-
 func (m *StoreCodeProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *StoreCodeProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_StoreCodeProposal.DiscardUnknown(m)
 }
@@ -127,11 +119,9 @@ func (*InstantiateContractProposal) ProtoMessage() {}
 func (*InstantiateContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{1}
 }
-
 func (m *InstantiateContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *InstantiateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_InstantiateContractProposal.Marshal(b, m, deterministic)
@@ -144,15 +134,12 @@ func (m *InstantiateContractProposal) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
-
 func (m *InstantiateContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_InstantiateContractProposal.Merge(m, src)
 }
-
 func (m *InstantiateContractProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *InstantiateContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_InstantiateContractProposal.DiscardUnknown(m)
 }
@@ -170,7 +157,7 @@ type InstantiateContract2Proposal struct {
 	Title string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
 	// Description is a human readable text
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
-	// RunAs is the address that is passed to the contract's environment as sender
+	// RunAs is the address that is passed to the contract's enviroment as sender
 	RunAs string `protobuf:"bytes,3,opt,name=run_as,json=runAs,proto3" json:"run_as,omitempty"`
 	// Admin is an optional address that can execute migrations
 	Admin string `protobuf:"bytes,4,opt,name=admin,proto3" json:"admin,omitempty"`
@@ -194,11 +181,9 @@ func (*InstantiateContract2Proposal) ProtoMessage() {}
 func (*InstantiateContract2Proposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{2}
 }
-
 func (m *InstantiateContract2Proposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *InstantiateContract2Proposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_InstantiateContract2Proposal.Marshal(b, m, deterministic)
@@ -211,15 +196,12 @@ func (m *InstantiateContract2Proposal) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
-
 func (m *InstantiateContract2Proposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_InstantiateContract2Proposal.Merge(m, src)
 }
-
 func (m *InstantiateContract2Proposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *InstantiateContract2Proposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_InstantiateContract2Proposal.DiscardUnknown(m)
 }
@@ -250,11 +232,9 @@ func (*MigrateContractProposal) ProtoMessage() {}
 func (*MigrateContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{3}
 }
-
 func (m *MigrateContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MigrateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MigrateContractProposal.Marshal(b, m, deterministic)
@@ -267,15 +247,12 @@ func (m *MigrateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *MigrateContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MigrateContractProposal.Merge(m, src)
 }
-
 func (m *MigrateContractProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MigrateContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_MigrateContractProposal.DiscardUnknown(m)
 }
@@ -304,11 +281,9 @@ func (*SudoContractProposal) ProtoMessage() {}
 func (*SudoContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{4}
 }
-
 func (m *SudoContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *SudoContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_SudoContractProposal.Marshal(b, m, deterministic)
@@ -321,15 +296,12 @@ func (m *SudoContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
-
 func (m *SudoContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_SudoContractProposal.Merge(m, src)
 }
-
 func (m *SudoContractProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *SudoContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_SudoContractProposal.DiscardUnknown(m)
 }
@@ -362,11 +334,9 @@ func (*ExecuteContractProposal) ProtoMessage() {}
 func (*ExecuteContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{5}
 }
-
 func (m *ExecuteContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ExecuteContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ExecuteContractProposal.Marshal(b, m, deterministic)
@@ -379,15 +349,12 @@ func (m *ExecuteContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *ExecuteContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ExecuteContractProposal.Merge(m, src)
 }
-
 func (m *ExecuteContractProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ExecuteContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_ExecuteContractProposal.DiscardUnknown(m)
 }
@@ -416,11 +383,9 @@ func (*UpdateAdminProposal) ProtoMessage() {}
 func (*UpdateAdminProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{6}
 }
-
 func (m *UpdateAdminProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *UpdateAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UpdateAdminProposal.Marshal(b, m, deterministic)
@@ -433,15 +398,12 @@ func (m *UpdateAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
-
 func (m *UpdateAdminProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UpdateAdminProposal.Merge(m, src)
 }
-
 func (m *UpdateAdminProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *UpdateAdminProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UpdateAdminProposal.DiscardUnknown(m)
 }
@@ -468,11 +430,9 @@ func (*ClearAdminProposal) ProtoMessage() {}
 func (*ClearAdminProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{7}
 }
-
 func (m *ClearAdminProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ClearAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ClearAdminProposal.Marshal(b, m, deterministic)
@@ -485,15 +445,12 @@ func (m *ClearAdminProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *ClearAdminProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ClearAdminProposal.Merge(m, src)
 }
-
 func (m *ClearAdminProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ClearAdminProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_ClearAdminProposal.DiscardUnknown(m)
 }
@@ -520,11 +477,9 @@ func (*PinCodesProposal) ProtoMessage() {}
 func (*PinCodesProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{8}
 }
-
 func (m *PinCodesProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *PinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_PinCodesProposal.Marshal(b, m, deterministic)
@@ -537,15 +492,12 @@ func (m *PinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
-
 func (m *PinCodesProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_PinCodesProposal.Merge(m, src)
 }
-
 func (m *PinCodesProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *PinCodesProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_PinCodesProposal.DiscardUnknown(m)
 }
@@ -572,11 +524,9 @@ func (*UnpinCodesProposal) ProtoMessage() {}
 func (*UnpinCodesProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{9}
 }
-
 func (m *UnpinCodesProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *UnpinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UnpinCodesProposal.Marshal(b, m, deterministic)
@@ -589,15 +539,12 @@ func (m *UnpinCodesProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *UnpinCodesProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UnpinCodesProposal.Merge(m, src)
 }
-
 func (m *UnpinCodesProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *UnpinCodesProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UnpinCodesProposal.DiscardUnknown(m)
 }
@@ -618,11 +565,9 @@ func (*AccessConfigUpdate) ProtoMessage() {}
 func (*AccessConfigUpdate) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{10}
 }
-
 func (m *AccessConfigUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AccessConfigUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessConfigUpdate.Marshal(b, m, deterministic)
@@ -635,15 +580,12 @@ func (m *AccessConfigUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *AccessConfigUpdate) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessConfigUpdate.Merge(m, src)
 }
-
 func (m *AccessConfigUpdate) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AccessConfigUpdate) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessConfigUpdate.DiscardUnknown(m)
 }
@@ -671,11 +613,9 @@ func (*UpdateInstantiateConfigProposal) ProtoMessage() {}
 func (*UpdateInstantiateConfigProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{11}
 }
-
 func (m *UpdateInstantiateConfigProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *UpdateInstantiateConfigProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_UpdateInstantiateConfigProposal.Marshal(b, m, deterministic)
@@ -688,15 +628,12 @@ func (m *UpdateInstantiateConfigProposal) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
-
 func (m *UpdateInstantiateConfigProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_UpdateInstantiateConfigProposal.Merge(m, src)
 }
-
 func (m *UpdateInstantiateConfigProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *UpdateInstantiateConfigProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_UpdateInstantiateConfigProposal.DiscardUnknown(m)
 }
@@ -745,11 +682,9 @@ func (*StoreAndInstantiateContractProposal) ProtoMessage() {}
 func (*StoreAndInstantiateContractProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_68e9c908a42bedfa, []int{12}
 }
-
 func (m *StoreAndInstantiateContractProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *StoreAndInstantiateContractProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_StoreAndInstantiateContractProposal.Marshal(b, m, deterministic)
@@ -762,15 +697,12 @@ func (m *StoreAndInstantiateContractProposal) XXX_Marshal(b []byte, deterministi
 		return b[:n], nil
 	}
 }
-
 func (m *StoreAndInstantiateContractProposal) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_StoreAndInstantiateContractProposal.Merge(m, src)
 }
-
 func (m *StoreAndInstantiateContractProposal) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *StoreAndInstantiateContractProposal) XXX_DiscardUnknown() {
 	xxx_messageInfo_StoreAndInstantiateContractProposal.DiscardUnknown(m)
 }
@@ -924,7 +856,6 @@ func (this *StoreCodeProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *InstantiateContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -975,7 +906,6 @@ func (this *InstantiateContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *InstantiateContract2Proposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1032,7 +962,6 @@ func (this *InstantiateContract2Proposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *MigrateContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1069,7 +998,6 @@ func (this *MigrateContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *SudoContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1103,7 +1031,6 @@ func (this *SudoContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *ExecuteContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1148,7 +1075,6 @@ func (this *ExecuteContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *UpdateAdminProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1182,7 +1108,6 @@ func (this *UpdateAdminProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *ClearAdminProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1213,7 +1138,6 @@ func (this *ClearAdminProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *PinCodesProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1249,7 +1173,6 @@ func (this *PinCodesProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *UnpinCodesProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1285,7 +1208,6 @@ func (this *UnpinCodesProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *AccessConfigUpdate) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1313,7 +1235,6 @@ func (this *AccessConfigUpdate) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *UpdateInstantiateConfigProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1349,7 +1270,6 @@ func (this *UpdateInstantiateConfigProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *StoreAndInstantiateContractProposal) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1415,7 +1335,6 @@ func (this *StoreAndInstantiateContractProposal) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (m *StoreCodeProposal) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -2308,7 +2227,6 @@ func encodeVarintProposalLegacy(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *StoreCodeProposal) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2728,11 +2646,9 @@ func (m *StoreAndInstantiateContractProposal) Size() (n int) {
 func sovProposalLegacy(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozProposalLegacy(x uint64) (n int) {
 	return sovProposalLegacy(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *StoreCodeProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3067,7 +2983,6 @@ func (m *StoreCodeProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *InstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3365,7 +3280,6 @@ func (m *InstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *InstantiateContract2Proposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3717,7 +3631,6 @@ func (m *InstantiateContract2Proposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MigrateContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3917,7 +3830,6 @@ func (m *MigrateContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *SudoContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4098,7 +4010,6 @@ func (m *SudoContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ExecuteContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4345,7 +4256,6 @@ func (m *ExecuteContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *UpdateAdminProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4524,7 +4434,6 @@ func (m *UpdateAdminProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ClearAdminProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4671,7 +4580,6 @@ func (m *ClearAdminProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *PinCodesProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4862,7 +4770,6 @@ func (m *PinCodesProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *UnpinCodesProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5053,7 +4960,6 @@ func (m *UnpinCodesProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AccessConfigUpdate) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5156,7 +5062,6 @@ func (m *AccessConfigUpdate) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *UpdateInstantiateConfigProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5305,7 +5210,6 @@ func (m *UpdateInstantiateConfigProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *StoreAndInstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5772,7 +5676,6 @@ func (m *StoreAndInstantiateContractProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipProposalLegacy(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/query.pb.go
+++ b/x/wasm/types/query.pb.go
@@ -7,10 +7,6 @@ import (
 	bytes "bytes"
 	context "context"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	github_com_cometbft_cometbft_libs_bytes "github.com/cometbft/cometbft/libs/bytes"
 	_ "github.com/cosmos/cosmos-proto"
 	query "github.com/cosmos/cosmos-sdk/types/query"
@@ -22,14 +18,15 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -50,11 +47,9 @@ func (*QueryContractInfoRequest) ProtoMessage()    {}
 func (*QueryContractInfoRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{0}
 }
-
 func (m *QueryContractInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractInfoRequest.Marshal(b, m, deterministic)
@@ -67,15 +62,12 @@ func (m *QueryContractInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractInfoRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractInfoRequest.Merge(m, src)
 }
-
 func (m *QueryContractInfoRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractInfoRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractInfoRequest.DiscardUnknown(m)
 }
@@ -96,11 +88,9 @@ func (*QueryContractInfoResponse) ProtoMessage()    {}
 func (*QueryContractInfoResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{1}
 }
-
 func (m *QueryContractInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractInfoResponse.Marshal(b, m, deterministic)
@@ -113,15 +103,12 @@ func (m *QueryContractInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractInfoResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractInfoResponse.Merge(m, src)
 }
-
 func (m *QueryContractInfoResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractInfoResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractInfoResponse.DiscardUnknown(m)
 }
@@ -143,11 +130,9 @@ func (*QueryContractHistoryRequest) ProtoMessage()    {}
 func (*QueryContractHistoryRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{2}
 }
-
 func (m *QueryContractHistoryRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractHistoryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractHistoryRequest.Marshal(b, m, deterministic)
@@ -160,15 +145,12 @@ func (m *QueryContractHistoryRequest) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractHistoryRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractHistoryRequest.Merge(m, src)
 }
-
 func (m *QueryContractHistoryRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractHistoryRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractHistoryRequest.DiscardUnknown(m)
 }
@@ -189,11 +171,9 @@ func (*QueryContractHistoryResponse) ProtoMessage()    {}
 func (*QueryContractHistoryResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{3}
 }
-
 func (m *QueryContractHistoryResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractHistoryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractHistoryResponse.Marshal(b, m, deterministic)
@@ -206,15 +186,12 @@ func (m *QueryContractHistoryResponse) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractHistoryResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractHistoryResponse.Merge(m, src)
 }
-
 func (m *QueryContractHistoryResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractHistoryResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractHistoryResponse.DiscardUnknown(m)
 }
@@ -235,11 +212,9 @@ func (*QueryContractsByCodeRequest) ProtoMessage()    {}
 func (*QueryContractsByCodeRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{4}
 }
-
 func (m *QueryContractsByCodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractsByCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCodeRequest.Marshal(b, m, deterministic)
@@ -252,15 +227,12 @@ func (m *QueryContractsByCodeRequest) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractsByCodeRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCodeRequest.Merge(m, src)
 }
-
 func (m *QueryContractsByCodeRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractsByCodeRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCodeRequest.DiscardUnknown(m)
 }
@@ -282,11 +254,9 @@ func (*QueryContractsByCodeResponse) ProtoMessage()    {}
 func (*QueryContractsByCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{5}
 }
-
 func (m *QueryContractsByCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractsByCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCodeResponse.Marshal(b, m, deterministic)
@@ -299,15 +269,12 @@ func (m *QueryContractsByCodeResponse) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractsByCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCodeResponse.Merge(m, src)
 }
-
 func (m *QueryContractsByCodeResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractsByCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCodeResponse.DiscardUnknown(m)
 }
@@ -329,11 +296,9 @@ func (*QueryAllContractStateRequest) ProtoMessage()    {}
 func (*QueryAllContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{6}
 }
-
 func (m *QueryAllContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryAllContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAllContractStateRequest.Marshal(b, m, deterministic)
@@ -346,15 +311,12 @@ func (m *QueryAllContractStateRequest) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
-
 func (m *QueryAllContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAllContractStateRequest.Merge(m, src)
 }
-
 func (m *QueryAllContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryAllContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAllContractStateRequest.DiscardUnknown(m)
 }
@@ -375,11 +337,9 @@ func (*QueryAllContractStateResponse) ProtoMessage()    {}
 func (*QueryAllContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{7}
 }
-
 func (m *QueryAllContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryAllContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryAllContractStateResponse.Marshal(b, m, deterministic)
@@ -392,15 +352,12 @@ func (m *QueryAllContractStateResponse) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
-
 func (m *QueryAllContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryAllContractStateResponse.Merge(m, src)
 }
-
 func (m *QueryAllContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryAllContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryAllContractStateResponse.DiscardUnknown(m)
 }
@@ -421,11 +378,9 @@ func (*QueryRawContractStateRequest) ProtoMessage()    {}
 func (*QueryRawContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{8}
 }
-
 func (m *QueryRawContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryRawContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryRawContractStateRequest.Marshal(b, m, deterministic)
@@ -438,15 +393,12 @@ func (m *QueryRawContractStateRequest) XXX_Marshal(b []byte, deterministic bool)
 		return b[:n], nil
 	}
 }
-
 func (m *QueryRawContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryRawContractStateRequest.Merge(m, src)
 }
-
 func (m *QueryRawContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryRawContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryRawContractStateRequest.DiscardUnknown(m)
 }
@@ -466,11 +418,9 @@ func (*QueryRawContractStateResponse) ProtoMessage()    {}
 func (*QueryRawContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{9}
 }
-
 func (m *QueryRawContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryRawContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryRawContractStateResponse.Marshal(b, m, deterministic)
@@ -483,15 +433,12 @@ func (m *QueryRawContractStateResponse) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
-
 func (m *QueryRawContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryRawContractStateResponse.Merge(m, src)
 }
-
 func (m *QueryRawContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryRawContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryRawContractStateResponse.DiscardUnknown(m)
 }
@@ -513,11 +460,9 @@ func (*QuerySmartContractStateRequest) ProtoMessage()    {}
 func (*QuerySmartContractStateRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{10}
 }
-
 func (m *QuerySmartContractStateRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QuerySmartContractStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QuerySmartContractStateRequest.Marshal(b, m, deterministic)
@@ -530,15 +475,12 @@ func (m *QuerySmartContractStateRequest) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *QuerySmartContractStateRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QuerySmartContractStateRequest.Merge(m, src)
 }
-
 func (m *QuerySmartContractStateRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QuerySmartContractStateRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QuerySmartContractStateRequest.DiscardUnknown(m)
 }
@@ -558,11 +500,9 @@ func (*QuerySmartContractStateResponse) ProtoMessage()    {}
 func (*QuerySmartContractStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{11}
 }
-
 func (m *QuerySmartContractStateResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QuerySmartContractStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QuerySmartContractStateResponse.Marshal(b, m, deterministic)
@@ -575,15 +515,12 @@ func (m *QuerySmartContractStateResponse) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
-
 func (m *QuerySmartContractStateResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QuerySmartContractStateResponse.Merge(m, src)
 }
-
 func (m *QuerySmartContractStateResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QuerySmartContractStateResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QuerySmartContractStateResponse.DiscardUnknown(m)
 }
@@ -601,11 +538,9 @@ func (*QueryCodeRequest) ProtoMessage()    {}
 func (*QueryCodeRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{12}
 }
-
 func (m *QueryCodeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodeRequest.Marshal(b, m, deterministic)
@@ -618,15 +553,12 @@ func (m *QueryCodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
-
 func (m *QueryCodeRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodeRequest.Merge(m, src)
 }
-
 func (m *QueryCodeRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryCodeRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodeRequest.DiscardUnknown(m)
 }
@@ -647,11 +579,9 @@ func (*CodeInfoResponse) ProtoMessage()    {}
 func (*CodeInfoResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{13}
 }
-
 func (m *CodeInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *CodeInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CodeInfoResponse.Marshal(b, m, deterministic)
@@ -664,15 +594,12 @@ func (m *CodeInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return b[:n], nil
 	}
 }
-
 func (m *CodeInfoResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CodeInfoResponse.Merge(m, src)
 }
-
 func (m *CodeInfoResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *CodeInfoResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_CodeInfoResponse.DiscardUnknown(m)
 }
@@ -691,11 +618,9 @@ func (*QueryCodeResponse) ProtoMessage()    {}
 func (*QueryCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{14}
 }
-
 func (m *QueryCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodeResponse.Marshal(b, m, deterministic)
@@ -708,15 +633,12 @@ func (m *QueryCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
-
 func (m *QueryCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodeResponse.Merge(m, src)
 }
-
 func (m *QueryCodeResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodeResponse.DiscardUnknown(m)
 }
@@ -735,11 +657,9 @@ func (*QueryCodesRequest) ProtoMessage()    {}
 func (*QueryCodesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{15}
 }
-
 func (m *QueryCodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodesRequest.Marshal(b, m, deterministic)
@@ -752,15 +672,12 @@ func (m *QueryCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
-
 func (m *QueryCodesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodesRequest.Merge(m, src)
 }
-
 func (m *QueryCodesRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryCodesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodesRequest.DiscardUnknown(m)
 }
@@ -780,11 +697,9 @@ func (*QueryCodesResponse) ProtoMessage()    {}
 func (*QueryCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{16}
 }
-
 func (m *QueryCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryCodesResponse.Marshal(b, m, deterministic)
@@ -797,15 +712,12 @@ func (m *QueryCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *QueryCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryCodesResponse.Merge(m, src)
 }
-
 func (m *QueryCodesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryCodesResponse.DiscardUnknown(m)
 }
@@ -825,11 +737,9 @@ func (*QueryPinnedCodesRequest) ProtoMessage()    {}
 func (*QueryPinnedCodesRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{17}
 }
-
 func (m *QueryPinnedCodesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryPinnedCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPinnedCodesRequest.Marshal(b, m, deterministic)
@@ -842,15 +752,12 @@ func (m *QueryPinnedCodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *QueryPinnedCodesRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPinnedCodesRequest.Merge(m, src)
 }
-
 func (m *QueryPinnedCodesRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryPinnedCodesRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPinnedCodesRequest.DiscardUnknown(m)
 }
@@ -871,11 +778,9 @@ func (*QueryPinnedCodesResponse) ProtoMessage()    {}
 func (*QueryPinnedCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{18}
 }
-
 func (m *QueryPinnedCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryPinnedCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryPinnedCodesResponse.Marshal(b, m, deterministic)
@@ -888,15 +793,12 @@ func (m *QueryPinnedCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-
 func (m *QueryPinnedCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryPinnedCodesResponse.Merge(m, src)
 }
-
 func (m *QueryPinnedCodesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryPinnedCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryPinnedCodesResponse.DiscardUnknown(m)
 }
@@ -904,7 +806,8 @@ func (m *QueryPinnedCodesResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_QueryPinnedCodesResponse proto.InternalMessageInfo
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
-type QueryParamsRequest struct{}
+type QueryParamsRequest struct {
+}
 
 func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
@@ -912,11 +815,9 @@ func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{19}
 }
-
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsRequest.Marshal(b, m, deterministic)
@@ -929,15 +830,12 @@ func (m *QueryParamsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *QueryParamsRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsRequest.Merge(m, src)
 }
-
 func (m *QueryParamsRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsRequest.DiscardUnknown(m)
 }
@@ -956,11 +854,9 @@ func (*QueryParamsResponse) ProtoMessage()    {}
 func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{20}
 }
-
 func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
@@ -973,15 +869,12 @@ func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
-
 func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
 }
-
 func (m *QueryParamsResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryParamsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
 }
@@ -1003,11 +896,9 @@ func (*QueryContractsByCreatorRequest) ProtoMessage()    {}
 func (*QueryContractsByCreatorRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{21}
 }
-
 func (m *QueryContractsByCreatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractsByCreatorRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCreatorRequest.Marshal(b, m, deterministic)
@@ -1020,15 +911,12 @@ func (m *QueryContractsByCreatorRequest) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractsByCreatorRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCreatorRequest.Merge(m, src)
 }
-
 func (m *QueryContractsByCreatorRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractsByCreatorRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCreatorRequest.DiscardUnknown(m)
 }
@@ -1050,11 +938,9 @@ func (*QueryContractsByCreatorResponse) ProtoMessage()    {}
 func (*QueryContractsByCreatorResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{22}
 }
-
 func (m *QueryContractsByCreatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryContractsByCreatorResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryContractsByCreatorResponse.Marshal(b, m, deterministic)
@@ -1067,15 +953,12 @@ func (m *QueryContractsByCreatorResponse) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
-
 func (m *QueryContractsByCreatorResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryContractsByCreatorResponse.Merge(m, src)
 }
-
 func (m *QueryContractsByCreatorResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryContractsByCreatorResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryContractsByCreatorResponse.DiscardUnknown(m)
 }
@@ -1102,11 +985,9 @@ func (*QueryBuildAddressRequest) ProtoMessage()    {}
 func (*QueryBuildAddressRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{23}
 }
-
 func (m *QueryBuildAddressRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryBuildAddressRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBuildAddressRequest.Marshal(b, m, deterministic)
@@ -1119,15 +1000,12 @@ func (m *QueryBuildAddressRequest) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-
 func (m *QueryBuildAddressRequest) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBuildAddressRequest.Merge(m, src)
 }
-
 func (m *QueryBuildAddressRequest) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryBuildAddressRequest) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBuildAddressRequest.DiscardUnknown(m)
 }
@@ -1147,11 +1025,9 @@ func (*QueryBuildAddressResponse) ProtoMessage()    {}
 func (*QueryBuildAddressResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_9677c207036b9f2b, []int{24}
 }
-
 func (m *QueryBuildAddressResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *QueryBuildAddressResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_QueryBuildAddressResponse.Marshal(b, m, deterministic)
@@ -1164,15 +1040,12 @@ func (m *QueryBuildAddressResponse) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-
 func (m *QueryBuildAddressResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_QueryBuildAddressResponse.Merge(m, src)
 }
-
 func (m *QueryBuildAddressResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *QueryBuildAddressResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_QueryBuildAddressResponse.DiscardUnknown(m)
 }
@@ -1333,7 +1206,6 @@ func (this *QueryContractInfoResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *CodeInfoResponse) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1367,7 +1239,6 @@ func (this *CodeInfoResponse) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *QueryCodeResponse) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1397,10 +1268,8 @@ func (this *QueryCodeResponse) Equal(that interface{}) bool {
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ context.Context
-	_ grpc.ClientConn
-)
+var _ context.Context
+var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -1581,52 +1450,42 @@ type QueryServer interface {
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
-type UnimplementedQueryServer struct{}
+type UnimplementedQueryServer struct {
+}
 
 func (*UnimplementedQueryServer) ContractInfo(ctx context.Context, req *QueryContractInfoRequest) (*QueryContractInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractInfo not implemented")
 }
-
 func (*UnimplementedQueryServer) ContractHistory(ctx context.Context, req *QueryContractHistoryRequest) (*QueryContractHistoryResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractHistory not implemented")
 }
-
 func (*UnimplementedQueryServer) ContractsByCode(ctx context.Context, req *QueryContractsByCodeRequest) (*QueryContractsByCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractsByCode not implemented")
 }
-
 func (*UnimplementedQueryServer) AllContractState(ctx context.Context, req *QueryAllContractStateRequest) (*QueryAllContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AllContractState not implemented")
 }
-
 func (*UnimplementedQueryServer) RawContractState(ctx context.Context, req *QueryRawContractStateRequest) (*QueryRawContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RawContractState not implemented")
 }
-
 func (*UnimplementedQueryServer) SmartContractState(ctx context.Context, req *QuerySmartContractStateRequest) (*QuerySmartContractStateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SmartContractState not implemented")
 }
-
 func (*UnimplementedQueryServer) Code(ctx context.Context, req *QueryCodeRequest) (*QueryCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Code not implemented")
 }
-
 func (*UnimplementedQueryServer) Codes(ctx context.Context, req *QueryCodesRequest) (*QueryCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Codes not implemented")
 }
-
 func (*UnimplementedQueryServer) PinnedCodes(ctx context.Context, req *QueryPinnedCodesRequest) (*QueryPinnedCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PinnedCodes not implemented")
 }
-
 func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsRequest) (*QueryParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Params not implemented")
 }
-
 func (*UnimplementedQueryServer) ContractsByCreator(ctx context.Context, req *QueryContractsByCreatorRequest) (*QueryContractsByCreatorResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ContractsByCreator not implemented")
 }
-
 func (*UnimplementedQueryServer) BuildAddress(ctx context.Context, req *QueryBuildAddressRequest) (*QueryBuildAddressResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BuildAddress not implemented")
 }
@@ -2906,7 +2765,6 @@ func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *QueryContractInfoRequest) Size() (n int) {
 	if m == nil {
 		return 0
@@ -3315,11 +3173,9 @@ func (m *QueryBuildAddressResponse) Size() (n int) {
 func sovQuery(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozQuery(x uint64) (n int) {
 	return sovQuery(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *QueryContractInfoRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3402,7 +3258,6 @@ func (m *QueryContractInfoRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractInfoResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3518,7 +3373,6 @@ func (m *QueryContractInfoResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractHistoryRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3637,7 +3491,6 @@ func (m *QueryContractHistoryRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractHistoryResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3758,7 +3611,6 @@ func (m *QueryContractHistoryResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractsByCodeRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3864,7 +3716,6 @@ func (m *QueryContractsByCodeRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractsByCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -3983,7 +3834,6 @@ func (m *QueryContractsByCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryAllContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4102,7 +3952,6 @@ func (m *QueryAllContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryAllContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4223,7 +4072,6 @@ func (m *QueryAllContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryRawContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4340,7 +4188,6 @@ func (m *QueryRawContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryRawContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4425,7 +4272,6 @@ func (m *QueryRawContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QuerySmartContractStateRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4542,7 +4388,6 @@ func (m *QuerySmartContractStateRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QuerySmartContractStateResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4627,7 +4472,6 @@ func (m *QuerySmartContractStateResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryCodeRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4697,7 +4541,6 @@ func (m *QueryCodeRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *CodeInfoResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4866,7 +4709,6 @@ func (m *CodeInfoResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4987,7 +4829,6 @@ func (m *QueryCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryCodesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5074,7 +4915,6 @@ func (m *QueryCodesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5195,7 +5035,6 @@ func (m *QueryCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryPinnedCodesRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5282,7 +5121,6 @@ func (m *QueryPinnedCodesRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryPinnedCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5445,7 +5283,6 @@ func (m *QueryPinnedCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5496,7 +5333,6 @@ func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5580,7 +5416,6 @@ func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractsByCreatorRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5699,7 +5534,6 @@ func (m *QueryContractsByCreatorRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryContractsByCreatorResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5818,7 +5652,6 @@ func (m *QueryContractsByCreatorResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryBuildAddressRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5999,7 +5832,6 @@ func (m *QueryBuildAddressRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *QueryBuildAddressResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6082,7 +5914,6 @@ func (m *QueryBuildAddressResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipQuery(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/query.pb.gw.go
+++ b/x/wasm/types/query.pb.gw.go
@@ -25,15 +25,13 @@ import (
 )
 
 // Suppress "imported and not used" errors
-var (
-	_ codes.Code
-	_ io.Reader
-	_ status.Status
-	_ = runtime.String
-	_ = utilities.NewDoubleArray
-	_ = descriptor.ForMessage
-	_ = metadata.Join
-)
+var _ codes.Code
+var _ io.Reader
+var _ status.Status
+var _ = runtime.String
+var _ = utilities.NewDoubleArray
+var _ = descriptor.ForMessage
+var _ = metadata.Join
 
 func request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractInfoRequest
@@ -59,6 +57,7 @@ func request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.ContractInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -85,9 +84,12 @@ func local_request_Query_ContractInfo_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.ContractInfo(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_ContractHistory_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var (
+	filter_Query_ContractHistory_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+)
 
 func request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractHistoryRequest
@@ -120,6 +122,7 @@ func request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := client.ContractHistory(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_ContractHistory_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -153,9 +156,12 @@ func local_request_Query_ContractHistory_0(ctx context.Context, marshaler runtim
 
 	msg, err := server.ContractHistory(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_ContractsByCode_0 = &utilities.DoubleArray{Encoding: map[string]int{"code_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var (
+	filter_Query_ContractsByCode_0 = &utilities.DoubleArray{Encoding: map[string]int{"code_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+)
 
 func request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractsByCodeRequest
@@ -188,6 +194,7 @@ func request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Mars
 
 	msg, err := client.ContractsByCode(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_ContractsByCode_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -221,9 +228,12 @@ func local_request_Query_ContractsByCode_0(ctx context.Context, marshaler runtim
 
 	msg, err := server.ContractsByCode(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_AllContractState_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var (
+	filter_Query_AllContractState_0 = &utilities.DoubleArray{Encoding: map[string]int{"address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+)
 
 func request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryAllContractStateRequest
@@ -256,6 +266,7 @@ func request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Mar
 
 	msg, err := client.AllContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_AllContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -289,6 +300,7 @@ func local_request_Query_AllContractState_0(ctx context.Context, marshaler runti
 
 	msg, err := server.AllContractState(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
 func request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -326,6 +338,7 @@ func request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Mar
 
 	msg, err := client.RawContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_RawContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -363,6 +376,7 @@ func local_request_Query_RawContractState_0(ctx context.Context, marshaler runti
 
 	msg, err := server.RawContractState(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
 func request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -400,6 +414,7 @@ func request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := client.SmartContractState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_SmartContractState_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -437,6 +452,7 @@ func local_request_Query_SmartContractState_0(ctx context.Context, marshaler run
 
 	msg, err := server.SmartContractState(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
 func request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -463,6 +479,7 @@ func request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, clie
 
 	msg, err := client.Code(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -489,9 +506,12 @@ func local_request_Query_Code_0(ctx context.Context, marshaler runtime.Marshaler
 
 	msg, err := server.Code(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_Codes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+var (
+	filter_Query_Codes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
 
 func request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryCodesRequest
@@ -506,6 +526,7 @@ func request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, cli
 
 	msg, err := client.Codes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -521,9 +542,12 @@ func local_request_Query_Codes_0(ctx context.Context, marshaler runtime.Marshale
 
 	msg, err := server.Codes(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_PinnedCodes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+var (
+	filter_Query_PinnedCodes_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
 
 func request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryPinnedCodesRequest
@@ -538,6 +562,7 @@ func request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshale
 
 	msg, err := client.PinnedCodes(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -553,6 +578,7 @@ func local_request_Query_PinnedCodes_0(ctx context.Context, marshaler runtime.Ma
 
 	msg, err := server.PinnedCodes(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
 func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -561,6 +587,7 @@ func request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, cl
 
 	msg, err := client.Params(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -569,9 +596,12 @@ func local_request_Query_Params_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := server.Params(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_ContractsByCreator_0 = &utilities.DoubleArray{Encoding: map[string]int{"creator_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var (
+	filter_Query_ContractsByCreator_0 = &utilities.DoubleArray{Encoding: map[string]int{"creator_address": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+)
 
 func request_Query_ContractsByCreator_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryContractsByCreatorRequest
@@ -604,6 +634,7 @@ func request_Query_ContractsByCreator_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := client.ContractsByCreator(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_ContractsByCreator_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -637,9 +668,12 @@ func local_request_Query_ContractsByCreator_0(ctx context.Context, marshaler run
 
 	msg, err := server.ContractsByCreator(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
-var filter_Query_BuildAddress_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+var (
+	filter_Query_BuildAddress_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
 
 func request_Query_BuildAddress_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq QueryBuildAddressRequest
@@ -654,6 +688,7 @@ func request_Query_BuildAddress_0(ctx context.Context, marshaler runtime.Marshal
 
 	msg, err := client.BuildAddress(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
+
 }
 
 func local_request_Query_BuildAddress_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -669,6 +704,7 @@ func local_request_Query_BuildAddress_0(ctx context.Context, marshaler runtime.M
 
 	msg, err := server.BuildAddress(ctx, &protoReq)
 	return msg, metadata, err
+
 }
 
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
@@ -676,6 +712,7 @@ func local_request_Query_BuildAddress_0(ctx context.Context, marshaler runtime.M
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterQueryHandlerFromEndpoint instead.
 func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, server QueryServer) error {
+
 	mux.Handle("GET", pattern_Query_ContractInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -696,6 +733,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -718,6 +756,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractHistory_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -740,6 +779,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractsByCode_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_AllContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -762,6 +802,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_AllContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_RawContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -784,6 +825,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_RawContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_SmartContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -806,6 +848,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_SmartContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Code_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -828,6 +871,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Code_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Codes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -850,6 +894,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Codes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_PinnedCodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -872,6 +917,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_PinnedCodes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -894,6 +940,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCreator_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -916,6 +963,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_ContractsByCreator_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_BuildAddress_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -938,6 +986,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_BuildAddress_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	return nil
@@ -980,6 +1029,7 @@ func RegisterQueryHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "QueryClient" to call the correct interceptors.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
+
 	mux.Handle("GET", pattern_Query_ContractInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -997,6 +1047,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractInfo_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractHistory_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1016,6 +1067,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractHistory_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCode_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1035,6 +1087,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractsByCode_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_AllContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1054,6 +1107,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_AllContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_RawContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1073,6 +1127,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_RawContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_SmartContractState_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1092,6 +1147,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_SmartContractState_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Code_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1111,6 +1167,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Code_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Codes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1130,6 +1187,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Codes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_PinnedCodes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1149,6 +1207,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_PinnedCodes_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_Params_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1168,6 +1227,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_Params_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_ContractsByCreator_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1187,6 +1247,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_ContractsByCreator_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	mux.Handle("GET", pattern_Query_BuildAddress_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -1206,6 +1267,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Query_BuildAddress_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	return nil

--- a/x/wasm/types/tx.pb.go
+++ b/x/wasm/types/tx.pb.go
@@ -6,10 +6,6 @@ package types
 import (
 	context "context"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	_ "github.com/cosmos/cosmos-proto"
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	types "github.com/cosmos/cosmos-sdk/types"
@@ -21,14 +17,15 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -53,11 +50,9 @@ func (*MsgStoreCode) ProtoMessage()    {}
 func (*MsgStoreCode) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{0}
 }
-
 func (m *MsgStoreCode) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreCode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreCode.Marshal(b, m, deterministic)
@@ -70,15 +65,12 @@ func (m *MsgStoreCode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreCode) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreCode.Merge(m, src)
 }
-
 func (m *MsgStoreCode) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreCode) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreCode.DiscardUnknown(m)
 }
@@ -99,11 +91,9 @@ func (*MsgStoreCodeResponse) ProtoMessage()    {}
 func (*MsgStoreCodeResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{1}
 }
-
 func (m *MsgStoreCodeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreCodeResponse.Marshal(b, m, deterministic)
@@ -116,15 +106,12 @@ func (m *MsgStoreCodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreCodeResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreCodeResponse.Merge(m, src)
 }
-
 func (m *MsgStoreCodeResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreCodeResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreCodeResponse.DiscardUnknown(m)
 }
@@ -154,11 +141,9 @@ func (*MsgInstantiateContract) ProtoMessage()    {}
 func (*MsgInstantiateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{2}
 }
-
 func (m *MsgInstantiateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgInstantiateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContract.Marshal(b, m, deterministic)
@@ -171,15 +156,12 @@ func (m *MsgInstantiateContract) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *MsgInstantiateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContract.Merge(m, src)
 }
-
 func (m *MsgInstantiateContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgInstantiateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContract.DiscardUnknown(m)
 }
@@ -200,11 +182,9 @@ func (*MsgInstantiateContractResponse) ProtoMessage()    {}
 func (*MsgInstantiateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{3}
 }
-
 func (m *MsgInstantiateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgInstantiateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContractResponse.Marshal(b, m, deterministic)
@@ -217,15 +197,12 @@ func (m *MsgInstantiateContractResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *MsgInstantiateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContractResponse.Merge(m, src)
 }
-
 func (m *MsgInstantiateContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgInstantiateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContractResponse.DiscardUnknown(m)
 }
@@ -260,11 +237,9 @@ func (*MsgInstantiateContract2) ProtoMessage()    {}
 func (*MsgInstantiateContract2) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{4}
 }
-
 func (m *MsgInstantiateContract2) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgInstantiateContract2) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContract2.Marshal(b, m, deterministic)
@@ -277,15 +252,12 @@ func (m *MsgInstantiateContract2) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *MsgInstantiateContract2) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContract2.Merge(m, src)
 }
-
 func (m *MsgInstantiateContract2) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgInstantiateContract2) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContract2.DiscardUnknown(m)
 }
@@ -306,11 +278,9 @@ func (*MsgInstantiateContract2Response) ProtoMessage()    {}
 func (*MsgInstantiateContract2Response) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{5}
 }
-
 func (m *MsgInstantiateContract2Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgInstantiateContract2Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgInstantiateContract2Response.Marshal(b, m, deterministic)
@@ -323,15 +293,12 @@ func (m *MsgInstantiateContract2Response) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
-
 func (m *MsgInstantiateContract2Response) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgInstantiateContract2Response.Merge(m, src)
 }
-
 func (m *MsgInstantiateContract2Response) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgInstantiateContract2Response) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgInstantiateContract2Response.DiscardUnknown(m)
 }
@@ -356,11 +323,9 @@ func (*MsgExecuteContract) ProtoMessage()    {}
 func (*MsgExecuteContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{6}
 }
-
 func (m *MsgExecuteContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgExecuteContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgExecuteContract.Marshal(b, m, deterministic)
@@ -373,15 +338,12 @@ func (m *MsgExecuteContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *MsgExecuteContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgExecuteContract.Merge(m, src)
 }
-
 func (m *MsgExecuteContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgExecuteContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgExecuteContract.DiscardUnknown(m)
 }
@@ -400,11 +362,9 @@ func (*MsgExecuteContractResponse) ProtoMessage()    {}
 func (*MsgExecuteContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{7}
 }
-
 func (m *MsgExecuteContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgExecuteContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgExecuteContractResponse.Marshal(b, m, deterministic)
@@ -417,15 +377,12 @@ func (m *MsgExecuteContractResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-
 func (m *MsgExecuteContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgExecuteContractResponse.Merge(m, src)
 }
-
 func (m *MsgExecuteContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgExecuteContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgExecuteContractResponse.DiscardUnknown(m)
 }
@@ -450,11 +407,9 @@ func (*MsgMigrateContract) ProtoMessage()    {}
 func (*MsgMigrateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{8}
 }
-
 func (m *MsgMigrateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgMigrateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgMigrateContract.Marshal(b, m, deterministic)
@@ -467,15 +422,12 @@ func (m *MsgMigrateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *MsgMigrateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgMigrateContract.Merge(m, src)
 }
-
 func (m *MsgMigrateContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgMigrateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgMigrateContract.DiscardUnknown(m)
 }
@@ -495,11 +447,9 @@ func (*MsgMigrateContractResponse) ProtoMessage()    {}
 func (*MsgMigrateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{9}
 }
-
 func (m *MsgMigrateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgMigrateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgMigrateContractResponse.Marshal(b, m, deterministic)
@@ -512,15 +462,12 @@ func (m *MsgMigrateContractResponse) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-
 func (m *MsgMigrateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgMigrateContractResponse.Merge(m, src)
 }
-
 func (m *MsgMigrateContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgMigrateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgMigrateContractResponse.DiscardUnknown(m)
 }
@@ -543,11 +490,9 @@ func (*MsgUpdateAdmin) ProtoMessage()    {}
 func (*MsgUpdateAdmin) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{10}
 }
-
 func (m *MsgUpdateAdmin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateAdmin.Marshal(b, m, deterministic)
@@ -560,15 +505,12 @@ func (m *MsgUpdateAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateAdmin) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateAdmin.Merge(m, src)
 }
-
 func (m *MsgUpdateAdmin) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateAdmin) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateAdmin.DiscardUnknown(m)
 }
@@ -576,7 +518,8 @@ func (m *MsgUpdateAdmin) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgUpdateAdmin proto.InternalMessageInfo
 
 // MsgUpdateAdminResponse returns empty data
-type MsgUpdateAdminResponse struct{}
+type MsgUpdateAdminResponse struct {
+}
 
 func (m *MsgUpdateAdminResponse) Reset()         { *m = MsgUpdateAdminResponse{} }
 func (m *MsgUpdateAdminResponse) String() string { return proto.CompactTextString(m) }
@@ -584,11 +527,9 @@ func (*MsgUpdateAdminResponse) ProtoMessage()    {}
 func (*MsgUpdateAdminResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{11}
 }
-
 func (m *MsgUpdateAdminResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateAdminResponse.Marshal(b, m, deterministic)
@@ -601,15 +542,12 @@ func (m *MsgUpdateAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateAdminResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateAdminResponse.Merge(m, src)
 }
-
 func (m *MsgUpdateAdminResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateAdminResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateAdminResponse.DiscardUnknown(m)
 }
@@ -630,11 +568,9 @@ func (*MsgClearAdmin) ProtoMessage()    {}
 func (*MsgClearAdmin) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{12}
 }
-
 func (m *MsgClearAdmin) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgClearAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgClearAdmin.Marshal(b, m, deterministic)
@@ -647,15 +583,12 @@ func (m *MsgClearAdmin) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *MsgClearAdmin) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgClearAdmin.Merge(m, src)
 }
-
 func (m *MsgClearAdmin) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgClearAdmin) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgClearAdmin.DiscardUnknown(m)
 }
@@ -663,7 +596,8 @@ func (m *MsgClearAdmin) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgClearAdmin proto.InternalMessageInfo
 
 // MsgClearAdminResponse returns empty data
-type MsgClearAdminResponse struct{}
+type MsgClearAdminResponse struct {
+}
 
 func (m *MsgClearAdminResponse) Reset()         { *m = MsgClearAdminResponse{} }
 func (m *MsgClearAdminResponse) String() string { return proto.CompactTextString(m) }
@@ -671,11 +605,9 @@ func (*MsgClearAdminResponse) ProtoMessage()    {}
 func (*MsgClearAdminResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{13}
 }
-
 func (m *MsgClearAdminResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgClearAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgClearAdminResponse.Marshal(b, m, deterministic)
@@ -688,15 +620,12 @@ func (m *MsgClearAdminResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
-
 func (m *MsgClearAdminResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgClearAdminResponse.Merge(m, src)
 }
-
 func (m *MsgClearAdminResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgClearAdminResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgClearAdminResponse.DiscardUnknown(m)
 }
@@ -719,11 +648,9 @@ func (*MsgUpdateInstantiateConfig) ProtoMessage()    {}
 func (*MsgUpdateInstantiateConfig) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{14}
 }
-
 func (m *MsgUpdateInstantiateConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateInstantiateConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateInstantiateConfig.Marshal(b, m, deterministic)
@@ -736,15 +663,12 @@ func (m *MsgUpdateInstantiateConfig) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateInstantiateConfig) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateInstantiateConfig.Merge(m, src)
 }
-
 func (m *MsgUpdateInstantiateConfig) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateInstantiateConfig) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateInstantiateConfig.DiscardUnknown(m)
 }
@@ -752,7 +676,8 @@ func (m *MsgUpdateInstantiateConfig) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgUpdateInstantiateConfig proto.InternalMessageInfo
 
 // MsgUpdateInstantiateConfigResponse returns empty data
-type MsgUpdateInstantiateConfigResponse struct{}
+type MsgUpdateInstantiateConfigResponse struct {
+}
 
 func (m *MsgUpdateInstantiateConfigResponse) Reset()         { *m = MsgUpdateInstantiateConfigResponse{} }
 func (m *MsgUpdateInstantiateConfigResponse) String() string { return proto.CompactTextString(m) }
@@ -760,11 +685,9 @@ func (*MsgUpdateInstantiateConfigResponse) ProtoMessage()    {}
 func (*MsgUpdateInstantiateConfigResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{15}
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateInstantiateConfigResponse.Marshal(b, m, deterministic)
@@ -777,15 +700,12 @@ func (m *MsgUpdateInstantiateConfigResponse) XXX_Marshal(b []byte, deterministic
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateInstantiateConfigResponse.Merge(m, src)
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateInstantiateConfigResponse.DiscardUnknown(m)
 }
@@ -810,11 +730,9 @@ func (*MsgUpdateParams) ProtoMessage()    {}
 func (*MsgUpdateParams) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{16}
 }
-
 func (m *MsgUpdateParams) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateParams.Marshal(b, m, deterministic)
@@ -827,15 +745,12 @@ func (m *MsgUpdateParams) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateParams) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateParams.Merge(m, src)
 }
-
 func (m *MsgUpdateParams) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateParams) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateParams.DiscardUnknown(m)
 }
@@ -846,7 +761,8 @@ var xxx_messageInfo_MsgUpdateParams proto.InternalMessageInfo
 // MsgUpdateParams message.
 //
 // Since: 0.40
-type MsgUpdateParamsResponse struct{}
+type MsgUpdateParamsResponse struct {
+}
 
 func (m *MsgUpdateParamsResponse) Reset()         { *m = MsgUpdateParamsResponse{} }
 func (m *MsgUpdateParamsResponse) String() string { return proto.CompactTextString(m) }
@@ -854,11 +770,9 @@ func (*MsgUpdateParamsResponse) ProtoMessage()    {}
 func (*MsgUpdateParamsResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{17}
 }
-
 func (m *MsgUpdateParamsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateParamsResponse.Marshal(b, m, deterministic)
@@ -871,15 +785,12 @@ func (m *MsgUpdateParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateParamsResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateParamsResponse.Merge(m, src)
 }
-
 func (m *MsgUpdateParamsResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateParamsResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateParamsResponse.DiscardUnknown(m)
 }
@@ -904,11 +815,9 @@ func (*MsgSudoContract) ProtoMessage()    {}
 func (*MsgSudoContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{18}
 }
-
 func (m *MsgSudoContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgSudoContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgSudoContract.Marshal(b, m, deterministic)
@@ -921,15 +830,12 @@ func (m *MsgSudoContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
-
 func (m *MsgSudoContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgSudoContract.Merge(m, src)
 }
-
 func (m *MsgSudoContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgSudoContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgSudoContract.DiscardUnknown(m)
 }
@@ -951,11 +857,9 @@ func (*MsgSudoContractResponse) ProtoMessage()    {}
 func (*MsgSudoContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{19}
 }
-
 func (m *MsgSudoContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgSudoContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgSudoContractResponse.Marshal(b, m, deterministic)
@@ -968,15 +872,12 @@ func (m *MsgSudoContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return b[:n], nil
 	}
 }
-
 func (m *MsgSudoContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgSudoContractResponse.Merge(m, src)
 }
-
 func (m *MsgSudoContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgSudoContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgSudoContractResponse.DiscardUnknown(m)
 }
@@ -999,11 +900,9 @@ func (*MsgPinCodes) ProtoMessage()    {}
 func (*MsgPinCodes) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{20}
 }
-
 func (m *MsgPinCodes) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgPinCodes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgPinCodes.Marshal(b, m, deterministic)
@@ -1016,15 +915,12 @@ func (m *MsgPinCodes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-
 func (m *MsgPinCodes) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgPinCodes.Merge(m, src)
 }
-
 func (m *MsgPinCodes) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgPinCodes) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgPinCodes.DiscardUnknown(m)
 }
@@ -1035,7 +931,8 @@ var xxx_messageInfo_MsgPinCodes proto.InternalMessageInfo
 // MsgPinCodes message.
 //
 // Since: 0.40
-type MsgPinCodesResponse struct{}
+type MsgPinCodesResponse struct {
+}
 
 func (m *MsgPinCodesResponse) Reset()         { *m = MsgPinCodesResponse{} }
 func (m *MsgPinCodesResponse) String() string { return proto.CompactTextString(m) }
@@ -1043,11 +940,9 @@ func (*MsgPinCodesResponse) ProtoMessage()    {}
 func (*MsgPinCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{21}
 }
-
 func (m *MsgPinCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgPinCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgPinCodesResponse.Marshal(b, m, deterministic)
@@ -1060,15 +955,12 @@ func (m *MsgPinCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
-
 func (m *MsgPinCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgPinCodesResponse.Merge(m, src)
 }
-
 func (m *MsgPinCodesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgPinCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgPinCodesResponse.DiscardUnknown(m)
 }
@@ -1091,11 +983,9 @@ func (*MsgUnpinCodes) ProtoMessage()    {}
 func (*MsgUnpinCodes) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{22}
 }
-
 func (m *MsgUnpinCodes) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUnpinCodes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUnpinCodes.Marshal(b, m, deterministic)
@@ -1108,15 +998,12 @@ func (m *MsgUnpinCodes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUnpinCodes) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUnpinCodes.Merge(m, src)
 }
-
 func (m *MsgUnpinCodes) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUnpinCodes) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUnpinCodes.DiscardUnknown(m)
 }
@@ -1127,7 +1014,8 @@ var xxx_messageInfo_MsgUnpinCodes proto.InternalMessageInfo
 // MsgUnpinCodes message.
 //
 // Since: 0.40
-type MsgUnpinCodesResponse struct{}
+type MsgUnpinCodesResponse struct {
+}
 
 func (m *MsgUnpinCodesResponse) Reset()         { *m = MsgUnpinCodesResponse{} }
 func (m *MsgUnpinCodesResponse) String() string { return proto.CompactTextString(m) }
@@ -1135,11 +1023,9 @@ func (*MsgUnpinCodesResponse) ProtoMessage()    {}
 func (*MsgUnpinCodesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{23}
 }
-
 func (m *MsgUnpinCodesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUnpinCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUnpinCodesResponse.Marshal(b, m, deterministic)
@@ -1152,15 +1038,12 @@ func (m *MsgUnpinCodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byt
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUnpinCodesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUnpinCodesResponse.Merge(m, src)
 }
-
 func (m *MsgUnpinCodesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUnpinCodesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUnpinCodesResponse.DiscardUnknown(m)
 }
@@ -1206,11 +1089,9 @@ func (*MsgStoreAndInstantiateContract) ProtoMessage()    {}
 func (*MsgStoreAndInstantiateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{24}
 }
-
 func (m *MsgStoreAndInstantiateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreAndInstantiateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreAndInstantiateContract.Marshal(b, m, deterministic)
@@ -1223,15 +1104,12 @@ func (m *MsgStoreAndInstantiateContract) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreAndInstantiateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreAndInstantiateContract.Merge(m, src)
 }
-
 func (m *MsgStoreAndInstantiateContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreAndInstantiateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreAndInstantiateContract.DiscardUnknown(m)
 }
@@ -1257,11 +1135,9 @@ func (*MsgStoreAndInstantiateContractResponse) ProtoMessage()    {}
 func (*MsgStoreAndInstantiateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{25}
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreAndInstantiateContractResponse.Marshal(b, m, deterministic)
@@ -1274,15 +1150,12 @@ func (m *MsgStoreAndInstantiateContractResponse) XXX_Marshal(b []byte, determini
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreAndInstantiateContractResponse.Merge(m, src)
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreAndInstantiateContractResponse.DiscardUnknown(m)
 }
@@ -1303,11 +1176,9 @@ func (*MsgAddCodeUploadParamsAddresses) ProtoMessage()    {}
 func (*MsgAddCodeUploadParamsAddresses) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{26}
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgAddCodeUploadParamsAddresses.Marshal(b, m, deterministic)
@@ -1320,15 +1191,12 @@ func (m *MsgAddCodeUploadParamsAddresses) XXX_Marshal(b []byte, deterministic bo
 		return b[:n], nil
 	}
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgAddCodeUploadParamsAddresses.Merge(m, src)
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgAddCodeUploadParamsAddresses.DiscardUnknown(m)
 }
@@ -1337,7 +1205,8 @@ var xxx_messageInfo_MsgAddCodeUploadParamsAddresses proto.InternalMessageInfo
 
 // MsgAddCodeUploadParamsAddressesResponse defines the response
 // structure for executing a MsgAddCodeUploadParamsAddresses message.
-type MsgAddCodeUploadParamsAddressesResponse struct{}
+type MsgAddCodeUploadParamsAddressesResponse struct {
+}
 
 func (m *MsgAddCodeUploadParamsAddressesResponse) Reset() {
 	*m = MsgAddCodeUploadParamsAddressesResponse{}
@@ -1347,11 +1216,9 @@ func (*MsgAddCodeUploadParamsAddressesResponse) ProtoMessage()    {}
 func (*MsgAddCodeUploadParamsAddressesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{27}
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgAddCodeUploadParamsAddressesResponse.Marshal(b, m, deterministic)
@@ -1364,15 +1231,12 @@ func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_Marshal(b []byte, determin
 		return b[:n], nil
 	}
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgAddCodeUploadParamsAddressesResponse.Merge(m, src)
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgAddCodeUploadParamsAddressesResponse.DiscardUnknown(m)
 }
@@ -1393,11 +1257,9 @@ func (*MsgRemoveCodeUploadParamsAddresses) ProtoMessage()    {}
 func (*MsgRemoveCodeUploadParamsAddresses) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{28}
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRemoveCodeUploadParamsAddresses.Marshal(b, m, deterministic)
@@ -1410,15 +1272,12 @@ func (m *MsgRemoveCodeUploadParamsAddresses) XXX_Marshal(b []byte, deterministic
 		return b[:n], nil
 	}
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRemoveCodeUploadParamsAddresses.Merge(m, src)
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRemoveCodeUploadParamsAddresses.DiscardUnknown(m)
 }
@@ -1427,12 +1286,12 @@ var xxx_messageInfo_MsgRemoveCodeUploadParamsAddresses proto.InternalMessageInfo
 
 // MsgRemoveCodeUploadParamsAddressesResponse defines the response
 // structure for executing a MsgRemoveCodeUploadParamsAddresses message.
-type MsgRemoveCodeUploadParamsAddressesResponse struct{}
+type MsgRemoveCodeUploadParamsAddressesResponse struct {
+}
 
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) Reset() {
 	*m = MsgRemoveCodeUploadParamsAddressesResponse{}
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) String() string {
 	return proto.CompactTextString(m)
 }
@@ -1440,11 +1299,9 @@ func (*MsgRemoveCodeUploadParamsAddressesResponse) ProtoMessage() {}
 func (*MsgRemoveCodeUploadParamsAddressesResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{29}
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgRemoveCodeUploadParamsAddressesResponse.Marshal(b, m, deterministic)
@@ -1457,15 +1314,12 @@ func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_Marshal(b []byte, deter
 		return b[:n], nil
 	}
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgRemoveCodeUploadParamsAddressesResponse.Merge(m, src)
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgRemoveCodeUploadParamsAddressesResponse.DiscardUnknown(m)
 }
@@ -1495,11 +1349,9 @@ func (*MsgStoreAndMigrateContract) ProtoMessage()    {}
 func (*MsgStoreAndMigrateContract) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{30}
 }
-
 func (m *MsgStoreAndMigrateContract) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreAndMigrateContract) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreAndMigrateContract.Marshal(b, m, deterministic)
@@ -1512,15 +1364,12 @@ func (m *MsgStoreAndMigrateContract) XXX_Marshal(b []byte, deterministic bool) (
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreAndMigrateContract) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreAndMigrateContract.Merge(m, src)
 }
-
 func (m *MsgStoreAndMigrateContract) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreAndMigrateContract) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreAndMigrateContract.DiscardUnknown(m)
 }
@@ -1546,11 +1395,9 @@ func (*MsgStoreAndMigrateContractResponse) ProtoMessage()    {}
 func (*MsgStoreAndMigrateContractResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{31}
 }
-
 func (m *MsgStoreAndMigrateContractResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgStoreAndMigrateContractResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgStoreAndMigrateContractResponse.Marshal(b, m, deterministic)
@@ -1563,15 +1410,12 @@ func (m *MsgStoreAndMigrateContractResponse) XXX_Marshal(b []byte, deterministic
 		return b[:n], nil
 	}
 }
-
 func (m *MsgStoreAndMigrateContractResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgStoreAndMigrateContractResponse.Merge(m, src)
 }
-
 func (m *MsgStoreAndMigrateContractResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgStoreAndMigrateContractResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgStoreAndMigrateContractResponse.DiscardUnknown(m)
 }
@@ -1594,11 +1438,9 @@ func (*MsgUpdateContractLabel) ProtoMessage()    {}
 func (*MsgUpdateContractLabel) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{32}
 }
-
 func (m *MsgUpdateContractLabel) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateContractLabel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateContractLabel.Marshal(b, m, deterministic)
@@ -1611,15 +1453,12 @@ func (m *MsgUpdateContractLabel) XXX_Marshal(b []byte, deterministic bool) ([]by
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateContractLabel) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateContractLabel.Merge(m, src)
 }
-
 func (m *MsgUpdateContractLabel) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateContractLabel) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateContractLabel.DiscardUnknown(m)
 }
@@ -1627,7 +1466,8 @@ func (m *MsgUpdateContractLabel) XXX_DiscardUnknown() {
 var xxx_messageInfo_MsgUpdateContractLabel proto.InternalMessageInfo
 
 // MsgUpdateContractLabelResponse returns empty data
-type MsgUpdateContractLabelResponse struct{}
+type MsgUpdateContractLabelResponse struct {
+}
 
 func (m *MsgUpdateContractLabelResponse) Reset()         { *m = MsgUpdateContractLabelResponse{} }
 func (m *MsgUpdateContractLabelResponse) String() string { return proto.CompactTextString(m) }
@@ -1635,11 +1475,9 @@ func (*MsgUpdateContractLabelResponse) ProtoMessage()    {}
 func (*MsgUpdateContractLabelResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_4f74d82755520264, []int{33}
 }
-
 func (m *MsgUpdateContractLabelResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *MsgUpdateContractLabelResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_MsgUpdateContractLabelResponse.Marshal(b, m, deterministic)
@@ -1652,15 +1490,12 @@ func (m *MsgUpdateContractLabelResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-
 func (m *MsgUpdateContractLabelResponse) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_MsgUpdateContractLabelResponse.Merge(m, src)
 }
-
 func (m *MsgUpdateContractLabelResponse) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *MsgUpdateContractLabelResponse) XXX_DiscardUnknown() {
 	xxx_messageInfo_MsgUpdateContractLabelResponse.DiscardUnknown(m)
 }
@@ -1819,10 +1654,8 @@ var fileDescriptor_4f74d82755520264 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ context.Context
-	_ grpc.ClientConn
-)
+var _ context.Context
+var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -2120,72 +1953,57 @@ type MsgServer interface {
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
-type UnimplementedMsgServer struct{}
+type UnimplementedMsgServer struct {
+}
 
 func (*UnimplementedMsgServer) StoreCode(ctx context.Context, req *MsgStoreCode) (*MsgStoreCodeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StoreCode not implemented")
 }
-
 func (*UnimplementedMsgServer) InstantiateContract(ctx context.Context, req *MsgInstantiateContract) (*MsgInstantiateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InstantiateContract not implemented")
 }
-
 func (*UnimplementedMsgServer) InstantiateContract2(ctx context.Context, req *MsgInstantiateContract2) (*MsgInstantiateContract2Response, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method InstantiateContract2 not implemented")
 }
-
 func (*UnimplementedMsgServer) ExecuteContract(ctx context.Context, req *MsgExecuteContract) (*MsgExecuteContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ExecuteContract not implemented")
 }
-
 func (*UnimplementedMsgServer) MigrateContract(ctx context.Context, req *MsgMigrateContract) (*MsgMigrateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method MigrateContract not implemented")
 }
-
 func (*UnimplementedMsgServer) UpdateAdmin(ctx context.Context, req *MsgUpdateAdmin) (*MsgUpdateAdminResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateAdmin not implemented")
 }
-
 func (*UnimplementedMsgServer) ClearAdmin(ctx context.Context, req *MsgClearAdmin) (*MsgClearAdminResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ClearAdmin not implemented")
 }
-
 func (*UnimplementedMsgServer) UpdateInstantiateConfig(ctx context.Context, req *MsgUpdateInstantiateConfig) (*MsgUpdateInstantiateConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateInstantiateConfig not implemented")
 }
-
 func (*UnimplementedMsgServer) UpdateParams(ctx context.Context, req *MsgUpdateParams) (*MsgUpdateParamsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateParams not implemented")
 }
-
 func (*UnimplementedMsgServer) SudoContract(ctx context.Context, req *MsgSudoContract) (*MsgSudoContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method SudoContract not implemented")
 }
-
 func (*UnimplementedMsgServer) PinCodes(ctx context.Context, req *MsgPinCodes) (*MsgPinCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PinCodes not implemented")
 }
-
 func (*UnimplementedMsgServer) UnpinCodes(ctx context.Context, req *MsgUnpinCodes) (*MsgUnpinCodesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UnpinCodes not implemented")
 }
-
 func (*UnimplementedMsgServer) StoreAndInstantiateContract(ctx context.Context, req *MsgStoreAndInstantiateContract) (*MsgStoreAndInstantiateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StoreAndInstantiateContract not implemented")
 }
-
 func (*UnimplementedMsgServer) RemoveCodeUploadParamsAddresses(ctx context.Context, req *MsgRemoveCodeUploadParamsAddresses) (*MsgRemoveCodeUploadParamsAddressesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RemoveCodeUploadParamsAddresses not implemented")
 }
-
 func (*UnimplementedMsgServer) AddCodeUploadParamsAddresses(ctx context.Context, req *MsgAddCodeUploadParamsAddresses) (*MsgAddCodeUploadParamsAddressesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AddCodeUploadParamsAddresses not implemented")
 }
-
 func (*UnimplementedMsgServer) StoreAndMigrateContract(ctx context.Context, req *MsgStoreAndMigrateContract) (*MsgStoreAndMigrateContractResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method StoreAndMigrateContract not implemented")
 }
-
 func (*UnimplementedMsgServer) UpdateContractLabel(ctx context.Context, req *MsgUpdateContractLabel) (*MsgUpdateContractLabelResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method UpdateContractLabel not implemented")
 }
@@ -3994,7 +3812,6 @@ func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *MsgStoreCode) Size() (n int) {
 	if m == nil {
 		return 0
@@ -4628,11 +4445,9 @@ func (m *MsgUpdateContractLabelResponse) Size() (n int) {
 func sovTx(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozTx(x uint64) (n int) {
 	return sovTx(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *MsgStoreCode) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4785,7 +4600,6 @@ func (m *MsgStoreCode) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgStoreCodeResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -4889,7 +4703,6 @@ func (m *MsgStoreCodeResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgInstantiateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5123,7 +4936,6 @@ func (m *MsgInstantiateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5240,7 +5052,6 @@ func (m *MsgInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgInstantiateContract2) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5528,7 +5339,6 @@ func (m *MsgInstantiateContract2) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgInstantiateContract2Response) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5645,7 +5455,6 @@ func (m *MsgInstantiateContract2Response) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgExecuteContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5828,7 +5637,6 @@ func (m *MsgExecuteContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgExecuteContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -5913,7 +5721,6 @@ func (m *MsgExecuteContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgMigrateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6081,7 +5888,6 @@ func (m *MsgMigrateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6166,7 +5972,6 @@ func (m *MsgMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateAdmin) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6313,7 +6118,6 @@ func (m *MsgUpdateAdmin) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateAdminResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6364,7 +6168,6 @@ func (m *MsgUpdateAdminResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgClearAdmin) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6479,7 +6282,6 @@ func (m *MsgClearAdmin) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgClearAdminResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6530,7 +6332,6 @@ func (m *MsgClearAdminResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateInstantiateConfig) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6668,7 +6469,6 @@ func (m *MsgUpdateInstantiateConfig) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateInstantiateConfigResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6719,7 +6519,6 @@ func (m *MsgUpdateInstantiateConfigResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateParams) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6835,7 +6634,6 @@ func (m *MsgUpdateParams) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateParamsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6886,7 +6684,6 @@ func (m *MsgUpdateParamsResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgSudoContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7035,7 +6832,6 @@ func (m *MsgSudoContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgSudoContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7120,7 +6916,6 @@ func (m *MsgSudoContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgPinCodes) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7279,7 +7074,6 @@ func (m *MsgPinCodes) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgPinCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7330,7 +7124,6 @@ func (m *MsgPinCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUnpinCodes) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7489,7 +7282,6 @@ func (m *MsgUnpinCodes) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUnpinCodesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7540,7 +7332,6 @@ func (m *MsgUnpinCodesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgStoreAndInstantiateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -7943,7 +7734,6 @@ func (m *MsgStoreAndInstantiateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgStoreAndInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8060,7 +7850,6 @@ func (m *MsgStoreAndInstantiateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgAddCodeUploadParamsAddresses) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8175,7 +7964,6 @@ func (m *MsgAddCodeUploadParamsAddresses) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgAddCodeUploadParamsAddressesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8226,7 +8014,6 @@ func (m *MsgAddCodeUploadParamsAddressesResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgRemoveCodeUploadParamsAddresses) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8341,7 +8128,6 @@ func (m *MsgRemoveCodeUploadParamsAddresses) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgRemoveCodeUploadParamsAddressesResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8392,7 +8178,6 @@ func (m *MsgRemoveCodeUploadParamsAddressesResponse) Unmarshal(dAtA []byte) erro
 	}
 	return nil
 }
-
 func (m *MsgStoreAndMigrateContract) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8611,7 +8396,6 @@ func (m *MsgStoreAndMigrateContract) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgStoreAndMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8749,7 +8533,6 @@ func (m *MsgStoreAndMigrateContractResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateContractLabel) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8896,7 +8679,6 @@ func (m *MsgUpdateContractLabel) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *MsgUpdateContractLabelResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -8947,7 +8729,6 @@ func (m *MsgUpdateContractLabelResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipTx(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/x/wasm/types/types.pb.go
+++ b/x/wasm/types/types.pb.go
@@ -6,24 +6,21 @@ package types
 import (
 	bytes "bytes"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	github_com_cometbft_cometbft_libs_bytes "github.com/cometbft/cometbft/libs/bytes"
 	_ "github.com/cosmos/cosmos-proto"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var (
-	_ = proto.Marshal
-	_ = fmt.Errorf
-	_ = math.Inf
-)
+var _ = proto.Marshal
+var _ = fmt.Errorf
+var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -110,11 +107,9 @@ func (*AccessTypeParam) ProtoMessage()    {}
 func (*AccessTypeParam) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{0}
 }
-
 func (m *AccessTypeParam) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AccessTypeParam) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessTypeParam.Marshal(b, m, deterministic)
@@ -127,15 +122,12 @@ func (m *AccessTypeParam) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return b[:n], nil
 	}
 }
-
 func (m *AccessTypeParam) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessTypeParam.Merge(m, src)
 }
-
 func (m *AccessTypeParam) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AccessTypeParam) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessTypeParam.DiscardUnknown(m)
 }
@@ -154,11 +146,9 @@ func (*AccessConfig) ProtoMessage()    {}
 func (*AccessConfig) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{1}
 }
-
 func (m *AccessConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AccessConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AccessConfig.Marshal(b, m, deterministic)
@@ -171,15 +161,12 @@ func (m *AccessConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-
 func (m *AccessConfig) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AccessConfig.Merge(m, src)
 }
-
 func (m *AccessConfig) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AccessConfig) XXX_DiscardUnknown() {
 	xxx_messageInfo_AccessConfig.DiscardUnknown(m)
 }
@@ -197,11 +184,9 @@ func (*Params) ProtoMessage() {}
 func (*Params) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{2}
 }
-
 func (m *Params) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Params.Marshal(b, m, deterministic)
@@ -214,15 +199,12 @@ func (m *Params) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *Params) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Params.Merge(m, src)
 }
-
 func (m *Params) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *Params) XXX_DiscardUnknown() {
 	xxx_messageInfo_Params.DiscardUnknown(m)
 }
@@ -245,11 +227,9 @@ func (*CodeInfo) ProtoMessage()    {}
 func (*CodeInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{3}
 }
-
 func (m *CodeInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *CodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_CodeInfo.Marshal(b, m, deterministic)
@@ -262,15 +242,12 @@ func (m *CodeInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *CodeInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_CodeInfo.Merge(m, src)
 }
-
 func (m *CodeInfo) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *CodeInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_CodeInfo.DiscardUnknown(m)
 }
@@ -301,11 +278,9 @@ func (*ContractInfo) ProtoMessage()    {}
 func (*ContractInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{4}
 }
-
 func (m *ContractInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ContractInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractInfo.Marshal(b, m, deterministic)
@@ -318,15 +293,12 @@ func (m *ContractInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-
 func (m *ContractInfo) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractInfo.Merge(m, src)
 }
-
 func (m *ContractInfo) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ContractInfo) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractInfo.DiscardUnknown(m)
 }
@@ -349,11 +321,9 @@ func (*ContractCodeHistoryEntry) ProtoMessage()    {}
 func (*ContractCodeHistoryEntry) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{5}
 }
-
 func (m *ContractCodeHistoryEntry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *ContractCodeHistoryEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_ContractCodeHistoryEntry.Marshal(b, m, deterministic)
@@ -366,15 +336,12 @@ func (m *ContractCodeHistoryEntry) XXX_Marshal(b []byte, deterministic bool) ([]
 		return b[:n], nil
 	}
 }
-
 func (m *ContractCodeHistoryEntry) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_ContractCodeHistoryEntry.Merge(m, src)
 }
-
 func (m *ContractCodeHistoryEntry) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *ContractCodeHistoryEntry) XXX_DiscardUnknown() {
 	xxx_messageInfo_ContractCodeHistoryEntry.DiscardUnknown(m)
 }
@@ -397,11 +364,9 @@ func (*AbsoluteTxPosition) ProtoMessage()    {}
 func (*AbsoluteTxPosition) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{6}
 }
-
 func (m *AbsoluteTxPosition) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *AbsoluteTxPosition) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_AbsoluteTxPosition.Marshal(b, m, deterministic)
@@ -414,15 +379,12 @@ func (m *AbsoluteTxPosition) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-
 func (m *AbsoluteTxPosition) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_AbsoluteTxPosition.Merge(m, src)
 }
-
 func (m *AbsoluteTxPosition) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *AbsoluteTxPosition) XXX_DiscardUnknown() {
 	xxx_messageInfo_AbsoluteTxPosition.DiscardUnknown(m)
 }
@@ -443,11 +405,9 @@ func (*Model) ProtoMessage()    {}
 func (*Model) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e6155d98fa173e02, []int{7}
 }
-
 func (m *Model) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-
 func (m *Model) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
 		return xxx_messageInfo_Model.Marshal(b, m, deterministic)
@@ -460,15 +420,12 @@ func (m *Model) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-
 func (m *Model) XXX_Merge(src proto.Message) {
 	xxx_messageInfo_Model.Merge(m, src)
 }
-
 func (m *Model) XXX_Size() int {
 	return m.Size()
 }
-
 func (m *Model) XXX_DiscardUnknown() {
 	xxx_messageInfo_Model.DiscardUnknown(m)
 }
@@ -592,7 +549,6 @@ func (this *AccessTypeParam) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *AccessConfig) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -625,7 +581,6 @@ func (this *AccessConfig) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *Params) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -653,7 +608,6 @@ func (this *Params) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *CodeInfo) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -684,7 +638,6 @@ func (this *CodeInfo) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *ContractInfo) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -727,7 +680,6 @@ func (this *ContractInfo) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *ContractCodeHistoryEntry) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -761,7 +713,6 @@ func (this *ContractCodeHistoryEntry) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *AbsoluteTxPosition) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -789,7 +740,6 @@ func (this *AbsoluteTxPosition) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (this *Model) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -817,7 +767,6 @@ func (this *Model) Equal(that interface{}) bool {
 	}
 	return true
 }
-
 func (m *AccessTypeParam) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1181,7 +1130,6 @@ func encodeVarintTypes(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-
 func (m *AccessTypeParam) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1339,11 +1287,9 @@ func (m *Model) Size() (n int) {
 func sovTypes(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
-
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-
 func (m *AccessTypeParam) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1413,7 +1359,6 @@ func (m *AccessTypeParam) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AccessConfig) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1515,7 +1460,6 @@ func (m *AccessConfig) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *Params) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1618,7 +1562,6 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *CodeInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1768,7 +1711,6 @@ func (m *CodeInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2038,7 +1980,6 @@ func (m *ContractInfo) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *ContractCodeHistoryEntry) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2197,7 +2138,6 @@ func (m *ContractCodeHistoryEntry) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *AbsoluteTxPosition) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2286,7 +2226,6 @@ func (m *AbsoluteTxPosition) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func (m *Model) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2405,7 +2344,6 @@ func (m *Model) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-
 func skipTypes(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0


### PR DESCRIPTION
This PR ensures that we are using the protos from the SDK v0.50.x series