### PR TITLE
fix: add input validation to NewWasmApp constructor

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -239,6 +239,16 @@ func NewWasmApp(
 	wasmOpts []wasmkeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *WasmApp {
+	// Validate critical input parameters
+	if logger == nil {
+		panic("logger is required for WasmApp")
+	}
+	if db == nil {
+		panic("database is required for WasmApp")
+	}
+	if appOpts == nil {
+		panic("app options are required for WasmApp")
+	}
 	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles: proto.HybridResolver,
 		SigningOptions: signing.Options{


### PR DESCRIPTION
Add validation for critical input parameters (logger, db, appOpts) in NewWasmApp constructor to prevent runtime panics from nil values. 
This follows the same validation pattern used in other constructors like NewAnteHandler and provides clear error messages for debugging.