### PR TITLE
Add boundary tests for IBC channel parameter validation

### DIFF
--- a/x/wasm/ibc_test.go
+++ b/x/wasm/ibc_test.go
@@ -178,6 +178,38 @@ func TestMapToWasmVMIBCPacket(t *testing.T) {
 	}
 }
 
+func TestValidateChannelParams(t *testing.T) {
+	specs := map[string]struct {
+		channelID string
+		expErr    bool
+	}{
+		"valid zero channel sequence": {
+			channelID: "channel-0",
+		},
+		"valid max uint32 channel sequence": {
+			channelID: "channel-4294967295",
+		},
+		"invalid channel sequence beyond uint32": {
+			channelID: "channel-4294967296",
+			expErr:    true,
+		},
+		"invalid channel ID format": {
+			channelID: "invalid-channel",
+			expErr:    true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateChannelParams(spec.channelID)
+			if spec.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func IBCPacketFixture(mutators ...func(p *channeltypes.Packet)) channeltypes.Packet {
 	r := channeltypes.Packet{
 		Sequence:           1,


### PR DESCRIPTION
## Summary

Adds unit coverage for `ValidateChannelParams` to document and verify the IBC channel sequence boundary behavior.

The new tests cover:
- `channel-0`
- the maximum allowed `uint32` channel sequence
- a channel sequence above `uint32`
- an invalid channel ID format

This is a test-only change and does not modify runtime behavior.

## Testing

- `gofmt`
- `git diff --check`

I attempted to run:

```sh
go test -mod=readonly -tags='ledger test_ledger_mock' ./x/wasm -run '^TestValidateChannelParams$' -count=1