### PR TITLE
docs: fix 404 links in `scripts/README.md` and `INTEGRATION.md`

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -131,7 +131,7 @@ token contracts, your exchange code can simply call `wasm.Keeper.Execute`
 with a properly formatted message to move funds, or `wasm.Keeper.SmartQuery`
 to check balances.
 
-If you look at the unit tests in [`x/wasm/internal/keeper`](https://github.com/CosmWasm/wasmd/tree/master/x/wasm/internal/keeper),
+If you look at the unit tests in [`x/wasm/keeper`](https://github.com/CosmWasm/wasmd/tree/master/x/wasm/keeper),
 it should be pretty straight forward.
 
 <!-- TODO dead link above -->

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,5 +3,5 @@
 These scripts are copied from the [Cosmos-SDK](https://github.com/cosmos/cosmos-sdk/tree/v0.42.1/scripts) repository 
 with minor modifications. All credits and big thanks go to the original authors.
 
-Please note that a custom [fork](github.com/regen-network/protobuf) by the Regen network team is used.
+Please note that a custom [fork](https://github.com/regen-network/protobuf) by the Regen network team is used.
 See [`go.mod`](../go.mod) for version.


### PR DESCRIPTION
Hi! While working with the documentation, I noticed that some links lead nowhere. This makes it harder to understand the materials and creates inconvenience for users.