### PR TITLE
Example setup for testing aminojson signdoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
-LEDGER_ENABLED ?= true
+LEDGER_ENABLED ?= false
 SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')
 BINDIR ?= $(GOPATH)/bin
 SIMAPP = ./app
@@ -90,7 +90,7 @@ build-windows-client: go.sum
 	GOOS=windows GOARCH=amd64 go build -mod=readonly $(BUILD_FLAGS) -o build/wasmd.exe ./cmd/wasmd
 
 install: go.sum
-	go install -mod=readonly $(BUILD_FLAGS) ./cmd/wasmd
+	go install -mod=vendor $(BUILD_FLAGS) ./cmd/wasmd
 
 ########################################
 ### Tools & dependencies

--- a/scripts/contrib/local/05-test-aminojson.sh
+++ b/scripts/contrib/local/05-test-aminojson.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail -x
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "-----------------------"
+echo "## Add new CosmWasm contract"
+RESP=$(wasmd tx wasm store "$DIR/../../../x/wasm/keeper/testdata/hackatom.wasm" \
+  --from validator --gas 1500000 -y --chain-id=testing --node=http://localhost:26657 -b sync -o json --keyring-backend=test)
+sleep 6
+RESP=$(wasmd q tx $(echo "$RESP"| jq -r '.txhash') -o json)
+CODE_ID=$(echo "$RESP" | jq -r '.events[]| select(.type=="store_code").attributes[]| select(.key=="code_id").value')
+CODE_HASH=$(echo "$RESP" | jq -r '.events[]| select(.type=="store_code").attributes[]| select(.key=="code_checksum").value')
+echo "* Code id: $CODE_ID"
+echo "* Code checksum: $CODE_HASH"
+
+echo "-----------------------"
+echo "## Create new contract instance"
+INIT="{\"verifier\":\"$(wasmd keys show validator -a --keyring-backend=test)\", \"beneficiary\":\"$(wasmd keys show fred -a --keyring-backend=test)\"}"
+
+wasmd tx wasm instantiate "$CODE_ID" "$INIT" --admin="$(wasmd keys show validator -a --keyring-backend=test)" \
+  --from validator --amount="100ustake" --label "local0.1.0" \
+  --gas 1000000 -y --chain-id=testing -b sync -o json --keyring-backend=test --sign-mode amino-json


### PR DESCRIPTION
- checkout this branch
- run:
```
go mod tidy
go mod vendor
```

edit the function `func (h SignModeHandler) GetSignBytes` in `wasmd/vendor/cosmossdk.io/x/tx/signing/aminojson/aminojson.go` by replacing 
```
return h.encoder.Marshal(signDoc)
```
 with 
```
res, err := h.encoder.Marshal(signDoc)
fmt.Println(string(res))

return res, err
```


open a terminal and run:
```
make install
cd scripts/contrib/local
rm -rf /tmp/trash
HOME=/tmp/trash bash setup_wasmd.sh
HOME=/tmp/trash bash start_node.sh
```

Next terminal:
```
cd scripts/contrib/local
HOME=/tmp/trash bash 01-accounts.sh
HOME=/tmp/trash bash 05-test-aminojson.sh
```