### PR TITLE
Refactor: Improve error messages and type annotations in wasm types

### DIFF
--- a/x/wasm/types/errors.go
+++ b/x/wasm/types/errors.go
@@ -39,7 +39,7 @@ var (
 	// ErrInvalidMsg error when we cannot process the error returned from the contract
 	ErrInvalidMsg = errorsmod.Register(DefaultCodespace, 10, "invalid CosmosMsg from the contract")
 
-	// ErrMigrationFailed error for rust execution contract failure
+	// ErrMigrationFailed error for rust migration contract failure
 	ErrMigrationFailed = errorsmod.Register(DefaultCodespace, 11, "migrate wasm contract failed")
 
 	// ErrEmpty error for empty content

--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -12,7 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var AllAccessTypes = []AccessType{
+var AllAccessTypes []AccessType = []AccessType{
 	AccessTypeNobody,
 	AccessTypeAnyOfAddresses,
 	AccessTypeEverybody,
@@ -101,7 +101,7 @@ func (p Params) String() string {
 // ValidateBasic performs basic validation on wasm parameters
 func (p Params) ValidateBasic() error {
 	if err := validateAccessType(p.InstantiateDefaultPermission); err != nil {
-		return errors.Wrap(err, "instantiate default permission")
+		return errorsmod.Wrap(err, "instantiate default permission")
 	}
 	if err := p.CodeUploadAccess.ValidateBasic(); err != nil {
 		return errors.Wrap(err, "upload access")


### PR DESCRIPTION
- Fixed typo in `ErrMigrationFailed` description (errors.go): updated wording from "execution" to "migration" failure
- Explicitly defined the type for `AllAccessTypes` slice (params.go)
- Replaced `pkg/errors.Wrap()` with `errorsmod.Wrap()` for consistency with Cosmos SDK error handling (params.go)

