### PR TITLE
Fix typo in comment: change 'proposal flagsExecute' to 'proposal flags' for consistency

### DIFF
--- a/x/wasm/client/cli/gov_tx.go
+++ b/x/wasm/client/cli/gov_tx.go
@@ -517,7 +517,7 @@ func ProposalSudoContractCmd() *cobra.Command {
 		},
 		SilenceUsage: true,
 	}
-	// proposal flagsExecute
+	// proposal flags
 	addCommonProposalFlags(cmd)
 	return cmd
 }


### PR DESCRIPTION
The comment above the addCommonProposalFlags(cmd) call in ProposalSudoContractCmd was written as '// proposal flagsExecute', which is inconsistent with similar comments throughout the file (e.g., '// proposal flags'). This appears to be a typographical error, likely caused by accidental concatenation of 'flags' and 'Execute'. The comment was updated to '// proposal flags' to improve code readability and maintain consistency with the rest of the codebase.

Why is this a typo?

In the rest of the file, similar comments are written as '// proposal flags' to indicate where proposal-related flags are added to CLI commands. The presence of 'flagsExecute' is not meaningful and breaks the established commenting style, suggesting it was an accidental merge of two words. Correcting it helps keep the codebase clean and consistent.