### PR TITLE
Fix `TestIBCReflectContract`

### DIFF
--- a/tests/integration/ibc_integration_test.go
+++ b/tests/integration/ibc_integration_test.go
@@ -60,12 +60,12 @@ func TestIBCReflectContract(t *testing.T) {
 	path.EndpointA.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  sourcePortID,
 		Version: "ibc-reflect-v1",
-		Order:   channeltypes.UNORDERED,
+		Order:   channeltypes.ORDERED,
 	}
 	path.EndpointB.ChannelConfig = &ibctesting.ChannelConfig{
 		PortID:  counterpartPortID,
 		Version: "ibc-reflect-v1",
-		Order:   channeltypes.UNORDERED,
+		Order:   channeltypes.ORDERED,
 	}
 
 	coordinator.SetupConnections(&path.Path)


### PR DESCRIPTION
Looks like it was an incorrectly resolved conflict in #2258. The reflect contract expects an ordered channel and because of #2291 that's being enforced now.