### PR TITLE
Fix typo in `msg_dispatcher_test.go` comment: `contarctAddr` to `contractAddr`

### DIFF
--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -333,7 +333,7 @@ func TestDispatchSubmessages(t *testing.T) {
 				DispatchMsgFn: func(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) (events []sdk.Event, data [][]byte, msgResponses [][]*codectypes.Any, err error) {
 					events = []sdk.Event{
 						sdk.NewEvent("message", sdk.NewAttribute("_contract_address", contractAddr.String())),
-						// we don't know what the contarctAddr will be so we can't use it in the final tests
+						// we don't know what the contractAddr will be so we can't use it in the final tests
 						sdk.NewEvent("execute", sdk.NewAttribute("_contract_address", "placeholder-random-addr")),
 						sdk.NewEvent("wasm", sdk.NewAttribute("random", "data")),
 					}


### PR DESCRIPTION


Description:
This PR fixes a typo in a comment within the msg_dispatcher_test.go file. The word "contarctAddr" was misspelled and has been corrected to "contractAddr". This change improves code readability and maintains consistent terminology throughout the codebase.

Changes made:
- Corrected the misspelling in the comment on line 336
- No functional changes, only documentation improvement
