### PR TITLE
replace dead cosmos links to system.go

### DIFF
--- a/tests/system/system.go
+++ b/tests/system/system.go
@@ -758,7 +758,7 @@ type (
 )
 
 // Subscribe to receive events for a topic. Does not block.
-// For query syntax See https://docs.cosmos.network/master/core/events.html#subscribing-to-events
+// For query syntax See https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events
 func (l *EventListener) Subscribe(query string, cb EventConsumer) func() {
 	ctx, done := context.WithCancel(context.Background())
 	l.t.Cleanup(done)
@@ -780,7 +780,7 @@ func (l *EventListener) Subscribe(query string, cb EventConsumer) func() {
 }
 
 // AwaitQuery blocks and waits for a single result or timeout. This can be used with `broadcast-mode=async`.
-// For query syntax See https://docs.cosmos.network/master/core/events.html#subscribing-to-events
+// For query syntax See https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events
 func (l *EventListener) AwaitQuery(query string, optMaxWaitTime ...time.Duration) *ctypes.ResultEvent {
 	c, result := CaptureSingleEventConsumer()
 	maxWaitTime := DefaultWaitTime


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://docs.cosmos.network/master/core/events.html#subscribing-to-events - dead link
https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events - new link