### PR TITLE
Custom AuthorizationPolicy with code & contract info

### DIFF
--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -418,16 +418,16 @@ func contains[T comparable](src []T, o T) bool {
 }
 
 func (m msgServer) selectAuthorizationPolicy(ctx context.Context, actor string) types.AuthorizationPolicy {
+	if m.keeper.customAuthPolicy != nil {
+		if policy, ok := m.keeper.customAuthPolicy(ctx, actor); ok {
+			return policy
+		}
+	}
 	if actor == m.keeper.GetAuthority() {
 		return newGovAuthorizationPolicy(m.keeper.propagateGovAuthorization)
 	}
 	if policy, ok := types.SubMsgAuthzPolicy(ctx); ok {
 		return policy
-	}
-	if m.keeper.customAuthPolicy != nil {
-		if policy, ok := m.keeper.customAuthPolicy(ctx, actor); ok {
-			return policy
-		}
 	}
 	return DefaultAuthorizationPolicy{}
 }

--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -424,6 +424,11 @@ func (m msgServer) selectAuthorizationPolicy(ctx context.Context, actor string) 
 	if policy, ok := types.SubMsgAuthzPolicy(ctx); ok {
 		return policy
 	}
+	if m.keeper.customAuthPolicy != nil {
+		if policy, ok := m.keeper.customAuthPolicy(ctx, actor); ok {
+			return policy
+		}
+	}
 	return DefaultAuthorizationPolicy{}
 }
 

--- a/x/wasm/types/authz_policy.go
+++ b/x/wasm/types/authz_policy.go
@@ -26,10 +26,10 @@ const (
 // AuthorizationPolicy is an abstract authorization ruleset defined as an extension point that can be customized by
 // chains
 type AuthorizationPolicy interface {
-	CanCreateCode(chainConfigs ChainAccessConfigs, actor types.AccAddress, contractConfig AccessConfig) bool
-	CanInstantiateContract(c AccessConfig, actor types.AccAddress) bool
-	CanModifyContract(admin, actor types.AccAddress) bool
-	CanModifyCodeAccessConfig(creator, actor types.AccAddress, isSubset bool) bool
+	CanCreateCode(checksum []byte, chainConfigs ChainAccessConfigs, actor types.AccAddress, contractConfig AccessConfig) bool
+	CanInstantiateContract(code *CodeInfo, actor types.AccAddress) bool
+	CanModifyContract(contract *ContractInfo, actor types.AccAddress) bool
+	CanModifyCodeAccessConfig(code *CodeInfo, actor types.AccAddress, isSubset bool) bool
 	// SubMessageAuthorizationPolicy returns authorization policy to be used for submessages. Must never be nil
 	SubMessageAuthorizationPolicy(entrypoint AuthorizationPolicyAction) AuthorizationPolicy
 }


### PR DESCRIPTION
CosmWasm integration with THORChain requires a different model for permissioning than standard `AccessConfig` via `x/gov`:

- Code upload & instantiate permissions will be configured via "Mimir" (node-set configuration parameters), and will be restricted based on code checksum. This is in order to be able to provide clear accountability from the raw wasm code, through git commit, audit, compilation checksum, through to on-chain permissions. 
- Current design does not allow the `create` function to discriminate permissions based on the actual code being uploaded, instantiated (or contracts being modified).
- This PR extends the `AuthorizationPolicy interface` loaded in `msg_server.go` to have the `CodeInfo` passed during `CanCreateCode` and `CanInstantiateContract` checks. 
- It also adds `ContractInfo` where appropriate, for a more uniform and flexible interface
- All existing behaviour is retained
- As `selectAuthorizationPolicy` is currently fixed, this PR also adds a `customAuthPolicy func(ctx context.Context, actor string) (types.AuthorizationPolicy, bool)` value to the `Keeper` struct, which can be set in `NewKeeper` with an `Option`
- This allows chains to write custom `AuthorizationPolicy` implementations, accessing state outside x/wasm etc