### PR TITLE
Add codespace to error acknowledgement

### DIFF
--- a/x/wasm/ibc.go
+++ b/x/wasm/ibc.go
@@ -278,7 +278,7 @@ func (i IBCHandler) OnRecvPacket(
 	msg := wasmvmtypes.IBCPacketReceiveMsg{Packet: newIBCPacket(packet), Relayer: relayer.String()}
 	ack, err := i.keeper.OnRecvPacket(ctx.WithEventManager(em), contractAddr, msg)
 	if err != nil {
-		ack = channeltypes.NewErrorAcknowledgement(err)
+		ack = CreateErrorAcknowledgement(err)
 		// the state gets reverted, so we drop all captured events
 	} else if ack == nil || ack.Success() {
 		// emit all contract and submessage events on success
@@ -357,4 +357,13 @@ func ValidateChannelParams(channelID string) error {
 		return errorsmod.Wrapf(types.ErrMaxIBCChannels, "channel sequence %d is greater than max allowed transfer channels %d", channelSequence, math.MaxUint32)
 	}
 	return nil
+}
+
+// CreateErrorAcknowledgement turns an error into an error acknowledgement.
+//
+// This function is x/wasm specific and might include the full error text in the future
+// as we gain confidence that it is deterministic. Don't use it in other contexts.
+// See also https://github.com/CosmWasm/wasmd/issues/1740.
+func CreateErrorAcknowledgement(err error) ibcexported.Acknowledgement {
+	return channeltypes.NewErrorAcknowledgementWithCodespace(err)
 }

--- a/x/wasm/ibc_integration_test.go
+++ b/x/wasm/ibc_integration_test.go
@@ -171,8 +171,9 @@ func TestOnIBCPacketReceive(t *testing.T) {
 			expAck:     []byte(`{"error":"invalid packet: Generic error: my error"}`),
 		},
 		"with returned msg fails": {
+			// ErrInvalidAddress (https://github.com/cosmos/cosmos-sdk/blob/v0.50.7/types/errors/errors.go#L28-L29)
 			packetData: []byte(`{"return_msgs": {"msgs": [{"bank":{"send":{"to_address": "invalid-address", "amount": [{"denom": "ALX", "amount": "1"}]}}}]}}`),
-			expAck:     []byte(`{"error":"ABCI code: 7: error handling packet: see events for details"}`),
+			expAck:     []byte(`{"error":"ABCI error: sdk/7: error handling packet: see events for details"}`),
 		},
 		"with contract panic": {
 			packetData:          []byte(`{"panic":{}}`),

--- a/x/wasm/ibc_test.go
+++ b/x/wasm/ibc_test.go
@@ -51,8 +51,8 @@ func TestOnRecvPacket(t *testing.T) {
 		},
 		"contract returns err response": {
 			ibcPkg:      anyContractIBCPkg,
-			contractRsp: channeltypes.NewErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
-			expAck:      channeltypes.NewErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
+			contractRsp: CreateErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
+			expAck:      CreateErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
 			expEvents: sdk.Events{
 				{
 					Type: "ibc_packet_received",
@@ -87,7 +87,7 @@ func TestOnRecvPacket(t *testing.T) {
 		"returned messages executed with error": {
 			ibcPkg:               anyContractIBCPkg,
 			contractOkMsgExecErr: types.ErrInvalid.Wrap("testing"),
-			expAck:               channeltypes.NewErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
+			expAck:               CreateErrorAcknowledgement(types.ErrInvalid.Wrap("testing")),
 			expEvents: sdk.Events{{
 				Type: "ibc_packet_received",
 				Attributes: []abci.EventAttribute{


### PR DESCRIPTION
This adds the codespace to error acknowledgements by switching from NewErrorAcknowledgement to NewErrorAcknowledgementWithCodespace.

Also creates the initial infrastrucrture to further customize error acknowledgement creation.

Part of #1740