### PR TITLE
Fix broken link in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,7 @@
 
 With stargate, we have access to the `x/upgrade` module, which we can use to perform
 inline upgrades. Please first read both the basic 
-[x/upgrade spec](https://github.com/cosmos/cosmos-sdk/blob/master/x/upgrade/spec/01_concepts.md)
+[x/upgrade spec](https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/upgrade/spec/01_concepts.md)
 and [go docs](https://godoc.org/github.com/cosmos/cosmos-sdk/x/upgrade#hdr-Performing_Upgrades)
 for the background on the module.
 


### PR DESCRIPTION
Replaced the outdated link to the x/upgrade spec with the correct one pointing to a specific commit in the Cosmos SDK repository. This ensures long-term reliability, preventing potential issues if the master branch changes.

File changed: UPGRADING.md

Old link: https://github.com/cosmos/cosmos-sdk/blob/master/x/upgrade/spec/01_concepts.md
New link: https://github.com/cosmos/cosmos-sdk/blob/31fdee02280bd6f3e787489c8e443aabc8cfacb7/x/upgrade/spec/01_concepts.md