### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -114,19 +114,19 @@ func parseVerificationFlags(gzippedWasm []byte, flags *flag.FlagSet) (string, st
 	// if any set require others to be set
 	if len(source) != 0 || len(builder) != 0 || len(codeHash) != 0 {
 		if source == "" {
-			return "", "", nil, fmt.Errorf("source is required")
+			return "", "", nil, errors.New("source is required")
 		}
 		if _, err = url.ParseRequestURI(source); err != nil {
 			return "", "", nil, fmt.Errorf("source: %s", err)
 		}
 		if builder == "" {
-			return "", "", nil, fmt.Errorf("builder is required")
+			return "", "", nil, errors.New("builder is required")
 		}
 		if _, err := reference.ParseDockerRef(builder); err != nil {
 			return "", "", nil, fmt.Errorf("builder: %s", err)
 		}
 		if len(codeHash) == 0 {
-			return "", "", nil, fmt.Errorf("code hash is required")
+			return "", "", nil, errors.New("code hash is required")
 		}
 		// wasm is gzipped in parseStoreCodeArgs
 		// checksum generation will be decoupled here
@@ -319,10 +319,10 @@ func ProposalStoreAndInstantiateContractCmd() *cobra.Command {
 
 			// ensure sensible admin is set (or explicitly immutable)
 			if adminStr == "" && !noAdmin {
-				return fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
+				return errors.New("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
 			}
 			if adminStr != "" && noAdmin {
-				return fmt.Errorf("you set an admin and passed --no-admin, those cannot both be true")
+				return errors.New("you set an admin and passed --no-admin, those cannot both be true")
 			}
 
 			if adminStr != "" {

--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -216,7 +216,7 @@ func GetCmdQueryCode() *cobra.Command {
 				return err
 			}
 			if len(res.Data) == 0 {
-				return fmt.Errorf("contract not found")
+				return errors.New("contract not found")
 			}
 
 			fmt.Printf("Downloading wasm code to %s\n", args[1])

--- a/x/wasm/client/cli/tx.go
+++ b/x/wasm/client/cli/tx.go
@@ -116,7 +116,7 @@ func parseStoreCodeArgs(file, sender string, flags *flag.FlagSet) (types.MsgStor
 			return types.MsgStoreCode{}, err
 		}
 	} else if !ioutils.IsGzip(wasm) {
-		return types.MsgStoreCode{}, fmt.Errorf("invalid input file. Use wasm binary or gzip")
+		return types.MsgStoreCode{}, errors.New("invalid input file. Use wasm binary or gzip")
 	}
 
 	perm, err := parseAccessConfigFlags(flags)
@@ -202,7 +202,7 @@ func InstantiateContractCmd() *cobra.Command {
 Each contract instance has a unique address assigned.
 Example:
 $ %s tx wasm instantiate 1 '{"foo":"bar"}' --admin="$(%s keys show mykey -a)" \
-  --from mykey --amount="100ustake" --label "local0.1.0" 
+  --from mykey --amount="100ustake" --label "local0.1.0"
 `, version.AppName, version.AppName),
 		Aliases: []string{"start", "init", "inst", "i"},
 		Args:    cobra.ExactArgs(2),
@@ -236,13 +236,13 @@ func InstantiateContract2Cmd() *cobra.Command {
 			"--fix-msg [bool,optional]",
 		Short: "Instantiate a wasm contract with predictable address",
 		Long: fmt.Sprintf(`Creates a new instance of an uploaded wasm code with the given 'constructor' message.
-Each contract instance has a unique address assigned. They are assigned automatically but in order to have predictable addresses 
+Each contract instance has a unique address assigned. They are assigned automatically but in order to have predictable addresses
 for special use cases, the given 'salt' argument and '--fix-msg' parameters can be used to generate a custom address.
 
 Predictable address example (also see '%s query wasm build-address -h'):
 $ %s tx wasm instantiate2 1 '{"foo":"bar"}' $(echo -n "testing" | xxd -ps) --admin="$(%s keys show mykey -a)" \
   --from mykey --amount="100ustake" --label "local0.1.0" \
-   --fix-msg 
+   --fix-msg
 `, version.AppName, version.AppName, version.AppName),
 		Aliases: []string{"start", "init", "inst", "i"},
 		Args:    cobra.ExactArgs(3),
@@ -322,10 +322,10 @@ func parseInstantiateArgs(rawCodeID, initMsg string, kr keyring.Keyring, sender 
 
 	// ensure sensible admin is set (or explicitly immutable)
 	if adminStr == "" && !noAdmin {
-		return nil, fmt.Errorf("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
+		return nil, errors.New("you must set an admin or explicitly pass --no-admin to make it immutable (wasmd issue #719)")
 	}
 	if adminStr != "" && noAdmin {
-		return nil, fmt.Errorf("you set an admin and passed --no-admin, those cannot both be true")
+		return nil, errors.New("you set an admin and passed --no-admin, those cannot both be true")
 	}
 
 	if adminStr != "" {
@@ -625,7 +625,7 @@ func parseStoreCodeGrants(args []string) ([]types.CodeGrant, error) {
 		// access_config: nobody|everybody|address(es)
 		parts := strings.Split(c, ":")
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid format")
+			return nil, errors.New("invalid format")
 		}
 
 		if parts[1] == "*" {

--- a/x/wasm/keeper/wasmtesting/mock_keepers.go
+++ b/x/wasm/keeper/wasmtesting/mock_keepers.go
@@ -2,6 +2,7 @@ package wasmtesting
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
@@ -137,7 +138,7 @@ func (m *IBCContractKeeperMock) LoadAsyncAckPacket(ctx context.Context, portID, 
 	key := portID + fmt.Sprint(len(channelID)) + channelID
 	packet, ok := m.packets[key]
 	if !ok {
-		return channeltypes.Packet{}, fmt.Errorf("packet not found")
+		return channeltypes.Packet{}, errors.New("packet not found")
 	}
 	return packet, nil
 }

--- a/x/wasm/module.go
+++ b/x/wasm/module.go
@@ -3,6 +3,7 @@ package wasm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -304,7 +305,7 @@ func getExpectedLibwasmVersion() string {
 // `wasmd query wasm libwasmvm-version`.
 func CheckLibwasmVersion(wasmExpectedVersion string) error {
 	if wasmExpectedVersion == "" {
-		return fmt.Errorf("wasmvm module not exist")
+		return errors.New("wasmvm module not exist")
 	}
 	wasmVersion, err := wasmvm.LibwasmvmVersion()
 	if err != nil {

--- a/x/wasm/types/validation.go
+++ b/x/wasm/types/validation.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -80,19 +81,19 @@ func ValidateVerificationInfo(source, builder string, codeHash []byte) error {
 	// if any set require others to be set
 	if len(source) != 0 || len(builder) != 0 || len(codeHash) != 0 {
 		if source == "" {
-			return fmt.Errorf("source is required")
+			return errors.New("source is required")
 		}
 		if _, err := url.ParseRequestURI(source); err != nil {
 			return fmt.Errorf("source: %s", err)
 		}
 		if builder == "" {
-			return fmt.Errorf("builder is required")
+			return errors.New("builder is required")
 		}
 		if _, err := reference.ParseDockerRef(builder); err != nil {
 			return fmt.Errorf("builder: %s", err)
 		}
 		if codeHash == nil {
-			return fmt.Errorf("code hash is required")
+			return errors.New("code hash is required")
 		}
 		// code hash checksum match validation is done in the keeper, ungzipping consumes gas
 	}


### PR DESCRIPTION
Replaced fmt.Errorf with errors.New in cases where formatting is not required. This reduces unnecessary function calls, leading to slightly improved performance and cleaner code.

