### PR TITLE
Fix JSON  for wasmd v0.40.0

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -174,7 +174,7 @@ you put in your handler):
 
 ```sh
 # create the proposal
-# check the current height and add 100-200 or so for the upgrade time
+# check the current height and add 100-200 or so for the upgrade 
 # (the voting period is ~60 blocks)
 docker run --rm -it \
     --mount type=volume,source=musselnet_client,target=/root \
@@ -238,7 +238,6 @@ docker run --rm -it \
    "authority": "wasm10d07y265gmmuvt4z0w9aw880jnsr700js7zslc",
    "plan": {
     "name": "Upgrade",
-    "time": "0001-01-01T00:00:00Z",
     "height": "500",
     "info": "",
     "upgraded_client_state": null


### PR DESCRIPTION
This PR addresses a potential error in the UPGRADING.md documentation related to the incorrect use of the time field in the JSON for MsgSoftwareUpgrade in the "Vote on the upgrade (Starting from wasmd v0.40.0)" section. In Cosmos SDK v0.47.x and later, the time field is deprecated, and using an invalid value like "time": "0001-01-01T00:00:00Z" may cause validation failure when submitting an upgrade proposal. This is critical for the network upgrade process, as it could disrupt operations.

