### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/x/wasm/keeper/contract_keeper_test.go
+++ b/x/wasm/keeper/contract_keeper_test.go
@@ -143,7 +143,7 @@ func TestInstantiate2(t *testing.T) {
 			codeID:  example.CodeID,
 			sender:  otherAddr,
 			salt:    []byte(mySalt),
-			initMsg: []byte(fmt.Sprintf(`{"foo":%q}`, strings.Repeat("b", math.MaxInt16+1))), // too long kills CI
+			initMsg: fmt.Appendf(nil, `{"foo":%q}`, strings.Repeat("b", math.MaxInt16+1)), // too long kills CI
 			fixMsg:  true,
 		},
 	}

--- a/x/wasm/keeper/msg_dispatcher_test.go
+++ b/x/wasm/keeper/msg_dispatcher_test.go
@@ -231,7 +231,7 @@ func TestDispatchSubmessages(t *testing.T) {
 			msgs: []wasmvmtypes.SubMsg{{ID: 1, ReplyOn: wasmvmtypes.ReplyError}, {ID: 2, ReplyOn: wasmvmtypes.ReplyError}},
 			replyer: &mockReplyer{
 				replyFn: func(ctx sdk.Context, contractAddress sdk.AccAddress, reply wasmvmtypes.Reply) ([]byte, error) {
-					return []byte(fmt.Sprintf("myReplyData:%d", reply.ID)), nil
+					return fmt.Appendf(nil, "myReplyData:%d", reply.ID), nil
 				},
 			},
 			msgHandler: &wasmtesting.MockMessageHandler{

--- a/x/wasm/keeper/test_common.go
+++ b/x/wasm/keeper/test_common.go
@@ -442,7 +442,7 @@ func handleStoreCode(ctx sdk.Context, k types.ContractOpsKeeper, msg *types.MsgS
 	}
 
 	return &sdk.Result{
-		Data:   []byte(fmt.Sprintf("%d", codeID)),
+		Data:   fmt.Appendf(nil, "%d", codeID),
 		Events: ctx.EventManager().ABCIEvents(),
 	}, nil
 }


### PR DESCRIPTION
Optimize code using a more modern writing style. Official support from Go, for more details visit https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.