### PR TITLE
Update GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 


### PR DESCRIPTION
Version v5 introduces performance improvements, enhanced artifact integrity, and better support for handling multiple artifacts.
Release notes: https://github.com/actions/download-artifact/releases/tag/v5.0.0