### PR TITLE
Fix typos and grammar in documentation and code comments

### DIFF
--- a/scripts/contrib/relayer-tests/README.md
+++ b/scripts/contrib/relayer-tests/README.md
@@ -9,6 +9,6 @@ Make sure you run below scripts under `wasmd/scripts/contrib/relayer-tests` dire
 
 ## Thank you
 The setup scripts here are taken from [cosmos/relayer](https://github.com/cosmos/relayer)
-Thank your relayer team for these scripts.
+Thank you relayer team for these scripts.
 
 

--- a/x/wasm/keeper/handler_plugin_encoders_test.go
+++ b/x/wasm/keeper/handler_plugin_encoders_test.go
@@ -917,7 +917,7 @@ func TestConvertWasmCoinToSdkCoin(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"denom to short": {
+		"denom too short": {
 			src: wasmvmtypes.Coin{
 				Denom:  "f",
 				Amount: "1",

--- a/x/wasm/types/tx.pb.go
+++ b/x/wasm/types/tx.pb.go
@@ -134,7 +134,7 @@ var xxx_messageInfo_MsgStoreCodeResponse proto.InternalMessageInfo
 // MsgInstantiateContract create a new smart contract instance for the given
 // code id.
 type MsgInstantiateContract struct {
-	// Sender is the actor that signed the messages
+	// Sender is the that actor that signed the messages
 	Sender string `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	// Admin is an optional address that can execute migrations
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`

--- a/x/wasm/types/tx.pb.go
+++ b/x/wasm/types/tx.pb.go
@@ -134,7 +134,7 @@ var xxx_messageInfo_MsgStoreCodeResponse proto.InternalMessageInfo
 // MsgInstantiateContract create a new smart contract instance for the given
 // code id.
 type MsgInstantiateContract struct {
-	// Sender is the that actor that signed the messages
+	// Sender is the actor that signed the messages
 	Sender string `protobuf:"bytes,1,opt,name=sender,proto3" json:"sender,omitempty"`
 	// Admin is an optional address that can execute migrations
 	Admin string `protobuf:"bytes,2,opt,name=admin,proto3" json:"admin,omitempty"`


### PR DESCRIPTION
This PR fixes several typos and improves grammar:

1. Fixed "Thank your" to "Thank you" in relayer-tests README.md
2. Fixed "denom to short" to "denom too short" in test case description
3. Removed redundant "the" in comment for MsgInstantiateContract

These changes improve code readability and documentation accuracy without affecting functionality.