### PR TITLE
Update to wasmvm 2.2.0-rc.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN apk add git
 WORKDIR /code
 COPY . /code/
 # See https://github.com/CosmWasm/wasmvm/releases
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
-ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.1.2/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
-RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 0881c5b463e89e229b06370e9e2961aec0a5c636772d5142c68d351564464a66
-RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 58e1f6bfa89ee390cb9abc69a5bc126029a497fe09dd399f38a82d0d86fe95ef
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.0-rc.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v2.2.0-rc.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 8dd987a526466a9e96edcea03a53907bb782db599b5873f2797ffe5d0f0c063c
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 9242887a2bafbf60437886b93a54cd1af40c7129f1f388cda00ce2608f6ea46c
 
 # force it to use static lib (from above) not standard libgo_cosmwasm.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LINK_STATICALLY=true make build

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/CosmWasm/wasmd
 go 1.21
 
 require (
-	github.com/CosmWasm/wasmvm/v2 v2.1.2
+	github.com/CosmWasm/wasmvm/v2 v2.2.0-rc.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.50.10
 	github.com/cosmos/gogogateway v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CosmWasm/wasmvm/v2 v2.1.2 h1:GkJ5bAsRlLHfIQVg/FY1VHwLyBwlCjAhDea0B8L+e20=
-github.com/CosmWasm/wasmvm/v2 v2.1.2/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
+github.com/CosmWasm/wasmvm/v2 v2.2.0-rc.1 h1:AruXMJk5acRmbAiUz7Bxahw7faXdct19JGSWit1eDXs=
+github.com/CosmWasm/wasmvm/v2 v2.2.0-rc.1/go.mod h1:bMhLQL4Yp9CzJi9A83aR7VO9wockOsSlZbT4ztOl6bg=
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=

--- a/x/wasm/keeper/keeper_test.go
+++ b/x/wasm/keeper/keeper_test.go
@@ -402,7 +402,7 @@ func TestInstantiate(t *testing.T) {
 
 	gasAfter := ctx.GasMeter().GasConsumed()
 	if types.EnableGasVerification {
-		require.Equal(t, uint64(0x1bc8f), gasAfter-gasBefore)
+		require.Equal(t, uint64(0x1bca5), gasAfter-gasBefore)
 	}
 
 	// ensure it is stored properly
@@ -939,7 +939,7 @@ func TestExecute(t *testing.T) {
 	// make sure gas is properly deducted from ctx
 	gasAfter := ctx.GasMeter().GasConsumed()
 	if types.EnableGasVerification {
-		require.Equal(t, uint64(0x1acb4), gasAfter-gasBefore)
+		require.Equal(t, uint64(0x1acdb), gasAfter-gasBefore)
 	}
 	// ensure bob now exists and got both payments released
 	bobAcct = accKeeper.GetAccount(ctx, bob)

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -56,14 +56,14 @@ func initRecurseContract(t *testing.T) (contract sdk.AccAddress, ctx sdk.Context
 
 func TestGasCostOnQuery(t *testing.T) {
 	const (
-		GasNoWork           uint64 = 63_968
+		GasNoWork           uint64 = 63_987
 		GasNoWorkDiscounted uint64 = 5_968
 		// Note: about 100 SDK gas (10k CosmWasm gas) for each round of sha256
-		GasWork50           uint64 = 64_207 // this is a little shy of 50k gas - to keep an eye on the limit
+		GasWork50           uint64 = 64_234 // this is a little shy of 50k gas - to keep an eye on the limit
 		GasWork50Discounted uint64 = 6_207
 
-		GasReturnUnhashed uint64 = 55
-		GasReturnHashed   uint64 = 46
+		GasReturnUnhashed uint64 = 89
+		GasReturnHashed   uint64 = 86
 	)
 
 	cases := map[string]struct {
@@ -214,12 +214,12 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 
 	const (
 		// Note: about 100 SDK gas (10k CosmWasm gas) for each round of sha256
-		GasWork2k uint64 = 76_264 // = SetupContractCost + x // we have 6x gas used in cpu than in the instance
+		GasWork2k uint64 = 76_817 // = SetupContractCost + x // we have 6x gas used in cpu than in the instance
 
-		GasWork2kDiscounted uint64 = 18_264
+		GasWork2kDiscounted uint64 = 18_264 + 432
 
 		// This is overhead for calling into a sub-contract
-		GasReturnHashed uint64 = 48
+		GasReturnHashed uint64 = 48 + 132
 	)
 
 	cases := map[string]struct {
@@ -252,7 +252,7 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 		// it has enough gas to run 5 times and die on the 6th (5th time dispatching to sub-contract)
 		// however, if we don't charge the cpu gas before sub-dispatching, we can recurse over 20 times
 		"deep recursion, should die on 5th level": {
-			gasLimit: 150_000,
+			gasLimit: GasWork2k + 5*(GasWork2kDiscounted+GasReturnHashed) - 1000,
 			msg: Recurse{
 				Depth: 50,
 				Work:  2000,


### PR DESCRIPTION
Gas changes are because of the patch releases that happened in between 2.1.2 and 2.2.0, not because of 2.2 itself.