### PR TITLE
Corrected typos

### DIFF
--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -425,7 +425,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 	specs := map[string]struct {
 		req    *wasmvmtypes.WasmQuery
 		mock   mockWasmQueryKeeper
-		expRes wasmvmtypes.ContractInfoResponse
+		express wasmvmtypes.ContractInfoResponse
 		expErr bool
 	}{
 		"all good": {
@@ -441,7 +441,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return true },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Admin:   myAdminAddr,
@@ -477,7 +477,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return false },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Admin:   myAdminAddr,
@@ -497,7 +497,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 				},
 				IsPinnedCodeFn: func(ctx context.Context, codeID uint64) bool { return true },
 			},
-			expRes: wasmvmtypes.ContractInfoResponse{
+			express: wasmvmtypes.ContractInfoResponse{
 				CodeID:  1,
 				Creator: myCreatorAddr,
 				Pinned:  true,
@@ -515,7 +515,7 @@ func TestContractInfoWasmQuerier(t *testing.T) {
 			require.NoError(t, gotErr)
 			var gotRes wasmvmtypes.ContractInfoResponse
 			require.NoError(t, json.Unmarshal(gotBz, &gotRes))
-			assert.Equal(t, spec.expRes, gotRes)
+			assert.Equal(t, spec.express, gotRes)
 		})
 	}
 }
@@ -528,7 +528,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 	specs := map[string]struct {
 		req    *wasmvmtypes.WasmQuery
 		mock   mockWasmQueryKeeper
-		expRes wasmvmtypes.CodeInfoResponse
+		express wasmvmtypes.CodeInfoResponse
 		expErr bool
 	}{
 		"all good": {
@@ -547,7 +547,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 					}
 				},
 			},
-			expRes: wasmvmtypes.CodeInfoResponse{
+			express: wasmvmtypes.CodeInfoResponse{
 				CodeID:   1,
 				Creator:  myCreatorAddr,
 				Checksum: myRawChecksum,
@@ -582,7 +582,7 @@ func TestCodeInfoWasmQuerier(t *testing.T) {
 			require.NoError(t, gotErr)
 			var gotRes wasmvmtypes.CodeInfoResponse
 			require.NoError(t, json.Unmarshal(gotBz, &gotRes), string(gotBz))
-			assert.Equal(t, spec.expRes, gotRes)
+			assert.Equal(t, spec.express, gotRes)
 		})
 	}
 }


### PR DESCRIPTION
Changes made in:

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")

- /x/wasm/keeper/query_plugins_test.go ("expRes" → "express")
