### PR TITLE
refactor: remove redundant import aliases

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/CosmWasm/wasmd/app/upgrades"
 	"github.com/CosmWasm/wasmd/app/upgrades/noop"
-	v050 "github.com/CosmWasm/wasmd/app/upgrades/v050"
-	v2 "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
+	"github.com/CosmWasm/wasmd/app/upgrades/v050"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
 

--- a/tests/e2e/gov_test.go
+++ b/tests/e2e/gov_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
 	"github.com/CosmWasm/wasmd/tests/e2e"
 	wasmibctesting "github.com/CosmWasm/wasmd/tests/wasmibctesting"

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	secp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	distributionkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"

--- a/tests/integration/migrations_integration_test.go
+++ b/tests/integration/migrations_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/CosmWasm/wasmd/app"
-	v2 "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 

--- a/tests/integration/module_test.go
+++ b/tests/integration/module_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm/exported"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper/testdata"
-	v2 "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 

--- a/tests/integration/proposal_integration_test.go
+++ b/tests/integration/proposal_integration_test.go
@@ -15,7 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"

--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/address"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
 	"github.com/CosmWasm/wasmd/x/wasm/ioutils"
 	"github.com/CosmWasm/wasmd/x/wasm/types"

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -17,7 +17,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm/types"

--- a/x/wasm/keeper/migrations.go
+++ b/x/wasm/keeper/migrations.go
@@ -4,9 +4,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm/exported"
-	v1 "github.com/CosmWasm/wasmd/x/wasm/migrations/v1"
-	v2 "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
-	v3 "github.com/CosmWasm/wasmd/x/wasm/migrations/v3"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v1"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.

--- a/x/wasm/migrations/v2/store_test.go
+++ b/x/wasm/migrations/v2/store_test.go
@@ -18,7 +18,7 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
-	v2 "github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v2"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 

--- a/x/wasm/migrations/v3/store_test.go
+++ b/x/wasm/migrations/v3/store_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper"
 	"github.com/CosmWasm/wasmd/x/wasm/keeper/wasmtesting"
-	v3 "github.com/CosmWasm/wasmd/x/wasm/migrations/v3"
+	"github.com/CosmWasm/wasmd/x/wasm/migrations/v3"
 	"github.com/CosmWasm/wasmd/x/wasm/types"
 )
 


### PR DESCRIPTION
I found a lot of redundant aliases through this lint tool https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias. If possible, I would be very keen to integrate it into the CI.