### PR TITLE
refactor: use reflect.TypeFor

### DIFF
--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -79,7 +79,7 @@ type WasmVMResponseHandler interface {
 // list of account types that are accepted for wasm contracts. Chains importing wasmd
 // can overwrite this list with the WithAcceptedAccountTypesOnContractInstantiation option.
 var defaultAcceptedAccountTypes = map[reflect.Type]struct{}{
-	reflect.TypeOf(&authtypes.BaseAccount{}): {},
+	reflect.TypeFor[*authtypes.BaseAccount](): {},
 }
 
 // Keeper will have a reference to Wasm Engine with it's own data directory.

--- a/x/wasm/keeper/options_test.go
+++ b/x/wasm/keeper/options_test.go
@@ -132,8 +132,8 @@ func TestConstructorOptions(t *testing.T) {
 			srcOpt: WithAcceptedAccountTypesOnContractInstantiation(&authtypes.BaseAccount{}, &vestingtypes.ContinuousVestingAccount{}),
 			verify: func(t *testing.T, k Keeper) {
 				exp := map[reflect.Type]struct{}{
-					reflect.TypeOf(&authtypes.BaseAccount{}):                 {},
-					reflect.TypeOf(&vestingtypes.ContinuousVestingAccount{}): {},
+					reflect.TypeFor[*authtypes.BaseAccount]():                 {},
+					reflect.TypeFor[*vestingtypes.ContinuousVestingAccount](): {},
 				}
 				assert.Equal(t, exp, k.acceptedAccountTypes)
 			},


### PR DESCRIPTION
Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.

More info https://github.com/golang/go/issues/60088