### PR TITLE
Add gas cost for `UnpackAny`

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -5,13 +5,21 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/x/tx/signing"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -114,6 +122,80 @@ func BenchmarkTxSending(b *testing.B) {
 				_, err = appInfo.App.Commit()
 				require.NoError(b, err)
 				height++
+			}
+		})
+	}
+}
+
+func BenchmarkUnpackAny(b *testing.B) {
+	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+		ProtoFiles: proto.HybridResolver,
+		SigningOptions: signing.Options{
+			AddressCodec: address.Bech32Codec{
+				Bech32Prefix: sdk.GetConfig().GetBech32AccountAddrPrefix(),
+			},
+			ValidatorAddressCodec: address.Bech32Codec{
+				Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
+			},
+		},
+	})
+	require.NoError(b, err)
+
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+	std.RegisterInterfaces(interfaceRegistry)
+
+	mustCreateAny := func(b *testing.B, v proto.Message) *codectypes.Any {
+		b.Helper()
+		any, err := codectypes.NewAnyWithValue(v)
+		require.NoError(b, err)
+		return any
+	}
+
+	createNested := func(b *testing.B, depth int) *codectypes.Any {
+		b.Helper()
+		// create nested MsgExecs
+		nested := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{})
+		for i := 0; i < depth; i++ {
+			nested = authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&nested})
+		}
+
+		return mustCreateAny(b, &nested)
+	}
+
+	cases := map[string]struct {
+		msg    *codectypes.Any
+		expErr bool
+	}{
+		"garbage any": {
+			msg: &codectypes.Any{
+				TypeUrl: "aslasdf", // TODO: use a real type URL
+				Value:   []byte("oiuwurjtlwerlwmt032498u50j3oehr943q;l348u58q=-afvu89 290i32-1[1]"),
+			},
+			expErr: true,
+		},
+		"single MsgExec": {
+			msg: createNested(b, 1),
+		},
+		"10000 MsgExec": {
+			msg: createNested(b, 10000),
+		},
+		"100000 MsgExec": {
+			msg: createNested(b, 100000),
+		},
+	}
+
+	for name, tc := range cases {
+		b.Run(name, func(b *testing.B) {
+			b.Logf("%s msg size %v", name, len(tc.msg.Value))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var msg sdk.Msg
+				err := cdc.UnpackAny(tc.msg, &msg)
+				if tc.expErr {
+					require.Error(b, err)
+				} else {
+					require.NoError(b, err)
+				}
 			}
 		})
 	}

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"cosmossdk.io/x/tx/signing"
 	abci "github.com/cometbft/cometbft/abci/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+
