### PR TITLE
fix(wasmtesting): correct nil check in MockChannelKeeper.SetChannel

### DIFF
--- a/x/wasm/keeper/wasmtesting/mock_keepers.go
+++ b/x/wasm/keeper/wasmtesting/mock_keepers.go
@@ -60,7 +60,7 @@ func (m *MockChannelKeeper) GetAllChannelsWithPortPrefix(ctx sdk.Context, portPr
 }
 
 func (m *MockChannelKeeper) SetChannel(ctx sdk.Context, portID, channelID string, channel channeltypes.Channel) {
-	if m.GetChannelFn == nil {
+	if m.SetChannelFn == nil {
 		panic("not supposed to be called!")
 	}
 	m.SetChannelFn(ctx, portID, channelID, channel)


### PR DESCRIPTION
Fix incorrect nil check in SetChannel method - was checking GetChannelFn 
instead of SetChannelFn before calling the function. This ensures proper 
validation and maintains consistency with other mock methods.