### PR TITLE
fix 404 link ibc_integration_test.go

### DIFF
--- a/tests/integration/ibc_integration_test.go
+++ b/tests/integration/ibc_integration_test.go
@@ -85,7 +85,7 @@ func TestIBCReflectContract(t *testing.T) {
 	// only writes I see: https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/keeper/packet.go#L115-L116
 	// commitment is hashed packet: https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/types/packet.go#L14-L34
 	// how is the relayer supposed to get the original packet data??
-	// eg. ibctransfer doesn't store the packet either: https://github.com/cosmos/cosmos-sdk/blob/master/x/ibc/applications/transfer/keeper/relay.go#L145-L162
+	// eg. ibctransfer doesn't store the packet either: https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/keeper/relay.go#L141-L158
 	// ... or I guess the original packet data is only available in the event logs????
 	// https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/keeper/packet.go#L121-L132
 

--- a/tests/integration/ibc_integration_test.go
+++ b/tests/integration/ibc_integration_test.go
@@ -85,7 +85,7 @@ func TestIBCReflectContract(t *testing.T) {
 	// only writes I see: https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/keeper/packet.go#L115-L116
 	// commitment is hashed packet: https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/types/packet.go#L14-L34
 	// how is the relayer supposed to get the original packet data??
-	// eg. ibctransfer doesn't store the packet either: https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/keeper/relay.go#L141-L158
+	// eg. ibctransfer doesn't store the packet either: https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/applications/transfer/keeper/relay.go#L145-L162
 	// ... or I guess the original packet data is only available in the event logs????
 	// https://github.com/cosmos/cosmos-sdk/blob/31fdee0228bd6f3e787489c8e4434aabc8facb7d/x/ibc/core/04-channel/keeper/packet.go#L121-L132
 


### PR DESCRIPTION
Hi, I fixed 404 links in the documentation and replaced them with working ones.

https://github.com/cosmos/cosmos-sdk/blob/master/x/ibc/applications/transfer/keeper/relay.go#L145-L162 - old link
https://github.com/cosmos/ibc-go/blob/main/modules/apps/transfer/keeper/relay.go#L141-L158 - new link