### PR TITLE
Make `ContractAddrLen` variable

### DIFF
--- a/x/wasm/keeper/addresses_test.go
+++ b/x/wasm/keeper/addresses_test.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/CosmWasm/wasmd/x/wasm/types"
 	tmbytes "github.com/cometbft/cometbft/libs/bytes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
 func prepareCleanup(t *testing.T) {

--- a/x/wasm/keeper/addresses_test.go
+++ b/x/wasm/keeper/addresses_test.go
@@ -1,11 +1,14 @@
 package keeper
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/CosmWasm/wasmd/x/wasm/types"
 	tmbytes "github.com/cometbft/cometbft/libs/bytes"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,6 +70,24 @@ func TestBuildContractAddressClassic(t *testing.T) {
 			require.NoError(t, sdk.VerifyAddressFormat(gotAddr))
 		})
 	}
+}
+
+func TestBuildContractAddressPredictableShort(t *testing.T) {
+	types.ContractAddrLen = 20
+	// reset to default value after test completion
+	defer func() { types.ContractAddrLen = 32 }()
+
+	checksum, err := hex.DecodeString("13a1fc994cc6d1c81b746ee0c0ff6f90043875e0bf1d9be6b7d779fc978dc2a5")
+	require.NoError(t, err)
+	creator, err := sdk.AccAddressFromHexUnsafe("9999999999aaaaaaaaaabbbbbbbbbbcccccccccc")
+	require.NoError(t, err)
+	salt, err := hex.DecodeString("61")
+	require.NoError(t, err)
+	expAddr, err := sdk.AccAddressFromHexUnsafe("5e865d3e45ad3e961f77fd77d46543417ced44d9")
+	require.NoError(t, err)
+
+	addr := BuildContractAddressPredictable(checksum, creator, salt, []byte{})
+	assert.Equal(t, expAddr, addr)
 }
 
 func TestBuildContractAddressPredictable(t *testing.T) {

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -20,11 +20,12 @@ const (
 	defaultSmartQueryGasLimit uint64 = 3_000_000
 	defaultContractDebugMode         = false
 
-	// ContractAddrLen defines a valid address length for contracts
-	ContractAddrLen = 32
 	// SDKAddrLen defines a valid address length that was used in sdk address generation
 	SDKAddrLen = 20
 )
+
+// ContractAddrLen defines a valid address length for contracts
+var ContractAddrLen = 32
 
 func (m Model) ValidateBasic() error {
 	if len(m.Key) == 0 {


### PR DESCRIPTION
This should allow chains to customize the address length for contract addresses (both classic and instantiate2).
It's related to this issue: https://github.com/CosmWasm/cosmwasm/issues/2155#issuecomment-2134034689
Injective implemented this for their fork (they use 20).