### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/tests/integration/module_test.go
+++ b/tests/integration/module_test.go
@@ -167,7 +167,6 @@ func TestHandleCreate(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			data := setupTest(t)
 

--- a/x/wasm/keeper/query_plugins_test.go
+++ b/x/wasm/keeper/query_plugins_test.go
@@ -898,7 +898,6 @@ func TestGRPCQuerier(t *testing.T) {
 	errorsCount := atomic.Uint64{}
 	for range 50 {
 		for _, denom := range []string{denom1, denom2} {
-			denom := denom // copy
 			eg.Go(func() error {
 				queryReq := &banktypes.QueryBalanceRequest{
 					Address: addr,


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore


```shell
Does this mean I don’t have to write x := x in my loops anymore?[¶](https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore)

After you update your module to use go1.22 or a later version, yes.
```