### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,13 +15,9 @@ linters:
   enable:
     - errcheck
     - dogsled
-    - exportloopref
     - goconst
     - gocritic
-    - gci
-    - gofumpt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -30,7 +26,6 @@ linters:
     - staticcheck
     - revive
     - stylecheck
-    - typecheck
 #    - thelper # too many positives with table tests that have custom setup(*testing.T)
     - unconvert
     - unused


### PR DESCRIPTION
Removed `exportloopref`, `gci`, `gofumpt`, `gosimple`, and `typecheck` from `.golangci.yml` because they are now considered formatters, not linters. Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/)