### PR TITLE
Suppressed unnecessary help message

### DIFF
--- a/docker/setup_wasmd.sh
+++ b/docker/setup_wasmd.sh
@@ -13,7 +13,7 @@ sed -i "s/\"stake\"/\"$STAKE\"/" "$HOME"/.wasmd/config/genesis.json
 # this is essential for sub-1s block times (or header times go crazy)
 sed -i 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.wasmd/config/genesis.json
 
-if ! wasmd keys show validator; then
+if ! wasmd keys show validator > /dev/null 2>&1 ; then
   (echo "$PASSWORD"; echo "$PASSWORD") | wasmd keys add validator
 fi
 # hardcode the validator account for this instance


### PR DESCRIPTION
Currently, when running `setup_and_run.sh` or `setup_wasmd.sh` inside Docker container, when checking for the existance of the `validator` (line 16 in setup_wasmd.sh file), the executed command `wasmd keys show validator` displays unnecessary help and error messages, like this:
```text
   "contracts": [],
   "sequences": []
  }
 }
}
Usage:
  wasmd keys show [name_or_address [name_or_address...]] [flags]

Flags:
  -a, --address                  Output the address only (cannot be used with --output)
      --bech string              The Bech32 prefix encoding for a key (acc|val|cons) (default "acc")
  -d, --device                   Output the address in a ledger device (cannot be used with --pubkey)
  -h, --help                     help for show
      --multisig-threshold int   K out of N required signatures (default 1)
  -p, --pubkey                   Output the public key only (cannot be used with --output)

Global Flags:
      --home string              directory for config and data (default "/root/.wasmd")
      --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "os")
      --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
      --log_format string        The logging format (json|plain) (default "plain")
      --log_level string         The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>') (default "info")
      --log_no_color             Disable colored logs
      --output string            Output format (text|json) (default "text")
      --trace                    print out full stack trace on errors

10:05AM ERR failure when running app err="validator is not a valid name or address: decoding bech32 failed: invalid separator index -1"

- address: wasm1pz532txtnq598m7ty5uha34nkzppvxy8h92tdw
  name: validator
  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"Akf+4Fi8vpc6PP5gAp5dc98yq9YlxlbpQCqm5VSHDkd2"}'
  type: local
```
This PR discards these messages, while can be misleading for newcomers.
The output after this change is just:
```text
   "contracts": [],
   "sequences": []
  }
 }
}

- address: wasm1t2ydv9yj0u2ly8c9yk23jfczy2shrt36zq6va3
  name: validator
  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AuDbDIYnCOlnP78rmDcxVho31j5FS+VH9Ckp1GnLD6m9"}'
  type: local
```