### PR TITLE
Reduce storage usage from artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,13 +128,15 @@ jobs:
       - run:
           name: Build and run system tests
           command: make test-system
+      # In case of failure, collect some debugging data and store it
       - run:
+          name: Move output to artifacts
           command: |
-            mkdir -p /tmp/system-test-workspace
-            mv  /home/circleci/project/tests/system/testnet /tmp/system-test-workspace
+            mkdir -p /tmp/test-system-artifacts
+            mv  /home/circleci/project/tests/system/testnet /tmp/test-system-artifacts
           when: on_fail
       - store_artifacts:
-          path: /tmp/system-test-workspace
+          path: /tmp/test-system-artifacts
 
   benchmark:
     executor: golang
@@ -165,8 +167,6 @@ jobs:
           name: Run simulations
           command: |
             make test-sim-deterministic test-sim-multi-seed-short test-sim-import-export
-      - store_artifacts:
-          path: /tmp
 
   upload-coverage:
     executor: golang
@@ -198,7 +198,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build Docker artifact
+          name: Build Docker image
           command: docker build --pull -t "cosmwasm/wasmd:${CIRCLE_SHA1}" .
       - run:
           name: Ensure libwasmvm version is correct
@@ -232,7 +232,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Build Docker artifact
+          name: Build Docker image
           command: docker build --pull -t "cosmwasm/wasmd:${CIRCLE_TAG}" .
       - run:
           name: Push application Docker image to docker hub


### PR DESCRIPTION
Especially the simulations job stored huge amounts of data for every CI run. Was this ever used? If we really need it we should store more precisely what we need. E.g. by specifying the folders and only storing in case of failure. 