### PR TITLE
fix: comment typo

### DIFF
--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -358,7 +358,7 @@ func parseInstantiateArgs(rawCodeID, initMsg string, kr keyring.Keyring, sender 
 	return &msg, msg.ValidateBasic()
 }
 
-// ExecuteContractCmd will instantiate a contract from previously uploaded code.
+// ExecuteContractCmd will execute a contract method using its address and JSON-encoded arguments.
 func ExecuteContractCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "execute [contract_addr_bech32] [json_encoded_send_args] --amount [coins,optional]",


### PR DESCRIPTION
This PR fixes the comment typo of the function `ExecuteContractCmd`.