### PR TITLE
Add `newWasmModuleEvent` test cases for empty values

### DIFF
--- a/x/wasm/keeper/events_test.go
+++ b/x/wasm/keeper/events_test.go
@@ -246,6 +246,18 @@ func TestNewWasmModuleEvent(t *testing.T) {
 				sdk.NewAttribute("_contract_address", myContract.String()),
 				sdk.NewAttribute("my-real-key", "some-val"))},
 		},
+		"empty value": {
+			src: []wasmvmtypes.EventAttribute{{Key: "myKey", Value: ""}},
+			exp: sdk.Events{sdk.NewEvent("wasm",
+				sdk.NewAttribute("_contract_address", myContract.String()),
+				sdk.NewAttribute("myKey", ""))},
+		},
+		"whitespace-only value": {
+			src: []wasmvmtypes.EventAttribute{{Key: "myKey", Value: "     "}},
+			exp: sdk.Events{sdk.NewEvent("wasm",
+				sdk.NewAttribute("_contract_address", myContract.String()),
+				sdk.NewAttribute("myKey", ""))},
+		},
 		"empty elements": {
 			src:     make([]wasmvmtypes.EventAttribute, 10),
 			isError: true,


### PR DESCRIPTION
This behaviour was originally changed in #1618, but tests were only added for `newCustomEvents` (used for `Response.Events.Attributes`), not for `newWasmModuleEvent` (used for `Response.Attributes`).

This came up while fixing the behaviour in MultiTest: https://github.com/CosmWasm/cw-multi-test/issues/178