### PR TITLE
Update Codecov workflow to use download-artifact v6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 


### PR DESCRIPTION
bump actions/download-artifact from v5 to v6 in .github/workflows/_codecov.yml
keeps the Codecov job aligned with the latest GitHub Actions release