### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/x/wasm/migrations/v2/params_legacy.go
+++ b/x/wasm/migrations/v2/params_legacy.go
@@ -8,6 +8,7 @@ package v2
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/cosmos/gogoproto/jsonpb"
 
@@ -60,10 +61,8 @@ func validateAccessType(i interface{}) error {
 	if a == AccessTypeUnspecified {
 		return errorsmod.Wrap(types.ErrEmpty, "type")
 	}
-	for _, v := range AllAccessTypes {
-		if v == a {
-			return nil
-		}
+	if slices.Contains(AllAccessTypes, a) {
+		return nil
 	}
 	return errorsmod.Wrapf(types.ErrInvalid, "unknown type: %q", a)
 }

--- a/x/wasm/types/json_matching.go
+++ b/x/wasm/types/json_matching.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"slices"
 )
 
 // isJSONObjectWithTopLevelKey returns true if the given bytes are a valid JSON object
@@ -22,10 +23,8 @@ func isJSONObjectWithTopLevelKey(jsonBytes RawContractMessage, allowedKeys []str
 
 	// Loop is executed exactly once
 	for topLevelKey := range document {
-		for _, allowedKey := range allowedKeys {
-			if allowedKey == topLevelKey {
-				return true, nil
-			}
+		if slices.Contains(allowedKeys, topLevelKey) {
+			return true, nil
 		}
 		return false, nil
 	}

--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"slices"
 
 	"github.com/cosmos/gogoproto/jsonpb"
 	"github.com/pkg/errors"
@@ -113,10 +114,8 @@ func validateAccessType(a AccessType) error {
 	if a == AccessTypeUnspecified {
 		return errorsmod.Wrap(ErrEmpty, "type")
 	}
-	for _, v := range AllAccessTypes {
-		if v == a {
-			return nil
-		}
+	if slices.Contains(AllAccessTypes, a) {
+		return nil
 	}
 	return errorsmod.Wrapf(ErrInvalid, "unknown type: %q", a)
 }
@@ -143,12 +142,7 @@ func (a AccessConfig) Allowed(actor sdk.AccAddress) bool {
 	case AccessTypeEverybody:
 		return true
 	case AccessTypeAnyOfAddresses:
-		for _, v := range a.Addresses {
-			if v == actor.String() {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(a.Addresses, actor.String())
 	default:
 		panic("unknown type")
 	}

--- a/x/wasm/types/types.go
+++ b/x/wasm/types/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"slices"
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/v2/types"
 	"github.com/cosmos/gogoproto/proto"
@@ -251,11 +252,8 @@ func (a *AbsoluteTxPosition) Bytes() []byte {
 // ValidateBasic syntax checks
 func (c ContractCodeHistoryEntry) ValidateBasic() error {
 	var found bool
-	for _, v := range AllCodeHistoryTypes {
-		if c.Operation == v {
-			found = true
-			break
-		}
+	if slices.Contains(AllCodeHistoryTypes, c.Operation) {
+		found = true
 	}
 	if !found {
 		return ErrInvalid.Wrap("operation")
@@ -420,11 +418,8 @@ func isSubset(super, sub []string) bool {
 	}
 	var matches int
 	for _, o := range sub {
-		for _, s := range super {
-			if o == s {
-				matches++
-				break
-			}
+		if slices.Contains(super, o) {
+			matches++
 		}
 	}
 	return matches == len(sub)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.