### PR TITLE
Fixed adding new accounts

### DIFF
--- a/docker/setup_wasmd.sh
+++ b/docker/setup_wasmd.sh
@@ -21,8 +21,9 @@ echo "$PASSWORD" | wasmd genesis add-genesis-account validator "1000000000$STAKE
 
 # (optionally) add a few more genesis accounts
 for addr in "$@"; do
-  echo $addr
-  wasmd genesis add-genesis-account "$addr" "1000000000$STAKE,1000000000$FEE"
+  echo -e "\nAdding new account: $addr"
+  (echo "$PASSWORD"; echo "$PASSWORD") | wasmd keys add "$addr"
+  echo "$PASSWORD" | wasmd genesis add-genesis-account "$addr" "1000000000$STAKE,1000000000$FEE"
 done
 
 # submit a genesis validator tx


### PR DESCRIPTION
Fixed `setup_wasmd.sh` script, so adding new accounts is now possible like this (inside Docker container):
```shell
/opt # ./setup_and_run.sh alice bob
```