### PR TITLE
Rename InstantiateContractCosts -> SetupContractCost; Remove NewContractInstanceCosts

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -249,8 +249,8 @@ func (k Keeper) instantiate(
 		return nil, nil, types.ErrEmpty.Wrap("creator")
 	}
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	instanceCosts := k.gasRegister.NewContractInstanceCosts(k.IsPinnedCode(sdkCtx, codeID), len(initMsg))
-	sdkCtx.GasMeter().ConsumeGas(instanceCosts, "Loading CosmWasm module: instantiate")
+	setupCost := k.gasRegister.SetupContractCost(k.IsPinnedCode(sdkCtx, codeID), len(initMsg))
+	sdkCtx.GasMeter().ConsumeGas(setupCost, "Loading CosmWasm module: instantiate")
 
 	codeInfo := k.GetCodeInfo(ctx, codeID)
 	if codeInfo == nil {

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -382,8 +382,8 @@ func (k Keeper) execute(ctx context.Context, contractAddress, caller sdk.AccAddr
 		return nil, err
 	}
 
-	executeCosts := k.gasRegister.InstantiateContractCosts(k.IsPinnedCode(ctx, contractInfo.CodeID), len(msg))
-	sdkCtx.GasMeter().ConsumeGas(executeCosts, "Loading CosmWasm module: execute")
+	setupCost := k.gasRegister.SetupContractCost(k.IsPinnedCode(ctx, contractInfo.CodeID), len(msg))
+	sdkCtx.GasMeter().ConsumeGas(setupCost, "Loading CosmWasm module: execute")
 
 	// add more funds
 	if !coins.IsZero() {
@@ -428,8 +428,8 @@ func (k Keeper) migrate(
 	defer telemetry.MeasureSince(time.Now(), "wasm", "contract", "migrate")
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	migrateSetupCosts := k.gasRegister.InstantiateContractCosts(k.IsPinnedCode(ctx, newCodeID), len(msg))
-	sdkCtx.GasMeter().ConsumeGas(migrateSetupCosts, "Loading CosmWasm module: migrate")
+	setupCost := k.gasRegister.SetupContractCost(k.IsPinnedCode(ctx, newCodeID), len(msg))
+	sdkCtx.GasMeter().ConsumeGas(setupCost, "Loading CosmWasm module: migrate")
 
 	contractInfo := k.GetContractInfo(ctx, contractAddress)
 	if contractInfo == nil {
@@ -525,9 +525,9 @@ func (k Keeper) Sudo(ctx context.Context, contractAddress sdk.AccAddress, msg []
 		return nil, err
 	}
 
-	sudoSetupCosts := k.gasRegister.InstantiateContractCosts(k.IsPinnedCode(ctx, contractInfo.CodeID), len(msg))
+	setupCost := k.gasRegister.SetupContractCost(k.IsPinnedCode(ctx, contractInfo.CodeID), len(msg))
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.GasMeter().ConsumeGas(sudoSetupCosts, "Loading CosmWasm module: sudo")
+	sdkCtx.GasMeter().ConsumeGas(setupCost, "Loading CosmWasm module: sudo")
 
 	env := types.NewEnv(sdkCtx, contractAddress)
 
@@ -747,8 +747,8 @@ func (k Keeper) QuerySmart(ctx context.Context, contractAddr sdk.AccAddress, req
 		return nil, err
 	}
 
-	smartQuerySetupCosts := k.gasRegister.InstantiateContractCosts(k.IsPinnedCode(sdkCtx, contractInfo.CodeID), len(req))
-	sdkCtx.GasMeter().ConsumeGas(smartQuerySetupCosts, "Loading CosmWasm module: query")
+	setupCost := k.gasRegister.SetupContractCost(k.IsPinnedCode(sdkCtx, contractInfo.CodeID), len(req))
+	sdkCtx.GasMeter().ConsumeGas(setupCost, "Loading CosmWasm module: query")
 
 	// prepare querier
 	querier := k.newQueryHandler(sdkCtx, contractAddr)

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -211,7 +211,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 
 	const (
 		// Note: about 100 SDK gas (10k CosmWasm gas) for each round of sha256
-		GasWork2k uint64 = 77_161 // = NewContractInstanceCosts + x // we have 6x gas used in cpu than in the instance
+		GasWork2k uint64 = 77_161 // = SetupContractCost + x // we have 6x gas used in cpu than in the instance
 		// This is overhead for calling into a sub-contract
 		GasReturnHashed uint64 = 27
 	)

--- a/x/wasm/keeper/wasmtesting/gas_register.go
+++ b/x/wasm/keeper/wasmtesting/gas_register.go
@@ -10,7 +10,7 @@ import (
 type MockGasRegister struct {
 	CompileCostFn             func(byteLength int) storetypes.Gas
 	NewContractInstanceCostFn func(pinned bool, msgLen int) storetypes.Gas
-	InstantiateContractCostFn func(pinned bool, msgLen int) storetypes.Gas
+	SetupContractCostFn       func(pinned bool, msgLen int) storetypes.Gas
 	ReplyCostFn               func(pinned bool, reply wasmvmtypes.Reply) storetypes.Gas
 	EventCostsFn              func(evts []wasmvmtypes.EventAttribute) storetypes.Gas
 	ToWasmVMGasFn             func(source storetypes.Gas) uint64
@@ -39,11 +39,11 @@ func (m MockGasRegister) UncompressCosts(byteLength int) storetypes.Gas {
 	return m.UncompressCostsFn(byteLength)
 }
 
-func (m MockGasRegister) InstantiateContractCosts(pinned bool, msgLen int) storetypes.Gas {
-	if m.InstantiateContractCostFn == nil {
+func (m MockGasRegister) SetupContractCost(pinned bool, msgLen int) storetypes.Gas {
+	if m.SetupContractCostFn == nil {
 		panic("not expected to be called")
 	}
-	return m.InstantiateContractCostFn(pinned, msgLen)
+	return m.SetupContractCostFn(pinned, msgLen)
 }
 
 func (m MockGasRegister) ReplyCosts(pinned bool, reply wasmvmtypes.Reply) storetypes.Gas {

--- a/x/wasm/keeper/wasmtesting/gas_register.go
+++ b/x/wasm/keeper/wasmtesting/gas_register.go
@@ -8,21 +8,13 @@ import (
 
 // MockGasRegister mock that implements keeper.GasRegister
 type MockGasRegister struct {
-	CompileCostFn             func(byteLength int) storetypes.Gas
-	NewContractInstanceCostFn func(pinned bool, msgLen int) storetypes.Gas
-	SetupContractCostFn       func(pinned bool, msgLen int) storetypes.Gas
-	ReplyCostFn               func(pinned bool, reply wasmvmtypes.Reply) storetypes.Gas
-	EventCostsFn              func(evts []wasmvmtypes.EventAttribute) storetypes.Gas
-	ToWasmVMGasFn             func(source storetypes.Gas) uint64
-	FromWasmVMGasFn           func(source uint64) storetypes.Gas
-	UncompressCostsFn         func(byteLength int) storetypes.Gas
-}
-
-func (m MockGasRegister) NewContractInstanceCosts(pinned bool, msgLen int) storetypes.Gas {
-	if m.NewContractInstanceCostFn == nil {
-		panic("not expected to be called")
-	}
-	return m.NewContractInstanceCostFn(pinned, msgLen)
+	CompileCostFn       func(byteLength int) storetypes.Gas
+	SetupContractCostFn func(pinned bool, msgLen int) storetypes.Gas
+	ReplyCostFn         func(pinned bool, reply wasmvmtypes.Reply) storetypes.Gas
+	EventCostsFn        func(evts []wasmvmtypes.EventAttribute) storetypes.Gas
+	ToWasmVMGasFn       func(source storetypes.Gas) uint64
+	FromWasmVMGasFn     func(source uint64) storetypes.Gas
+	UncompressCostsFn   func(byteLength int) storetypes.Gas
 }
 
 func (m MockGasRegister) CompileCosts(byteLength int) storetypes.Gas {

--- a/x/wasm/types/gas_register.go
+++ b/x/wasm/types/gas_register.go
@@ -69,8 +69,6 @@ func DefaultPerByteUncompressCost() wasmvmtypes.UFraction {
 
 // GasRegister abstract source for gas costs
 type GasRegister interface {
-	// NewContractInstanceCosts costs to create a new contract instance from code
-	NewContractInstanceCosts(pinned bool, msgLen int) storetypes.Gas
 	// CompileCosts costs to persist and "compile" a new wasm contract
 	CompileCosts(byteLength int) storetypes.Gas
 	// UncompressCosts costs to unpack a new wasm contract
@@ -151,11 +149,6 @@ func NewWasmGasRegister(c WasmGasRegisterConfig) WasmGasRegister {
 	return WasmGasRegister{
 		c: c,
 	}
-}
-
-// NewContractInstanceCosts costs to create a new contract instance from code
-func (g WasmGasRegister) NewContractInstanceCosts(pinned bool, msgLen int) storetypes.Gas {
-	return g.SetupContractCost(pinned, msgLen)
 }
 
 // CompileCosts costs to persist and "compile" a new wasm contract

--- a/x/wasm/types/gas_register_test.go
+++ b/x/wasm/types/gas_register_test.go
@@ -48,70 +48,7 @@ func TestCompileCosts(t *testing.T) {
 	}
 }
 
-func TestNewContractInstanceCosts(t *testing.T) {
-	specs := map[string]struct {
-		srcLen    int
-		srcConfig WasmGasRegisterConfig
-		pinned    bool
-		exp       storetypes.Gas
-		expPanic  bool
-	}{
-		"small msg - pinned": {
-			srcLen:    1,
-			srcConfig: DefaultGasRegisterConfig(),
-			pinned:    true,
-			exp:       DefaultContractMessageDataCost,
-		},
-		"big msg - pinned": {
-			srcLen:    math.MaxUint32,
-			srcConfig: DefaultGasRegisterConfig(),
-			pinned:    true,
-			exp:       DefaultContractMessageDataCost * storetypes.Gas(math.MaxUint32),
-		},
-		"empty msg - pinned": {
-			srcLen:    0,
-			pinned:    true,
-			srcConfig: DefaultGasRegisterConfig(),
-			exp:       storetypes.Gas(0),
-		},
-		"small msg - unpinned": {
-			srcLen:    1,
-			srcConfig: DefaultGasRegisterConfig(),
-			exp:       DefaultContractMessageDataCost + DefaultInstanceCost,
-		},
-		"big msg - unpinned": {
-			srcLen:    math.MaxUint32,
-			srcConfig: DefaultGasRegisterConfig(),
-			exp:       DefaultContractMessageDataCost*math.MaxUint32 + DefaultInstanceCost,
-		},
-		"empty msg - unpinned": {
-			srcLen:    0,
-			srcConfig: DefaultGasRegisterConfig(),
-			exp:       DefaultInstanceCost,
-		},
-
-		"negative len": {
-			srcLen:    -1,
-			srcConfig: DefaultGasRegisterConfig(),
-			expPanic:  true,
-		},
-	}
-	for name, spec := range specs {
-		t.Run(name, func(t *testing.T) {
-			if spec.expPanic {
-				assert.Panics(t, func() {
-					NewWasmGasRegister(spec.srcConfig).NewContractInstanceCosts(spec.pinned, spec.srcLen)
-				})
-				return
-			}
-			gotGas := NewWasmGasRegister(spec.srcConfig).NewContractInstanceCosts(spec.pinned, spec.srcLen)
-			assert.Equal(t, spec.exp, gotGas)
-		})
-	}
-}
-
 func TestSetupContractCost(t *testing.T) {
-	// same as TestNewContractInstanceCosts currently
 	specs := map[string]struct {
 		srcLen    int
 		srcConfig WasmGasRegisterConfig

--- a/x/wasm/types/gas_register_test.go
+++ b/x/wasm/types/gas_register_test.go
@@ -110,7 +110,7 @@ func TestNewContractInstanceCosts(t *testing.T) {
 	}
 }
 
-func TestContractInstanceCosts(t *testing.T) {
+func TestSetupContractCost(t *testing.T) {
 	// same as TestNewContractInstanceCosts currently
 	specs := map[string]struct {
 		srcLen    int
@@ -163,11 +163,11 @@ func TestContractInstanceCosts(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if spec.expPanic {
 				assert.Panics(t, func() {
-					NewWasmGasRegister(spec.srcConfig).InstantiateContractCosts(spec.pinned, spec.srcLen)
+					NewWasmGasRegister(spec.srcConfig).SetupContractCost(spec.pinned, spec.srcLen)
 				})
 				return
 			}
-			gotGas := NewWasmGasRegister(spec.srcConfig).InstantiateContractCosts(spec.pinned, spec.srcLen)
+			gotGas := NewWasmGasRegister(spec.srcConfig).SetupContractCost(spec.pinned, spec.srcLen)
 			assert.Equal(t, spec.exp, gotGas)
 		})
 	}


### PR DESCRIPTION
This PR makes to changes to improve clarity on how starting a contract execution is charged. They are independent an in one commit each:

1. **Rename InstantiateContractCosts -> SetupContractCost.** The term "instantiate" has two different meanings in our stack: (a) the contract instance identified by a blockchain address (b) the Wasmer instance created before calling an entry point. Here "InstantiateContract" was referring to the later, which is more an implementation detail. To avoid confusion we can use a different term that was in the codebase already: "setup".
2. **Remove NewContractInstanceCosts.** This was just an alias that was used for one entry point (MsgInstantiateContract/MsgInstantiateContract2). However, we do not maintain entry-point specific gas values for all other cases. So having this extra is confusing. If we want entrypoint specific functions here, we should create them for all entry points.

Also in general we should migrate "costs" -> "cost" when we get the chance since this the the price for a single operation.