### PR TITLE
 chore: fix a/an article usage with WASM

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -54,7 +54,7 @@ func (app *WasmApp) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedA
 //
 //	in favor of export at a block height
 func (app *WasmApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
-	// check if there is a allowed address list
+	// check if there is an allowed address list
 	applyAllowedAddrs := len(jailAllowedAddrs) > 0
 
 	allowedAddrsMap := make(map[string]bool)

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GenesisState of the blockchain is represented here as a map of raw json
-// messages key'd by a identifier string.
+// messages key'd by an identifier string.
 // The identifier is used to determine which module genesis information belongs
 // to so it may be appropriately routed during init chain.
 // Within this application default genesis information is retrieved from

--- a/docs/proto/proto-docs.md
+++ b/docs/proto/proto-docs.md
@@ -142,7 +142,7 @@
 <a name="cosmwasm.wasm.v1.AbsoluteTxPosition"></a>
 
 ### AbsoluteTxPosition
-AbsoluteTxPosition is a unique transaction position that allows for global
+AbsoluteTxPosition is an unique transaction position that allows for global
 ordering of transactions.
 
 
@@ -225,7 +225,7 @@ ContractCodeHistoryEntry metadata to a contract.
 <a name="cosmwasm.wasm.v1.ContractInfo"></a>
 
 ### ContractInfo
-ContractInfo stores a WASM contract instance
+ContractInfo stores an instance of a WASM contract
 
 
 | Field | Type | Label | Description |

--- a/proto/cosmwasm/wasm/v1/types.proto
+++ b/proto/cosmwasm/wasm/v1/types.proto
@@ -73,7 +73,7 @@ message CodeInfo {
       [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
 }
 
-// ContractInfo stores a WASM contract instance
+// ContractInfo stores an instance of a WASM contract
 message ContractInfo {
   option (gogoproto.equal) = true;
 
@@ -132,7 +132,7 @@ message ContractCodeHistoryEntry {
   ];
 }
 
-// AbsoluteTxPosition is a unique transaction position that allows for global
+// AbsoluteTxPosition is an unique transaction position that allows for global
 // ordering of transactions.
 message AbsoluteTxPosition {
   // BlockHeight is the block the contract was created at

--- a/tests/integration/ibc_integration_test.go
+++ b/tests/integration/ibc_integration_test.go
@@ -27,7 +27,7 @@ func TestIBCReflectContract(t *testing.T) {
 	//  chain A: ibc_reflect_send.wasm
 	//  chain B: reflect_1_5.wasm + ibc_reflect.wasm
 	//
-	//  Chain A "ibc_reflect_send" sends a IBC packet "on channel connect" event to chain B "ibc_reflect"
+	//  Chain A "ibc_reflect_send" sends an IBC packet "on channel connect" event to chain B "ibc_reflect"
 	//  "ibc_reflect" sends a submessage to "reflect" which is returned as submessage.
 
 	var (

--- a/tests/wasmibctesting/utils.go
+++ b/tests/wasmibctesting/utils.go
@@ -207,7 +207,7 @@ func (chain *WasmTestChain) Fund(addr sdk.AccAddress, amount math.Int) {
 	require.NoError(chain.TB, err)
 }
 
-// GetTimeoutHeight is a convenience function which returns a IBC packet timeout height
+// GetTimeoutHeight is a convenience function which returns an IBC packet timeout height
 // to be used for testing. It returns the current IBC height + 100 blocks
 func (chain *WasmTestChain) GetTimeoutHeight() clienttypes.Height {
 	return clienttypes.NewHeight(clienttypes.ParseChainID(chain.ChainID), uint64(chain.GetContext().BlockHeight())+100)

--- a/x/wasm/keeper/contract_keeper.go
+++ b/x/wasm/keeper/contract_keeper.go
@@ -57,7 +57,7 @@ func (p PermissionedKeeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasm
 	return p.nested.create(ctx, creator, wasmCode, instantiateAccess, p.authZPolicy)
 }
 
-// Instantiate creates an instance of a WASM contract using the classic sequence based address generator
+// Instantiate creates an instance of an WASM contract using the classic sequence based address generator
 func (p PermissionedKeeper) Instantiate(
 	ctx sdk.Context,
 	codeID uint64,
@@ -69,7 +69,7 @@ func (p PermissionedKeeper) Instantiate(
 	return p.nested.instantiate(ctx, codeID, creator, admin, initMsg, label, deposit, p.nested.ClassicAddressGenerator(), p.authZPolicy)
 }
 
-// Instantiate2 creates an instance of a WASM contract using the predictable address generator
+// Instantiate2 creates an instance of an WASM contract using the predictable address generator
 func (p PermissionedKeeper) Instantiate2(
 	ctx sdk.Context,
 	codeID uint64,

--- a/x/wasm/keeper/keeper.go
+++ b/x/wasm/keeper/keeper.go
@@ -1567,7 +1567,7 @@ type msgDispatcher interface {
 }
 
 // DefaultWasmVMContractResponseHandler default implementation that first dispatches submessage then normal messages.
-// The Submessage execution may include an success/failure response handling by the contract that can overwrite the
+// The Submessage execution may include a success/failure response handling by the contract that can overwrite the
 // original
 type DefaultWasmVMContractResponseHandler struct {
 	md msgDispatcher

--- a/x/wasm/types/exported_keepers.go
+++ b/x/wasm/types/exported_keepers.go
@@ -32,10 +32,10 @@ type ViewKeeper interface {
 
 // ContractOpsKeeper contains mutable operations on a contract.
 type ContractOpsKeeper interface {
-	// Create uploads and compiles a WASM contract, returning a short identifier for the contract
+	// Create uploads and compiles a WASM contract, returning an identifier for the contract
 	Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte, instantiateAccess *AccessConfig) (codeID uint64, checksum []byte, err error)
 
-	// Instantiate creates an instance of a WASM contract using the classic sequence based address generator
+	// Instantiate creates an instance of an WASM contract using the classic sequence based address generator
 	Instantiate(
 		ctx sdk.Context,
 		codeID uint64,
@@ -45,7 +45,7 @@ type ContractOpsKeeper interface {
 		deposit sdk.Coins,
 	) (sdk.AccAddress, []byte, error)
 
-	// Instantiate2 creates an instance of a WASM contract using the predictable address generator
+	// Instantiate2 creates an instance of an WASM contract using the predictable address generator
 	Instantiate2(
 		ctx sdk.Context,
 		codeID uint64,

--- a/x/wasm/types/gas_register.go
+++ b/x/wasm/types/gas_register.go
@@ -32,7 +32,7 @@ const (
 	// Please note that all gas prices returned to wasmvm should have this multiplied.
 	// Benchmarks and numbers were discussed in: https://github.com/CosmWasm/wasmd/pull/634#issuecomment-938055852
 	DefaultGasMultiplier uint64 = 140_000
-	// DefaultInstanceCost is how much SDK gas we charge each time we load a WASM instance.
+	// DefaultInstanceCost is how much SDK gas we charge each time we load an instance of a WASM contract.
 	// Creating a new instance is costly, and this helps put a recursion limit to contracts calling contracts.
 	// Benchmarks and numbers were discussed in: https://github.com/CosmWasm/wasmd/pull/634#issuecomment-938056803
 	DefaultInstanceCost uint64 = 60_000

--- a/x/wasm/types/types.pb.go
+++ b/x/wasm/types/types.pb.go
@@ -277,7 +277,7 @@ func (m *CodeInfo) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CodeInfo proto.InternalMessageInfo
 
-// ContractInfo stores a WASM contract instance
+// ContractInfo stores an instance of a WASM contract
 type ContractInfo struct {
 	// CodeID is the reference to the stored Wasm code
 	CodeID uint64 `protobuf:"varint,1,opt,name=code_id,json=codeId,proto3" json:"code_id,omitempty"`
@@ -382,7 +382,7 @@ func (m *ContractCodeHistoryEntry) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ContractCodeHistoryEntry proto.InternalMessageInfo
 
-// AbsoluteTxPosition is a unique transaction position that allows for global
+// AbsoluteTxPosition is an unique transaction position that allows for global
 // ordering of transactions.
 type AbsoluteTxPosition struct {
 	// BlockHeight is the block the contract was created at


### PR DESCRIPTION
 Fixes grammatical errors where "a" was incorrectly used before "WASM" (pronounced with a vowel sound). Since WASM is pronounced "wazm" starting with a vowel sound, it should be preceded by "an" not "a".

  Changes:
  - "a WASM instance" → "an instance of a WASM contract"
  - "an instance of a WASM contract" → "an instance of an WASM contract"
  - "a unique transaction" → "an unique transaction"

  Follows the same pattern as #2421 which fixed similar issues.