### PR TITLE
Update LICENSE to clean copy of Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-License: Apache2.0
 
                                  Apache License
                            Version 2.0, January 2004
@@ -180,7 +179,7 @@ License: Apache2.0
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -188,7 +187,7 @@ License: Apache2.0
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 All in Bits, Inc
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copied from https://www.apache.org/licenses/LICENSE-2.0.txt

Trying to address this broken auto-detection:
<img width="754" alt="Bildschirmfoto 2025-03-04 um 21 37 44" src="https://github.com/user-attachments/assets/1b784835-7dd8-47bf-8af9-1ba484999c5e" />

Let's see if GitHub understands our license then