### PR TITLE
Streamline Stargate/gRPC querier interfaces

### DIFF
--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -332,6 +332,9 @@ func IBCQuerier(wasm contractMetaDataSource, channelKeeper types.ChannelKeeper) 
 	}
 }
 
+// RejectGrpcQuerier is a querier that rejects all gRPC queries.
+//
+// Use AcceptListGrpcQuerier instead to create a list of accepted query types.
 func RejectGrpcQuerier(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
 	return nil, wasmvmtypes.UnsupportedRequest{Kind: "gRPC queries are disabled on this chain"}
 }
@@ -375,7 +378,9 @@ func AcceptListGrpcQuerier(acceptList AcceptedQueries, queryRouter GRPCQueryRout
 	}
 }
 
-// RejectStargateQuerier rejects all stargate queries
+// RejectStargateQuerier is a querier that rejects all stargate queries.
+//
+// Use AcceptListStargateQuerier instead to create a list of accepted query types.
 func RejectStargateQuerier(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
 	return nil, wasmvmtypes.UnsupportedRequest{Kind: "Stargate queries are disabled on this chain"}
 }

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -84,8 +84,10 @@ func (q QueryHandler) GasConsumed() uint64 {
 
 type CustomQuerier func(ctx sdk.Context, request json.RawMessage) ([]byte, error)
 
-type stargateQuerierFn func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error)
-type grpcQuerierFn func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error)
+type (
+	stargateQuerierFn func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error)
+	grpcQuerierFn     func(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error)
+)
 
 type QueryPlugins struct {
 	Bank         func(ctx sdk.Context, request *wasmvmtypes.BankQuery) ([]byte, error)

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -121,7 +121,7 @@ func DefaultQueryPlugins(
 		Custom:       NoCustomQuerier,
 		IBC:          IBCQuerier(wasm, channelKeeper),
 		Staking:      StakingQuerier(staking, distKeeper),
-		Stargate:     RejectStargateQuerier(),
+		Stargate:     RejectStargateQuerier,
 		Grpc:         RejectGrpcQuerier,
 		Wasm:         WasmQuerier(wasm),
 		Distribution: DistributionQuerier(distKeeper),
@@ -376,10 +376,8 @@ func AcceptListGrpcQuerier(acceptList AcceptedQueries, queryRouter GRPCQueryRout
 }
 
 // RejectStargateQuerier rejects all stargate queries
-func RejectStargateQuerier() func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
-	return func(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
-		return nil, wasmvmtypes.UnsupportedRequest{Kind: "Stargate queries are disabled"}
-	}
+func RejectStargateQuerier(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
+	return nil, wasmvmtypes.UnsupportedRequest{Kind: "Stargate queries are disabled"}
 }
 
 // AcceptedQueries defines accepted Stargate or gRPC queries as a map where the key is the query path

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -333,7 +333,7 @@ func IBCQuerier(wasm contractMetaDataSource, channelKeeper types.ChannelKeeper) 
 }
 
 func RejectGrpcQuerier(ctx sdk.Context, request *wasmvmtypes.GrpcQuery) (proto.Message, error) {
-	return nil, wasmvmtypes.UnsupportedRequest{Kind: "gRPC queries are disabled"}
+	return nil, wasmvmtypes.UnsupportedRequest{Kind: "gRPC queries are disabled on this chain"}
 }
 
 // AcceptListGrpcQuerier supports a preconfigured set of gRPC queries only.
@@ -377,7 +377,7 @@ func AcceptListGrpcQuerier(acceptList AcceptedQueries, queryRouter GRPCQueryRout
 
 // RejectStargateQuerier rejects all stargate queries
 func RejectStargateQuerier(ctx sdk.Context, request *wasmvmtypes.StargateQuery) ([]byte, error) {
-	return nil, wasmvmtypes.UnsupportedRequest{Kind: "Stargate queries are disabled"}
+	return nil, wasmvmtypes.UnsupportedRequest{Kind: "Stargate queries are disabled on this chain"}
 }
 
 // AcceptedQueries defines accepted Stargate or gRPC queries as a map where the key is the query path


### PR DESCRIPTION
This PR aims to improve readbility of the Stargate/gRPC querier interfaces and implementations. It helped me reason about what chains need to do to override defaults. Hope it helps someone.