### PR TITLE
 fix typo in subtype string and update Contributor Covenant link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [Contributor Covenant 1.4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/x/wasm/keeper/authz_policy_test.go
+++ b/x/wasm/keeper/authz_policy_test.go
@@ -40,7 +40,7 @@ func TestDefaultAuthzPolicyCanCreateCode(t *testing.T) {
 			contractInstConf: types.AllowEverybody,
 			exp:              false,
 		},
-		"contract config -  subtype": {
+		"contract config - subtype": {
 			chainConfigs:     types.NewChainAccessConfigs(types.AllowEverybody, types.AllowEverybody),
 			contractInstConf: types.AccessTypeAnyOfAddresses.With(myActorAddress),
 			exp:              true,
@@ -213,7 +213,7 @@ func TestGovAuthzPolicyCanCreateCode(t *testing.T) {
 			chainConfigs:     types.NewChainAccessConfigs(types.AccessTypeAnyOfAddresses.With(otherAddress), types.AllowEverybody),
 			contractInstConf: types.AllowEverybody,
 		},
-		"contract config -  subtype": {
+		"contract config - subtype": {
 			chainConfigs:     types.NewChainAccessConfigs(types.AllowEverybody, types.AllowEverybody),
 			contractInstConf: types.AccessTypeAnyOfAddresses.With(myActorAddress),
 		},

--- a/x/wasm/keeper/contract_keeper.go
+++ b/x/wasm/keeper/contract_keeper.go
@@ -32,7 +32,7 @@ type decoratedKeeper interface {
 	execute(ctx context.Context, contractAddress, caller sdk.AccAddress, msg []byte, coins sdk.Coins) ([]byte, error)
 	Sudo(ctx context.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error)
 	setContractInfoExtension(ctx context.Context, contract sdk.AccAddress, extra types.ContractInfoExtension) error
-	setAccessConfig(ctx context.Context, codeID uint64, caller sdk.AccAddress, newConfig types.AccessConfig, autz types.AuthorizationPolicy) error
+	setAccessConfig(ctx context.Context, codeID uint64, caller sdk.AccAddress, newConfig types.AccessConfig, authz types.AuthorizationPolicy) error
 	ClassicAddressGenerator() AddressGenerator
 }
 

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -924,7 +924,7 @@ func TestConvertWasmCoinToSdkCoin(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"invalid demum char": {
+		"invalid denom char": {
 			src: wasmvmtypes.Coin{
 				Denom:  "&fff",
 				Amount: "1",


### PR DESCRIPTION
Description:
This PR includes the following changes:
1. Fixes typo in "subtype" string in authz_policy_test.go (removes extra space)
2. Updates the Contributor Covenant link and version reference in CODE_OF_CONDUCT.md to use the canonical format
These are minor text corrections that improve code consistency and documentation accuracy.