### PR TITLE
Optimize memory allocation in RemoveCodeUploadParamsAddresses

### DIFF
--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -392,7 +392,7 @@ func (m msgServer) RemoveCodeUploadParamsAddresses(goCtx context.Context, req *t
 		return nil, errorsmod.Wrap(types.ErrInvalid, "permission")
 	}
 	addresses := params.CodeUploadAccess.Addresses
-	newAddresses := make([]string, 0)
+	newAddresses := make([]string, 0, len(addresses))
 	for _, addr := range addresses {
 		if slices.Contains(req.Addresses, addr) {
 			continue


### PR DESCRIPTION
Pre-allocate memory for the newAddresses slice based on the maximum possible size (length of original addresses slice) to avoid multiple memory reallocations during append operations. This is a performance optimization that follows Go best practices for slice handling