+	"cosmossdk.io/x/tx/signing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
-	"github.com/cosmos/cosmos-sdk/codec/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/std"
@@ -128,7 +127,7 @@ func BenchmarkTxSending(b *testing.B) {
 }
 
 func BenchmarkUnpackAny(b *testing.B) {
-	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+	interfaceRegistry, err := codectypes.NewInterfaceRegistryWithOptions(codectypes.InterfaceRegistryOptions{
 		ProtoFiles: proto.HybridResolver,
 		SigningOptions: signing.Options{
 			AddressCodec: address.Bech32Codec{
@@ -168,7 +167,7 @@ func BenchmarkUnpackAny(b *testing.B) {
 	}{
 		"garbage any": {
 			msg: &codectypes.Any{
-				TypeUrl: "aslasdf", // TODO: use a real type URL
+				TypeUrl: "aslasdf",
 				Value:   []byte("oiuwurjtlwerlwmt032498u50j3oehr943q;l348u58q=-afvu89 290i32-1[1]"),
 			},
 			expErr: true,

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -213,7 +213,7 @@ func EncodeAnyMsg(unpacker codectypes.AnyUnpacker) AnyEncoder {
 		}
 		var sdkMsg sdk.Msg
 
-		ctx.GasMeter().ConsumeGas((700000*uint64(len(msg.Value)))/types.DefaultGasMultiplier, "unpacking AnyMsg")
+		ctx.GasMeter().ConsumeGas(700000/types.DefaultGasMultiplier, "unpacking AnyMsg")
 		if err := unpacker.UnpackAny(&codecAny, &sdkMsg); err != nil {
 			return nil, errorsmod.Wrap(types.ErrInvalidMsg, fmt.Sprintf("Cannot unpack proto message with type URL: %s", msg.TypeURL))
 		}

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -24,6 +24,10 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
+// anyMsgGasCost is the gas cost for unpacking an AnyMsg, in CosmWasm gas units (not SDK gas units).
+// With the default gas multiplier, this amounts to 5 SDK gas.
+const anyMsgGasCost = 700000
+
 type (
 	BankEncoder         func(sender sdk.AccAddress, msg *wasmvmtypes.BankMsg) ([]sdk.Msg, error)
 	CustomEncoder       func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error)
@@ -213,7 +217,7 @@ func EncodeAnyMsg(unpacker codectypes.AnyUnpacker) AnyEncoder {
 		}
 		var sdkMsg sdk.Msg
 
-		ctx.GasMeter().ConsumeGas(700000/types.DefaultGasMultiplier, "unpacking AnyMsg")
+		ctx.GasMeter().ConsumeGas(anyMsgGasCost/types.DefaultGasMultiplier, "unpacking AnyMsg")
 		if err := unpacker.UnpackAny(&codecAny, &sdkMsg); err != nil {
 			return nil, errorsmod.Wrap(types.ErrInvalidMsg, fmt.Sprintf("Cannot unpack proto message with type URL: %s", msg.TypeURL))
 		}

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -29,7 +29,7 @@ type (
 	CustomEncoder       func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error)
 	DistributionEncoder func(sender sdk.AccAddress, msg *wasmvmtypes.DistributionMsg) ([]sdk.Msg, error)
 	StakingEncoder      func(sender sdk.AccAddress, msg *wasmvmtypes.StakingMsg) ([]sdk.Msg, error)
-	AnyEncoder          func(sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error)
+	AnyEncoder          func(ctx sdk.Context, sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error)
 	WasmEncoder         func(sender sdk.AccAddress, msg *wasmvmtypes.WasmMsg) ([]sdk.Msg, error)
 	IBCEncoder          func(ctx sdk.Context, sender sdk.AccAddress, contractIBCPortID string, msg *wasmvmtypes.IBCMsg) ([]sdk.Msg, error)
 )
@@ -40,7 +40,7 @@ type MessageEncoders struct {
 	Distribution func(sender sdk.AccAddress, msg *wasmvmtypes.DistributionMsg) ([]sdk.Msg, error)
 	IBC          func(ctx sdk.Context, sender sdk.AccAddress, contractIBCPortID string, msg *wasmvmtypes.IBCMsg) ([]sdk.Msg, error)
 	Staking      func(sender sdk.AccAddress, msg *wasmvmtypes.StakingMsg) ([]sdk.Msg, error)
-	Any          func(sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error)
+	Any          func(ctx sdk.Context, sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error)
 	Wasm         func(sender sdk.AccAddress, msg *wasmvmtypes.WasmMsg) ([]sdk.Msg, error)
 	Gov          func(sender sdk.AccAddress, msg *wasmvmtypes.GovMsg) ([]sdk.Msg, error)
 }
@@ -102,7 +102,7 @@ func (e MessageEncoders) Encode(ctx sdk.Context, contractAddr sdk.AccAddress, co
 	case msg.Staking != nil:
 		return e.Staking(contractAddr, msg.Staking)
 	case msg.Any != nil:
-		return e.Any(contractAddr, msg.Any)
+		return e.Any(ctx, contractAddr, msg.Any)
 	case msg.Wasm != nil:
 		return e.Wasm(contractAddr, msg.Wasm)
 	case msg.Gov != nil:
@@ -206,12 +206,14 @@ func EncodeStakingMsg(sender sdk.AccAddress, msg *wasmvmtypes.StakingMsg) ([]sdk
 }
 
 func EncodeAnyMsg(unpacker codectypes.AnyUnpacker) AnyEncoder {
-	return func(sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error) {
+	return func(ctx sdk.Context, sender sdk.AccAddress, msg *wasmvmtypes.AnyMsg) ([]sdk.Msg, error) {
 		codecAny := codectypes.Any{
 			TypeUrl: msg.TypeURL,
 			Value:   msg.Value,
 		}
 		var sdkMsg sdk.Msg
+
+		ctx.GasMeter().ConsumeGas((700000*uint64(len(msg.Value)))/types.DefaultGasMultiplier, "unpacking AnyMsg")
 		if err := unpacker.UnpackAny(&codecAny, &sdkMsg); err != nil {
 			return nil, errorsmod.Wrap(types.ErrInvalidMsg, fmt.Sprintf("Cannot unpack proto message with type URL: %s", msg.TypeURL))
 		}

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -432,7 +433,8 @@ func TestEncoding(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			encoder := DefaultEncoders(encodingConfig.Codec, wasmtesting.MockIBCTransferKeeper{})
-			res, err := encoder.Encode(sdk.Context{}, tc.sender, "", tc.srcMsg)
+			gm := storetypes.NewInfiniteGasMeter()
+			res, err := encoder.Encode(sdk.Context{}.WithGasMeter(gm), tc.sender, "", tc.srcMsg)
 			if tc.expError {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
breaking for people using a custom Any encoder

Benchmark results:
```
BenchmarkUnpackAny/garbage_any-8          2235267       521.9 ns/op     136 B/op       4 allocs/op
BenchmarkUnpackAny/single_MsgExec-8       1736608       686.1 ns/op       24 B/op       2 allocs/op
BenchmarkUnpackAny/10000_MsgExec-8        1724133       689.4 ns/op       24 B/op       2 allocs/op
BenchmarkUnpackAny/100000_MsgExec-8       1723904       690.6 ns/op       24 B/op       2 allocs/op
```

So, it looks like it takes roughly 700ns
Our gas target in CosmWasm uses a target of 1e12 Gas/s = 1e3 Gas/ns. That means:
1e3 Gas/ns * 700ns = 700000 Gas (in CW Gas units)

With the default gas multiplier, it's 5 SDK gas