### PR TITLE
Update proposal_legacy_test.go

### DIFF
--- a/x/wasm/types/proposal_legacy_test.go
+++ b/x/wasm/types/proposal_legacy_test.go
@@ -43,7 +43,7 @@ func TestValidateProposalCommons(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"prevent leading white spaces in title": {
+		"prevent leading whitespaces in title": {
 			src: commonProposal{
 				Title:       " Foo",
 				Description: "Bar",
@@ -63,7 +63,7 @@ func TestValidateProposalCommons(t *testing.T) {
 			},
 			expErr: true,
 		},
-		"prevent leading white spaces in description": {
+		"prevent leading whitespaces in description": {
 			src: commonProposal{
 				Title:       "Foo",
 				Description: " Bar",


### PR DESCRIPTION
Changed "white spaces" to "whitespaces" in error messages for proposal title and description validation.
This improves the consistency and correctness of the error messages shown to users. No logic was changed.