### PR TITLE
Mark QuerySmart contract error as deterministic

### DIFF
--- a/x/wasm/keeper/contract_keeper_test.go
+++ b/x/wasm/keeper/contract_keeper_test.go
@@ -202,5 +202,5 @@ func TestQuerierError(t *testing.T) {
 	require.Error(t, err)
 
 	// we expect the contract's "reply 1 not found" to be in there
-	assert.Equal(t, "Generic error: Querier contract error: reply 1 not found: query wasm contract failed: query wasm contract failed", err.Error())
+	assert.Contains(t, err.Error(), "reply 1 not found")
 }

--- a/x/wasm/keeper/contract_keeper_test.go
+++ b/x/wasm/keeper/contract_keeper_test.go
@@ -14,8 +14,10 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/CosmWasm/wasmd/x/wasm/keeper/testdata"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper/wasmtesting"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 )
 
 func TestInstantiate2(t *testing.T) {
@@ -168,4 +170,37 @@ func TestInstantiate2(t *testing.T) {
 			assert.NotEmpty(t, gotAddr)
 		})
 	}
+}
+
+func TestQuerierError(t *testing.T) {
+	parentCtx, keepers := CreateTestInput(t, false, AvailableCapabilities)
+	parentCtx = parentCtx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+
+	contract := InstantiateReflectExampleContract(t, parentCtx, keepers)
+
+	// this query will fail in the contract because there is no such reply
+	erroringQuery := testdata.ReflectQueryMsg{
+		SubMsgResult: &testdata.SubCall{
+			ID: 1,
+		},
+	}
+	// we make the reflect contract run the erroring query to check if our error stays
+	queryType := testdata.ReflectQueryMsg{
+		Chain: &testdata.ChainQuery{
+			Request: &wasmvmtypes.QueryRequest{
+				Wasm: &wasmvmtypes.WasmQuery{
+					Smart: &wasmvmtypes.SmartQuery{
+						ContractAddr: contract.Contract.String(),
+						Msg:          mustMarshal(t, erroringQuery),
+					},
+				},
+			},
+		},
+	}
+	query := mustMarshal(t, queryType)
+	_, err := keepers.WasmKeeper.QuerySmart(parentCtx, contract.Contract, query)
+	require.Error(t, err)
+
+	// we expect the contract's "reply 1 not found" to be in there
+	assert.Equal(t, "Generic error: Querier contract error: reply 1 not found: query wasm contract failed: query wasm contract failed", err.Error())
 }

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -799,7 +799,7 @@ func (k Keeper) QuerySmart(ctx context.Context, contractAddr sdk.AccAddress, req
 		return nil, errorsmod.Wrap(types.ErrVMError, qErr.Error())
 	}
 	if queryResult.Err != "" {
-		return nil, errorsmod.Wrap(types.ErrQueryFailed, queryResult.Err)
+		return nil, types.MarkErrorDeterministic(errorsmod.Wrap(types.ErrQueryFailed, queryResult.Err))
 	}
 	return queryResult.Ok, nil
 }

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -263,8 +263,8 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			},
 			expectQueriesFromContract: 10,
 			expectOutOfGas:            false,
-			expectError:               "query wasm contract failed", // Error we get from the contract instance doing the failing query, not wasmd
-			expectedGas:               10*(GasWork2k+GasReturnHashed) - 249,
+			expectError:               "query wasm contract failed",          // Error we get from the contract instance doing the failing query, not wasmd
+			expectedGas:               10*(GasWork2k+GasReturnHashed) + 3124, // lots of additional gas for long error message
 		},
 	}
 


### PR DESCRIPTION
We apparently didn't mark this as deterministic in #1804.