### PR TITLE
Wasm: compare allowlist entries by decoded address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.70.2...HEAD)
 
+- Fix case-insensitive Bech32 address matching in wasm access allowlists
+
 ## [v0.70.2](https://github.com/CosmWasm/wasmd/tree/v0.70.2) (2026-05-22)
 
 [Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.70.1...v0.70.2)

--- a/x/wasm/types/params.go
+++ b/x/wasm/types/params.go
@@ -142,7 +142,13 @@ func (a AccessConfig) Allowed(actor sdk.AccAddress) bool {
 	case AccessTypeEverybody:
 		return true
 	case AccessTypeAnyOfAddresses:
-		return slices.Contains(a.Addresses, actor.String())
+		for _, configured := range a.Addresses {
+			addr, err := sdk.AccAddressFromBech32(configured)
+			if err == nil && addr.Equals(actor) {
+				return true
+			}
+		}
+		return false
 	default:
 		panic("unknown type")
 	}

--- a/x/wasm/types/params_test.go
+++ b/x/wasm/types/params_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -245,6 +246,54 @@ func TestAccessTypeWith(t *testing.T) {
 			assert.Panics(t, func() {
 				spec.src.With(spec.addrs...)
 			})
+		})
+	}
+}
+
+func TestAccessConfigAllowedCaseInsensitiveBech32(t *testing.T) {
+	actor := sdk.AccAddress(randBytes(SDKAddrLen))
+	other := sdk.AccAddress(randBytes(SDKAddrLen))
+
+	tests := map[string]struct {
+		configured string
+		valid      bool
+		allowed    bool
+	}{
+		"lowercase configured address": {
+			configured: actor.String(),
+			valid:      true,
+			allowed:    true,
+		},
+		"uppercase configured address": {
+			configured: strings.ToUpper(actor.String()),
+			valid:      true,
+			allowed:    true,
+		},
+		"different address": {
+			configured: other.String(),
+			valid:      true,
+			allowed:    false,
+		},
+		"invalid address": {
+			configured: "invalid address",
+			valid:      false,
+			allowed:    false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := AccessConfig{
+				Permission: AccessTypeAnyOfAddresses,
+				Addresses:  []string{test.configured},
+			}
+			err := config.ValidateBasic()
+			if test.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			assert.Equal(t, test.allowed, config.Allowed(actor))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Compare `AccessTypeAnyOfAddresses` entries by decoded `sdk.AccAddress` values instead of raw Bech32 strings.
- Honor valid uppercase Bech32 allowlist entries.
- Add regression coverage for lowercase, uppercase, different, and invalid addresses.
- Add an Unreleased changelog entry.

## Testing

- `go test ./x/wasm/types`
- `go test ./x/wasm/keeper`


Fixes https://github.com/CosmWasm/wasmd/issues/2538