### PR TITLE
Fix typos in documentation

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -6,14 +6,14 @@ If you want to use Wasm in your own app, here is how you can get this working
 quickly and easily. 
 First start with this [article](https://medium.com/cosmwasm/cosmwasm-for-ctos-iv-native-integrations-713140bf75fc) 
 in the "CosmWasm for CTOs" series that gives you a high level view. 
-Then check to make sure you fit the pre-requisites,
+Then check to make sure you fit the prerequisites,
 then integrate the `x/wasm` module as described below, and finally, you
 can add custom messages and queries to your custom Go/SDK modules, exposing
 them to any chain-specific contract.
 
 ## Prerequisites
 
-The pre-requisites of integrating `x/wasm` into your custom app is to be using 
+The prerequisites of integrating `x/wasm` into your custom app are to be using 
 a compatible version of the Cosmos SDK, and to accept some limits to the
 hardware it runs on.
 

--- a/scripts/contrib/prometheus/README.md
+++ b/scripts/contrib/prometheus/README.md
@@ -40,7 +40,7 @@ Note the `format` parameter in the request for the endpoint:
 # port 9090 is used by wasmd already
 docker run -it -v $(pwd)/scripts/contrib/prometheus:/prometheus  -p9091:9090  prom/prometheus --config.file=/prometheus/prometheus.yaml
 ```
-* Open [console](http://localhost:9091) and find `wasm_`service metrics
+* Open [console](http://localhost:9091) and find `wasm_` service metrics
 
 ## Run Grafana
 

--- a/x/wasm/Governance.md
+++ b/x/wasm/Governance.md
@@ -6,7 +6,7 @@ a high-level, technical introduction meant to provide context before
 looking into the code, or constructing proposals. 
 
 ## Proposal Types
-We have added 15 new wasm specific proposal messages that cover the contract's live cycle and authorization:
+We have added 15 new wasm specific proposal messages that cover the contract's lifecycle and authorization:
  
 * `MsgStoreCode` - upload a wasm binary
 * `MsgInstantiateContract` - instantiate a wasm contract

--- a/x/wasm/keeper/wasmtesting/mock_engine.go
+++ b/x/wasm/keeper/wasmtesting/mock_engine.go
@@ -258,7 +258,7 @@ type IBCContractCallbacks interface {
 	IBCChannelOpen(
 		codeID wasmvm.Checksum,
 		env wasmvmtypes.Env,
-		msg wasmvmtypes.IBCChannelOpenMsg,
+		channel wasmvmtypes.IBCChannelOpenMsg,
 		store wasmvm.KVStore,
 		goapi wasmvm.GoAPI,
 		querier wasmvm.Querier,
@@ -413,7 +413,7 @@ type MockIBCContractCallbacks struct {
 	IBCPacketTimeoutFn  func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketTimeoutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResult, uint64, error)
 }
 
-func (m MockIBCContractCallbacks) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCChannelOpenResult, uint64, error) {
+func (m MockIBCContractCallbacks) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, channel wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCChannelOpenResult, uint64, error) {
 	if m.IBCChannelOpenFn == nil {
 		panic("not expected to be called")
 	}

--- a/x/wasm/keeper/wasmtesting/mock_engine.go
+++ b/x/wasm/keeper/wasmtesting/mock_engine.go
@@ -258,7 +258,7 @@ type IBCContractCallbacks interface {
 	IBCChannelOpen(
 		codeID wasmvm.Checksum,
 		env wasmvmtypes.Env,
-		channel wasmvmtypes.IBCChannelOpenMsg,
+		msg wasmvmtypes.IBCChannelOpenMsg,
 		store wasmvm.KVStore,
 		goapi wasmvm.GoAPI,
 		querier wasmvm.Querier,
@@ -413,7 +413,7 @@ type MockIBCContractCallbacks struct {
 	IBCPacketTimeoutFn  func(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCPacketTimeoutMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCBasicResult, uint64, error)
 }
 
-func (m MockIBCContractCallbacks) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, channel wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCChannelOpenResult, uint64, error) {
+func (m MockIBCContractCallbacks) IBCChannelOpen(codeID wasmvm.Checksum, env wasmvmtypes.Env, msg wasmvmtypes.IBCChannelOpenMsg, store wasmvm.KVStore, goapi wasmvm.GoAPI, querier wasmvm.Querier, gasMeter wasmvm.GasMeter, gasLimit uint64, deserCost wasmvmtypes.UFraction) (*wasmvmtypes.IBCChannelOpenResult, uint64, error) {
 	if m.IBCChannelOpenFn == nil {
 		panic("not expected to be called")
 	}


### PR DESCRIPTION
This PR fixes spelling inconsistencies in the documentation by:
- Changing "pre-requisites" to "prerequisites" in INTEGRATION.md
- Ensuring consistent spelling across documentation files

This is a minor documentation improvement that makes the terminology more consistent with standard technical writing practices.