### PR TITLE
Fix "immutible" typo

### DIFF
--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -319,7 +319,7 @@ func ProposalStoreAndInstantiateContractCmd() *cobra.Command {
 
 			// ensure sensible admin is set (or explicitly immutable)
 			if adminStr == "" && !noAdmin {
-				return fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutible (wasmd issue #719)")
+				return fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
 			}
 			if adminStr != "" && noAdmin {
 				return fmt.Errorf("you set an admin and passed --no-admin, those cannot both be true")

--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -322,7 +322,7 @@ func parseInstantiateArgs(rawCodeID, initMsg string, kr keyring.Keyring, sender 
 
 	// ensure sensible admin is set (or explicitly immutable)
 	if adminStr == "" && !noAdmin {
-		return nil, fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutible (wasmd issue #719)")
+		return nil, fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
 	}
 	if adminStr != "" && noAdmin {
 		return nil, fmt.Errorf("you set an admin and passed --no-admin, those cannot both be true")


### PR DESCRIPTION
This PR fixes the typo "immutible" when the `--no-admin` flag is omitted on a transaction, i.e. instantiating a contract.