### PR TITLE
Add BuiltInCapabilities() to x/wasm/keeper and deprecate AllCapabilities()

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -642,7 +642,7 @@ func NewWasmApp(
 		app.GRPCQueryRouter(),
 		wasmDir,
 		wasmConfig,
-		AllCapabilities(),
+		wasmkeeper.BuiltInCapabilities(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		wasmOpts...,
 	)

--- a/app/wasm.go
+++ b/app/wasm.go
@@ -1,17 +1,10 @@
 package app
 
-// AllCapabilities returns all capabilities available with the current wasmvm
-// See https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md
-// This functionality is going to be moved upstream: https://github.com/CosmWasm/wasmvm/issues/425
+import (
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+)
+
+// Deprecated: Use BuiltInCapabilities from github.com/CosmWasm/wasmd/x/wasm/keeper
 func AllCapabilities() []string {
-	return []string{
-		"iterator",
-		"staking",
-		"stargate",
-		"cosmwasm_1_1",
-		"cosmwasm_1_2",
-		"cosmwasm_1_3",
-		"cosmwasm_1_4",
-		"cosmwasm_2_0",
-	}
+	return wasmkeeper.BuiltInCapabilities()
 }

--- a/x/wasm/keeper/capabilities.go
+++ b/x/wasm/keeper/capabilities.go
@@ -1,0 +1,20 @@
+package keeper
+
+// BuiltInCapabilities returns all capabilities currently supported by this version of x/wasm.
+// See also https://github.com/CosmWasm/cosmwasm/blob/main/docs/CAPABILITIES-BUILT-IN.md.
+//
+// Use this directly or together with your chain's custom capabilities (if any):
+//
+//	append(wasmkeeper.BuiltInCapabilities(), "token_factory")
+func BuiltInCapabilities() []string {
+	return []string{
+		"iterator",
+		"staking",
+		"stargate",
+		"cosmwasm_1_1",
+		"cosmwasm_1_2",
+		"cosmwasm_1_3",
+		"cosmwasm_1_4",
+		"cosmwasm_2_0",
+	}
+}


### PR DESCRIPTION
`AllCapabilities()` is currently used by chains
1. without additions (https://github.com/cosmos/gaia/pull/3051/files#diff-1ac782d2fab1d48ad7f7ef06cf2d58b37c99b6b4c98879a5ad86a985b73fad58R456)
2. with additions (https://github.com/CosmosContracts/juno/blob/e98863bf7112f4b117a2114e22f7482367362764/app/keepers/keepers.go#L114)

This is good since it avoids bugs and adds newly added capabilities autimatically in an upgrade.

This PR does not change functionality but improves things in the following ways:
- Better documentation
- Better function name
- As Pino highlighted, the symbols from `app` should not be imported by chains using x/wasm