### PR TITLE
Adapt non-cgo keeper with the latest changes in NewKeeper signature (release v0.53)

### DIFF
--- a/x/wasm/keeper/keeper_no_cgo.go
+++ b/x/wasm/keeper/keeper_no_cgo.go
@@ -3,7 +3,7 @@
 package keeper
 
 import (
-	storetypes "cosmossdk.io/store/types"
+	corestoretypes "cosmossdk.io/core/store"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 
@@ -14,7 +14,7 @@ import (
 // If customEncoders is non-nil, we can use this to override some of the message handler, especially custom
 func NewKeeper(
 	cdc codec.Codec,
-	storeKey storetypes.StoreKey,
+	storeService corestoretypes.KVStoreService,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 	stakingKeeper types.StakingKeeper,
@@ -28,7 +28,7 @@ func NewKeeper(
 	_ GRPCQueryRouter,
 	homeDir string,
 	wasmConfig types.WasmConfig,
-	availableCapabilities string,
+	availableCapabilities []string,
 	authority string,
 	opts ...Option,
 ) Keeper {


### PR DESCRIPTION
This PR intends to backport https://github.com/CosmWasm/wasmd/pull/2079 for release v0.53.x