### PR TITLE
Allow typ as identifier name

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -3,6 +3,7 @@ extend-ignore-re = ["(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"]
 
 [default.extend-identifiers]
 iNdEx = "iNdEx"
+typ = "typ"
 
 [files]
 extend-exclude = ["**/go.mod", "**/go.sum", "**/*.pb.go"]


### PR DESCRIPTION
The typos tool is complaining about this right now.