### PR TITLE
fix: correct typo in function name WithGovSubMsgAuthZPropagated

### DIFF
--- a/x/wasm/keeper/options.go
+++ b/x/wasm/keeper/options.go
@@ -175,8 +175,8 @@ func WithAcceptedAccountTypesOnContractInstantiation(accts ...sdk.AccountI) Opti
 	})
 }
 
-// WitGovSubMsgAuthZPropagated overwrites the default gov authorization policy for sub-messages
-func WitGovSubMsgAuthZPropagated(entries ...types.AuthorizationPolicyAction) Option {
+// WithGovSubMsgAuthZPropagated overwrites the default gov authorization policy for sub-messages
+func WithGovSubMsgAuthZPropagated(entries ...types.AuthorizationPolicyAction) Option {
 	x := make(map[types.AuthorizationPolicyAction]struct{}, len(entries))
 	for _, e := range entries {
 		x[e] = struct{}{}

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -139,7 +139,7 @@ func TestConstructorOptions(t *testing.T) {
 			},
 		},
 		"gov propagation": {
-			srcOpt: WitGovSubMsgAuthZPropagated(types.AuthZActionInstantiate, types.AuthZActionMigrateContract),
+			srcOpt: WithGovSubMsgAuthZPropagated(types.AuthZActionInstantiate, types.AuthZActionMigrateContract),
 			verify: func(t *testing.T, k Keeper) {
 				exp := map[types.AuthorizationPolicyAction]struct{}{
 					types.AuthZActionInstantiate:     {},


### PR DESCRIPTION
Fixed a typo in the function name WitGovSubMsgAuthZPropagated by adding the missing 'h' to make it WithGovSubMsgAuthZPropagated. This maintains consistency with other similar functions in the codebase like WithWasmEngine, WithMessageHandler, etc.