### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/tests/system/cli.go
+++ b/tests/system/cli.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-	"golang.org/x/exp/slices"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/tests/system/go.mod
+++ b/tests/system/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/cometbft/cometbft v0.38.15
 	github.com/tidwall/gjson v1.14.2
 	github.com/tidwall/sjson v1.2.5
-	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0
+	golang.org/x/exp v0.0.0-20240404231335-c0f41cb1a7a0 // indirect
 )
 
 require (


### PR DESCRIPTION
# Description

These experimental packages are now available in the Go standard library since Go 1.21 and Go 1.23:

golang.org/x/exp/slices -> slices([https://go.dev/doc/go1.21#slices](https://go.dev/doc/go1.21#slices))