### PR TITLE
Simplify release text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,9 +254,7 @@ jobs:
             gh release create ${CIRCLE_TAG} \
             --title "$CIRCLE_TAG" \
             --draft \
-            --notes "# Wasmd ${CIRCLE_TAG} Release
-            See the [CHANGELOG](https://github.com/CosmWasm/wasmd/blob/${CIRCLE_TAG}/CHANGELOG.md) for details on the changes in this version.
-            "
+            --notes "See the [CHANGELOG](https://github.com/CosmWasm/wasmd/blob/${CIRCLE_TAG}/CHANGELOG.md) for details on the changes in this version."
 
 workflows:
   test-suite:


### PR DESCRIPTION
This removed this redundant title

<img width="855" alt="Bildschirmfoto 2024-07-17 um 16 44 52" src="https://github.com/user-attachments/assets/789579ef-0aeb-4005-97d2-3393a64f3996">

More semantically the release pages have two h1s which do not make sense (same as here: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.8). I think the h1 should be the title and notes only containing follow-up contents.