### PR TITLE
chore(ci): bump artifact actions to v5

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,7 +87,7 @@ jobs:
           done
 
       - name: Upload coverage and logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-${{ matrix.shard }}
           path: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload test system artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-system-artifacts
           path: /tmp/test-system-artifacts


### PR DESCRIPTION
switch the artifact upload/download steps to the v5 Actions release so we pick up the Node 24 compatibility and latest fixes; proof:[ actions/upload-artifact v5.0.0 release](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)