### PR TITLE
Fix and simplify recurse gas tests

### DIFF
--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -56,14 +56,14 @@ func initRecurseContract(t *testing.T) (contract sdk.AccAddress, ctx sdk.Context
 
 func TestGasCostOnQuery(t *testing.T) {
 	const (
-		GasNoWork           uint64 = 63_987 + 6
-		GasNoWorkDiscounted uint64 = 5_968
-		// Note: about 100 SDK gas (10k CosmWasm gas) for each round of sha256
-		GasWork50           uint64 = 64_234 + 6 // this is a little shy of 50k gas - to keep an eye on the limit
-		GasWork50Discounted uint64 = 6_207
+		GasNoWork uint64 = 63_993
+		GasWork50 uint64 = 64_240
+		// should be discounted exactly by the difference between normal instance cost and discounted instance cost
+		GasNoWorkDiscounted uint64 = GasNoWork - (types.DefaultInstanceCost - types.DefaultInstanceCostDiscount)
+		GasWork50Discounted uint64 = GasWork50 - (types.DefaultInstanceCost - types.DefaultInstanceCostDiscount)
 
-		GasReturnUnhashed uint64 = 89 + 10
-		GasReturnHashed   uint64 = 86 + 10
+		GasReturnUnhashed uint64 = 74
+		GasReturnHashed   uint64 = 63
 	)
 
 	cases := map[string]struct {
@@ -214,12 +214,16 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 
 	const (
 		// Note: about 100 SDK gas (10k CosmWasm gas) for each round of sha256
-		GasWork2k uint64 = 76_817 + 5 // = SetupContractCost + x // we have 6x gas used in cpu than in the instance
+		GasWork2k uint64 = 76_822 // = SetupContractCost + x // we have 6x gas used in cpu than in the instance
 
-		GasWork2kDiscounted uint64 = 18_264 + 432 + 10
+		// should be discounted exactly by the difference between normal instance cost and discounted instance cost
+		GasWork2kDiscounted uint64 = GasWork2k - (types.DefaultInstanceCost - types.DefaultInstanceCostDiscount)
 
 		// This is overhead for calling into a sub-contract
-		GasReturnHashed uint64 = 48 + 132
+		GasReturnHashed uint64 = 64
+
+		// lots of additional gas for long error message
+		GasError uint64 = 3408
 	)
 
 	cases := map[string]struct {
@@ -268,8 +272,8 @@ func TestLimitRecursiveQueryGas(t *testing.T) {
 			},
 			expectQueriesFromContract: 10,
 			expectOutOfGas:            false,
-			expectError:               "query wasm contract failed",                                                      // Error we get from the contract instance doing the failing query, not wasmd
-			expectedGas:               GasWork2k + GasReturnHashed + 9*(GasWork2kDiscounted+GasReturnHashed) + 3279 + 13, // lots of additional gas for long error message
+			expectError:               "query wasm contract failed", // Error we get from the contract instance doing the failing query, not wasmd
+			expectedGas:               GasWork2k + GasReturnHashed + 9*(GasWork2kDiscounted+GasReturnHashed) + GasError,
 		},
 	}
 


### PR DESCRIPTION
These tests have been a constant annoyance for me when upgrading wasmvm. Because some of the changes in here, it was not obvious anymore how to split up the changes in gas cost, so the numbers slowly drifted away from what they should be.

This should make it a bit more clear what the expected numbers are and make it easier to update them in the future.