### PR TITLE
fix: error message in UndefinedLimit.Accept

### DIFF
--- a/x/wasm/types/authz.go
+++ b/x/wasm/types/authz.go
@@ -545,7 +545,7 @@ func (u UndefinedLimit) ValidateBasic() error {
 
 // Accept always returns error
 func (u UndefinedLimit) Accept(_ sdk.Context, _ AuthzableWasmMsg) (*ContractAuthzLimitAcceptResult, error) {
-	return nil, sdkerrors.ErrNotFound.Wrapf("undefined filter")
+	return nil, sdkerrors.ErrNotFound.Wrapf("undefined limit")
 }
 
 // NewMaxCallsLimit constructor


### PR DESCRIPTION
Correct the returned error text from "undefined filter" to "undefined limit" in x/wasm/types/authz.go.
Clarifies the error source and aligns with the type (UndefinedLimit) for better diagnostics.