### PR TITLE
fixed to pass linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wasm Zone
+# Wasm Zone *Zero*
 
 [![CircleCI](https://circleci.com/gh/CosmWasm/wasmd/tree/main.svg?style=shield)](https://circleci.com/gh/CosmWasm/wasmd/tree/main)
 [![codecov](https://codecov.io/gh/cosmwasm/wasmd/branch/main/graph/badge.svg)](https://codecov.io/gh/cosmwasm/wasmd)
@@ -9,6 +9,11 @@
 <!-- [![GolangCI](https://golangci.com/badges/github.com/CosmWasm/wasmd.svg)](https://golangci.com/r/github.com/CosmWasm/wasmd) -->
 
 This repository hosts `Wasmd`, the first implementation of a cosmos zone with wasm smart contracts enabled.
+
+**In contrast to the original at [github.com/CosmWasm/wasmd](https://github.com/CosmWasm/wasmd),
+this version uses a pure Go based WASM VM called 
+[wazero](https://github.com/tetratelabs/wazero). It has no Cgo interface or dependency on the 
+Rust toolchain.**
 
 This code was forked from the `cosmos/gaia` repository as a basis and then we added `x/wasm` and cleaned up
 many gaia-specific files. However, the `wasmd` binary should function just like `gaiad` except for the

--- a/x/wasm/keeper/authz_policy.go
+++ b/x/wasm/keeper/authz_policy.go
@@ -10,12 +10,16 @@ var _ types.AuthorizationPolicy = DefaultAuthorizationPolicy{}
 
 type DefaultAuthorizationPolicy struct{}
 
-func (p DefaultAuthorizationPolicy) CanCreateCode(chainConfigs types.ChainAccessConfigs, actor sdk.AccAddress, contractConfig types.AccessConfig) bool {
+func (p DefaultAuthorizationPolicy) CanCreateCode(chainConfigs types.ChainAccessConfigs,
+	actor sdk.AccAddress, contractConfig types.AccessConfig,
+) bool {
 	return chainConfigs.Upload.Allowed(actor) &&
 		contractConfig.IsSubset(chainConfigs.Instantiate)
 }
 
-func (p DefaultAuthorizationPolicy) CanInstantiateContract(config types.AccessConfig, actor sdk.AccAddress) bool {
+func (p DefaultAuthorizationPolicy) CanInstantiateContract(config types.AccessConfig,
+	actor sdk.AccAddress,
+) bool {
 	return config.Allowed(actor)
 }
 
@@ -23,7 +27,9 @@ func (p DefaultAuthorizationPolicy) CanModifyContract(admin, actor sdk.AccAddres
 	return admin != nil && admin.Equals(actor)
 }
 
-func (p DefaultAuthorizationPolicy) CanModifyCodeAccessConfig(creator, actor sdk.AccAddress, isSubset bool) bool {
+func (p DefaultAuthorizationPolicy) CanModifyCodeAccessConfig(creator, actor sdk.AccAddress,
+	isSubset bool,
+) bool {
 	return creator != nil && creator.Equals(actor) && isSubset
 }
 
@@ -55,11 +61,15 @@ func newGovAuthorizationPolicy(propagate map[types.AuthorizationPolicyAction]str
 }
 
 // CanCreateCode implements AuthorizationPolicy.CanCreateCode to allow gov actions. Always returns true.
-func (p GovAuthorizationPolicy) CanCreateCode(types.ChainAccessConfigs, sdk.AccAddress, types.AccessConfig) bool {
+func (p GovAuthorizationPolicy) CanCreateCode(types.ChainAccessConfigs, sdk.AccAddress,
+	types.AccessConfig,
+) bool {
 	return true
 }
 
-func (p GovAuthorizationPolicy) CanInstantiateContract(types.AccessConfig, sdk.AccAddress) bool {
+func (p GovAuthorizationPolicy) CanInstantiateContract(types.AccessConfig,
+	sdk.AccAddress,
+) bool {
 	return true
 }
 
@@ -67,14 +77,16 @@ func (p GovAuthorizationPolicy) CanModifyContract(sdk.AccAddress, sdk.AccAddress
 	return true
 }
 
-func (p GovAuthorizationPolicy) CanModifyCodeAccessConfig(sdk.AccAddress, sdk.AccAddress, bool) bool {
+func (p GovAuthorizationPolicy) CanModifyCodeAccessConfig(sdk.AccAddress, sdk.AccAddress,
+	bool,
+) bool {
 	return true
 }
 
 // SubMessageAuthorizationPolicy returns new policy with fine-grained gov permission for given action only
 func (p GovAuthorizationPolicy) SubMessageAuthorizationPolicy(action types.AuthorizationPolicyAction) types.AuthorizationPolicy {
 	defaultPolicy := DefaultAuthorizationPolicy{}
-	if p.propagate != nil && len(p.propagate) != 0 {
+	if len(p.propagate) != 0 {
 		if _, ok := p.propagate[action]; ok {
 			return NewPartialGovAuthorizationPolicy(defaultPolicy, action)
 		}
@@ -92,15 +104,21 @@ type PartialGovAuthorizationPolicy struct {
 }
 
 // NewPartialGovAuthorizationPolicy constructor
-func NewPartialGovAuthorizationPolicy(defaultPolicy types.AuthorizationPolicy, entrypoint types.AuthorizationPolicyAction) PartialGovAuthorizationPolicy {
+func NewPartialGovAuthorizationPolicy(defaultPolicy types.AuthorizationPolicy,
+	entrypoint types.AuthorizationPolicyAction,
+) PartialGovAuthorizationPolicy {
 	return PartialGovAuthorizationPolicy{action: entrypoint, defaultPolicy: defaultPolicy}
 }
 
-func (p PartialGovAuthorizationPolicy) CanCreateCode(chainConfigs types.ChainAccessConfigs, actor sdk.AccAddress, contractConfig types.AccessConfig) bool {
+func (p PartialGovAuthorizationPolicy) CanCreateCode(chainConfigs types.ChainAccessConfigs,
+	actor sdk.AccAddress, contractConfig types.AccessConfig,
+) bool {
 	return p.defaultPolicy.CanCreateCode(chainConfigs, actor, contractConfig)
 }
 
-func (p PartialGovAuthorizationPolicy) CanInstantiateContract(c types.AccessConfig, actor sdk.AccAddress) bool {
+func (p PartialGovAuthorizationPolicy) CanInstantiateContract(c types.AccessConfig,
+	actor sdk.AccAddress,
+) bool {
 	if p.action == types.AuthZActionInstantiate {
 		return true
 	}
@@ -114,7 +132,9 @@ func (p PartialGovAuthorizationPolicy) CanModifyContract(admin, actor sdk.AccAdd
 	return p.defaultPolicy.CanModifyContract(admin, actor)
 }
 
-func (p PartialGovAuthorizationPolicy) CanModifyCodeAccessConfig(creator, actor sdk.AccAddress, isSubset bool) bool {
+func (p PartialGovAuthorizationPolicy) CanModifyCodeAccessConfig(creator, actor sdk.AccAddress,
+	isSubset bool,
+) bool {
 	return p.defaultPolicy.CanModifyCodeAccessConfig(creator, actor, isSubset)
 }
 

--- a/zero/zero.go
+++ b/zero/zero.go
@@ -1,0 +1,127 @@
+package symbols
+
+import (
+	wasmvm "github.com/CosmWasm/wasmvm/v2"
+	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
+)
+
+// These variables are the variables and functions used in wasmd from wasmvm
+
+var (
+	// functions
+
+	CreateChecksum   = wasmvm.CreateChecksum
+	LibwasmvmVersion = wasmvm.LibwasmvmVersion
+	NewVM            = wasmvm.NewVM
+	ToSystemError    = wasmvmtypes.ToSystemError
+	NewCoin          = wasmvmtypes.NewCoin
+
+	// types
+
+	GasMeter wasmvm.GasMeter
+	GoAPI    wasmvm.GoAPI
+	KVStore  wasmvm.KVStore
+	Querier  wasmvm.Querier
+	WasmCode wasmvm.WasmCode
+
+	AllBalancesResponse              wasmvmtypes.AllBalancesResponse
+	AllDelegationsResponse           wasmvmtypes.AllDelegationsResponse
+	AllDenomMetadataQuery            wasmvmtypes.AllDenomMetadataQuery
+	AllValidatorsResponse            wasmvmtypes.AllValidatorsResponse
+	AnalysisReport                   wasmvmtypes.AnalysisReport
+	AnyMsg                           wasmvmtypes.AnyMsg
+	BalanceResponse                  wasmvmtypes.BalanceResponse
+	BankMsg                          wasmvmtypes.BankMsg
+	BankQuery                        wasmvmtypes.BankQuery
+	BondedDenomResponse              wasmvmtypes.BondedDenomResponse
+	ChannelResponse                  wasmvmtypes.ChannelResponse
+	Checksum                         wasmvmtypes.Checksum
+	CodeInfoResponse                 wasmvmtypes.CodeInfoResponse
+	Coin                             wasmvmtypes.Coin
+	ContractInfo                     wasmvmtypes.ContractInfo
+	ContractInfoResponse             wasmvmtypes.ContractInfoResponse
+	ContractResult                   wasmvmtypes.ContractResult
+	CosmosMsg                        wasmvmtypes.CosmosMsg
+	DecCoin                          wasmvmtypes.DecCoin
+	Delegation                       wasmvmtypes.Delegation
+	DelegationResponse               wasmvmtypes.DelegationResponse
+	DelegationRewardsResponse        wasmvmtypes.DelegationRewardsResponse
+	DelegationTotalRewardsResponse   wasmvmtypes.DelegationTotalRewardsResponse
+	DelegatorReward                  wasmvmtypes.DelegatorReward
+	DelegatorValidatorsResponse      wasmvmtypes.DelegatorValidatorsResponse
+	DelegatorWithdrawAddressResponse wasmvmtypes.DelegatorWithdrawAddressResponse
+	DenomMetadata                    wasmvmtypes.DenomMetadata
+	DenomMetadataResponse            wasmvmtypes.DenomMetadataResponse
+	DistributionMsg                  wasmvmtypes.DistributionMsg
+	DistributionQuery                wasmvmtypes.DistributionQuery
+	Env                              wasmvmtypes.Env
+	Event                            wasmvmtypes.Event
+	EventAttribute                   wasmvmtypes.EventAttribute
+	FullDelegation                   wasmvmtypes.FullDelegation
+	GovMsg                           wasmvmtypes.GovMsg
+	GrpcQuery                        wasmvmtypes.GrpcQuery
+	IBCAckCallbackMsg                wasmvmtypes.IBCAckCallbackMsg
+	IBCAcknowledgement               wasmvmtypes.IBCAcknowledgement
+	IBCBasicResponse                 wasmvmtypes.IBCBasicResponse
+	IBCBasicResult                   wasmvmtypes.IBCBasicResult
+	IBCChannel                       wasmvmtypes.IBCChannel
+	IBCChannelCloseMsg               wasmvmtypes.IBCChannelCloseMsg
+	IBCChannelConnectMsg             wasmvmtypes.IBCChannelConnectMsg
+	IBCChannelOpenMsg                wasmvmtypes.IBCChannelOpenMsg
+	IBCChannelOpenResult             wasmvmtypes.IBCChannelOpenResult
+	IBCCloseConfirm                  wasmvmtypes.IBCCloseConfirm
+	IBCCloseInit                     wasmvmtypes.IBCCloseInit
+	IBCDestinationCallbackMsg        wasmvmtypes.IBCDestinationCallbackMsg
+	IBCEndpoint                      wasmvmtypes.IBCEndpoint
+	IBCMsg                           wasmvmtypes.IBCMsg
+	IBCOpenAck                       wasmvmtypes.IBCOpenAck
+	IBCOpenConfirm                   wasmvmtypes.IBCOpenConfirm
+	IBCOpenInit                      wasmvmtypes.IBCOpenInit
+	IBCOpenTry                       wasmvmtypes.IBCOpenTry
+	IBCPacket                        wasmvmtypes.IBCPacket
+	IBCPacketAckMsg                  wasmvmtypes.IBCPacketAckMsg
+	IBCPacketReceiveMsg              wasmvmtypes.IBCPacketReceiveMsg
+	IBCPacketTimeoutMsg              wasmvmtypes.IBCPacketTimeoutMsg
+	IBCQuery                         wasmvmtypes.IBCQuery
+	IBCReceiveResult                 wasmvmtypes.IBCReceiveResult
+	IBCSourceCallbackMsg             wasmvmtypes.IBCSourceCallbackMsg
+	IBCTimeout                       wasmvmtypes.IBCTimeout
+	IBCTimeoutBlock                  wasmvmtypes.IBCTimeoutBlock
+	IBCTimeoutCallbackMsg            wasmvmtypes.IBCTimeoutCallbackMsg
+	Iterator                         wasmvmtypes.Iterator
+	ListChannelsResponse             wasmvmtypes.ListChannelsResponse
+	MessageInfo                      wasmvmtypes.MessageInfo
+	Metrics                          wasmvmtypes.Metrics
+	MsgResponse                      wasmvmtypes.MsgResponse
+	PinnedMetrics                    wasmvmtypes.PinnedMetrics
+	PortIDResponse                   wasmvmtypes.PortIDResponse
+	QueryRequest                     wasmvmtypes.QueryRequest
+	Reply                            wasmvmtypes.Reply
+	Response                         wasmvmtypes.Response
+	StakingMsg                       wasmvmtypes.StakingMsg
+	StakingQuery                     wasmvmtypes.StakingQuery
+	StargateQuery                    wasmvmtypes.StargateQuery
+	SubMsg                           wasmvmtypes.SubMsg
+	SubMsgResponse                   wasmvmtypes.SubMsgResponse
+	SubMsgResult                     wasmvmtypes.SubMsgResult
+	SupplyResponse                   wasmvmtypes.SupplyResponse
+	UFraction                        wasmvmtypes.UFraction
+	Unknown                          wasmvmtypes.Unknown
+	UnsupportedRequest               wasmvmtypes.UnsupportedRequest
+	Validator                        wasmvmtypes.Validator
+	ValidatorResponse                wasmvmtypes.ValidatorResponse
+	WasmMsg                          wasmvmtypes.WasmMsg
+	WasmQuery                        wasmvmtypes.WasmQuery
+	arrayEvent                       wasmvmtypes.Array[wasmvmtypes.Event]
+	NoSuchContract                   wasmvmtypes.NoSuchContract
+	NoSuchCode                       wasmvmtypes.NoSuchCode
+
+	Yes          = wasmvmtypes.Yes
+	No           = wasmvmtypes.No
+	NoWithVeto   = wasmvmtypes.NoWithVeto
+	Abstain      = wasmvmtypes.Abstain
+	ReplySuccess = wasmvmtypes.ReplySuccess
+	ReplyError   = wasmvmtypes.ReplyError
+	ReplyAlways  = wasmvmtypes.ReplyAlways
+	ReplyNever   = wasmvmtypes.ReplyNever
+)


### PR DESCRIPTION
minor thing to get `make all` to work, on current default version of golangci-lint