### PR TITLE
fix: correct typos and spacing in wasm keeper comments

### DIFF
--- a/x/wasm/keeper/msg_dispatcher.go
+++ b/x/wasm/keeper/msg_dispatcher.go
@@ -36,7 +36,7 @@ type replyer interface {
 	reply(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) ([]byte, error)
 }
 
-// MessageDispatcher coordinates message sending and submessage reply/ state commits
+// MessageDispatcher coordinates message sending and submessage reply/state commits
 type MessageDispatcher struct {
 	messenger Messenger
 	keeper    replyer

--- a/x/wasm/keeper/query_plugins.go
+++ b/x/wasm/keeper/query_plugins.go
@@ -53,7 +53,7 @@ var _ wasmvmtypes.Querier = QueryHandler{}
 func (q QueryHandler) Query(request wasmvmtypes.QueryRequest, gasLimit uint64) ([]byte, error) {
 	// set a limit for a subCtx
 	sdkGas := q.gasRegister.FromWasmVMGas(gasLimit)
-	// discard all changes/ events in subCtx by not committing the cached context
+	// discard all changes/events in subCtx by not committing the cached context
 	subCtx, _ := q.Ctx.WithGasMeter(storetypes.NewGasMeter(sdkGas)).CacheContext()
 
 	// make sure we charge the higher level context even on panic

--- a/x/wasm/keeper/recurse_test.go
+++ b/x/wasm/keeper/recurse_test.go
@@ -37,7 +37,7 @@ type recurseResponse struct {
 	Hashed []byte `json:"hashed"`
 }
 
-// number os wasm queries called from a contract
+// number of wasm queries called from a contract
 var totalWasmQueryCounter int
 
 func initRecurseContract(t *testing.T) (contract sdk.AccAddress, ctx sdk.Context, keeper *Keeper) {


### PR DESCRIPTION
Fixed spacing in msg_dispatcher.go and query_plugins.go comments (reply/ state → reply/state, changes/ events → changes/events).

Fixed typo os → of in recurse_test.go.