### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/cosmos/proto-builder:0.14.0
       options: --user root # workaround for a problem during actions/checkout, see https://github.com/actions/checkout/issues/1014
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Fix permissions # needed because of root user fix above
         run: git config --global --add safe.directory "$PWD"
       - name: Format protobuf

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ jobs:
   setup-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check go mod tidy
         run: |
           go mod tidy
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -65,7 +65,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-cover
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Go modules cache
         uses: actions/cache@v4
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup-dependencies
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run simulations
         run: make test-sim-deterministic test-sim-multi-seed-short test-sim-import-export
@@ -182,7 +182,7 @@ jobs:
     env:
       IMAGE_NAME: cosmwasm/wasmd
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/codeql-analizer.yml
+++ b/.github/workflows/codeql-analizer.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/proto-buf-linter.yml
+++ b/.github/workflows/proto-buf-linter.yml
@@ -13,7 +13,7 @@ jobs:
   buf-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1.47.2
 
       # lint checks

--- a/.github/workflows/proto-buf-publisher.yml
+++ b/.github/workflows/proto-buf-publisher.yml
@@ -16,7 +16,7 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@v1.47.2
 
       # lint checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/staticmajor.yml
+++ b/.github/workflows/staticmajor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Staticmajor action
         id: staticmajor
         uses: orijtech/staticmajor-action@main

--- a/.github/workflows/typo-check.yml
+++ b/.github/workflows/typo-check.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run spell-check
         uses: crate-ci/typos@master


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0