### PR TITLE
Fix error wrapping on recursive calls

### DIFF
--- a/x/wasm/keeper/handler_plugin.go
+++ b/x/wasm/keeper/handler_plugin.go
@@ -133,7 +133,7 @@ type callDepthMessageHandler struct {
 func (h callDepthMessageHandler) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, msgResponses [][]*codectypes.Any, err error) {
 	ctx, err = checkAndIncreaseCallDepth(ctx, h.MaxCallDepth)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, errorsmod.Wrap(err, "dispatch")
 	}
 
 	return h.Messenger.DispatchMsg(ctx, contractAddr, contractIBCPortID, msg)

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -431,7 +431,7 @@ func (k Keeper) execute(ctx context.Context, contractAddress, caller sdk.AccAddr
 
 	data, err := k.handleContractResponse(sdkCtx, contractAddress, contractInfo.IBCPortID, res.Ok.Messages, res.Ok.Attributes, res.Ok.Data, res.Ok.Events)
 	if err != nil {
-		return nil, errorsmod.Wrap(err, "dispatch")
+		return nil, err
 	}
 
 	return data, nil
@@ -1481,7 +1481,7 @@ func (h DefaultWasmVMContractResponseHandler) Handle(ctx sdk.Context, contractAd
 	result := origRspData
 	switch rsp, err := h.md.DispatchSubmessages(ctx, contractAddr, ibcPort, messages); {
 	case err != nil:
-		return nil, errorsmod.Wrap(err, "submessages")
+		return nil, err
 	case rsp != nil:
 		result = rsp
 	}


### PR DESCRIPTION
Now the error looks like: `dispatch: max call depth exceeded`