### PR TITLE
Fix typos in error messages for proposal validation

### DIFF
--- a/x/wasm/types/proposal_legacy.go
+++ b/x/wasm/types/proposal_legacy.go
@@ -730,7 +730,7 @@ func (p UnpinCodesProposal) String() string {
 
 func validateProposalCommons(title, description string) error {
 	if strings.TrimSpace(title) != title {
-		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal title must not start/end with white spaces")
+		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal title must not start/end with whitespaces")
 	}
 	if len(title) == 0 {
 		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal title cannot be blank")
@@ -739,7 +739,7 @@ func validateProposalCommons(title, description string) error {
 		return errorsmod.Wrapf(govtypes.ErrInvalidProposalContent, "proposal title is longer than max length of %d", v1beta1.MaxTitleLength)
 	}
 	if strings.TrimSpace(description) != description {
-		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal description must not start/end with white spaces")
+		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal description must not start/end with whitespaces")
 	}
 	if len(description) == 0 {
 		return errorsmod.Wrap(govtypes.ErrInvalidProposalContent, "proposal description cannot be blank")


### PR DESCRIPTION
Corrected the wording in error messages within the validateProposalCommons function in proposal_legacy.go:
- Changed "white spaces" to "whitespaces" in error messages for proposal title and description validation.
This improves the consistency and correctness of the error messages shown to users. No logic was changed.