### PR TITLE
docs: fix ‘contact’ → ‘contract’ typos

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -240,7 +240,7 @@ If the response contains a non-empty list of `attributes`, `x/wasm` will emit a 
 always be tagged with `_contract_address` by the Go module, so this is trust-worthy. The contract itself cannot overwrite
 this field. Beyond this, the `attributes` returned by the contract, these are appended to the same event.
 
-A contact may also return custom `events`. These are multiple events, each with their own type as well as attributes.
+A contract may also return custom `events`. These are multiple events, each with their own type as well as attributes.
 When they are received, `x/wasm` prepends `wasm-` to the event type returned by the contact to avoid them trying to fake
 an eg. `transfer` event from the bank module. The output here may look like:
 
@@ -312,7 +312,7 @@ consistent way possible.
 ### Combining Events from Sub-Messages
 
 Each time a contract is executed, it not only returns the `message` event from its call, the `execute` event for the
-contact and the `wasm` event with any custom fields from the contract itself. It will also return the same set of information
+contract and the `wasm` event with any custom fields from the contract itself. It will also return the same set of information
 for all messages that it returned, which were later dispatched. The event system was really designed for one main
 action emitting events, so we define a structure to flatten this event tree:
 
@@ -382,7 +382,7 @@ sdk.NewEvent(
 
 When the `reply` clause in a contract is called, it will receive the data returned from the message it
 applies to, as well as all events from that message. In the above case, when the `reply` function was called
-on `contractAddr` in response to initializing a contact, it would get the binary-encoded `initData` in the `data`
+on `contractAddr` in response to initializing a contract, it would get the binary-encoded `initData` in the `data`
 field, and the following in the `events` field:
 
 ```go


### PR DESCRIPTION
replace three instances of “contact” with “contract” in Event System section (`custom events`, `execute event`, i`nitializing a contract`).